### PR TITLE
feat(prompts): add in-app prompt editor with DB overrides and version history

### DIFF
--- a/app/Ai/Agents/PersonalityAgent.php
+++ b/app/Ai/Agents/PersonalityAgent.php
@@ -2,7 +2,7 @@
 
 namespace App\Ai\Agents;
 
-use Illuminate\Support\Facades\View;
+use App\Facades\Prompts;
 use Laravel\Ai\Attributes\Model;
 use Laravel\Ai\Attributes\Provider;
 use Laravel\Ai\Contracts\Agent;
@@ -26,9 +26,9 @@ class PersonalityAgent implements Agent
 
     public function instructions(): Stringable|string
     {
-        return View::make('prompts.personality', [
+        return Prompts::render('personality', [
             'type' => $this->type,
             'context' => $this->context,
-        ])->render();
+        ]);
     }
 }

--- a/app/Ai/Agents/RepoRoutingAgent.php
+++ b/app/Ai/Agents/RepoRoutingAgent.php
@@ -2,6 +2,7 @@
 
 namespace App\Ai\Agents;
 
+use App\Facades\Prompts;
 use Laravel\Ai\Attributes\Model;
 use Laravel\Ai\Attributes\Provider;
 use Laravel\Ai\Contracts\Agent;
@@ -20,12 +21,6 @@ class RepoRoutingAgent implements Agent
 
     public function instructions(): Stringable|string
     {
-        return <<<'INSTRUCTIONS'
-You are a routing classifier. The user will give you a list of repositories (with descriptions) and a task description. Your job is to pick the single repository the task most likely belongs to.
-
-Respond with ONLY the repository slug on a single line, with no other text, no explanation, and no formatting. Example response: acme/api
-
-If you cannot confidently determine the correct repository based on the information provided, respond with ONLY the word: UNKNOWN
-INSTRUCTIONS;
+        return Prompts::render('agents-repo-routing');
     }
 }

--- a/app/Facades/Prompts.php
+++ b/app/Facades/Prompts.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Facades;
+
+use App\Services\PromptResolver;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static string render(string $slug, array<string, mixed> $data = [])
+ * @method static string renderDefault(string $slug, array<string, mixed> $data = [])
+ * @method static string fileContent(string $slug)
+ * @method static array<int, string> validate(string $content, array<string, mixed> $fixture = [])
+ *
+ * @see PromptResolver
+ */
+class Prompts extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return PromptResolver::class;
+    }
+}

--- a/app/Livewire/PromptEditor.php
+++ b/app/Livewire/PromptEditor.php
@@ -1,0 +1,384 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Prompt;
+use App\Models\PromptVersion;
+use App\Prompts\PromptDefinitions;
+use App\Prompts\PromptFixtures;
+use App\Services\PromptResolver;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View as BladeView;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * @property array<string, array{label: string, category: string, type: string}> $sidebarPrompts
+ * @property array<int, string> $availableVariables
+ * @property array<int, array{label: string, data: array<string, mixed>}> $fixtures
+ * @property array<int, string> $unusedVariables
+ * @property array<int, string> $unknownVariables
+ * @property Collection<int, PromptVersion> $versions
+ * @property bool $isCustomized
+ */
+#[Title('Prompts')]
+class PromptEditor extends Component
+{
+    public ?string $selectedSlug = null;
+
+    public string $content = '';
+
+    public int $fixtureIndex = 0;
+
+    public ?int $selectedVersionId = null;
+
+    public string $saveMessage = '';
+
+    public bool $saveError = false;
+
+    public string $previewBody = '';
+
+    public bool $previewOk = true;
+
+    public bool $showHistory = false;
+
+    public bool $showDiff = false;
+
+    public bool $showResetConfirm = false;
+
+    public function mount(): void
+    {
+        $first = array_key_first(PromptDefinitions::all());
+        if ($first !== null) {
+            $this->selectPrompt($first);
+        }
+    }
+
+    public function selectPrompt(string $slug): void
+    {
+        if (! PromptDefinitions::has($slug)) {
+            return;
+        }
+
+        $this->selectedSlug = $slug;
+        $this->fixtureIndex = 0;
+        $this->selectedVersionId = null;
+        $this->saveMessage = '';
+        $this->saveError = false;
+        $this->showHistory = false;
+        $this->showDiff = false;
+        $this->showResetConfirm = false;
+
+        $prompt = $this->promptRecord();
+
+        if ($prompt && $prompt->is_customized && trim((string) $prompt->content) !== '') {
+            $this->content = (string) $prompt->content;
+        } else {
+            $this->content = $this->defaultContent($slug);
+        }
+
+        $this->refreshPreview();
+    }
+
+    public function updatedContent(): void
+    {
+        $this->refreshPreview();
+    }
+
+    public function updatedFixtureIndex(): void
+    {
+        $this->refreshPreview();
+    }
+
+    private function refreshPreview(): void
+    {
+        if ($this->selectedSlug === null) {
+            $this->previewOk = true;
+            $this->previewBody = '';
+
+            return;
+        }
+
+        $fixtures = PromptFixtures::for($this->selectedSlug);
+        $data = $fixtures[$this->fixtureIndex]['data'] ?? [];
+
+        foreach (PromptResolver::DISALLOWED_DIRECTIVES as $directive) {
+            if (preg_match('/@' . preg_quote($directive, '/') . '\b/', $this->content) === 1) {
+                $this->previewOk = false;
+                $this->previewBody = "Directive @{$directive} is not allowed in prompts.";
+
+                return;
+            }
+        }
+
+        try {
+            $this->previewBody = trim(Blade::render($this->content, $data));
+            $this->previewOk = true;
+        } catch (Throwable $e) {
+            $factory = \Illuminate\Support\Facades\View::getFacadeRoot();
+            if (is_object($factory) && method_exists($factory, 'flushState')) {
+                $factory->flushState();
+            }
+
+            $this->previewOk = false;
+            $this->previewBody = $e->getMessage();
+        }
+    }
+
+    public function save(PromptResolver $resolver): void
+    {
+        if ($this->selectedSlug === null) {
+            return;
+        }
+
+        $slug = $this->selectedSlug;
+        $fixture = PromptFixtures::firstData($slug);
+
+        $errors = $resolver->validate($this->content, $fixture);
+
+        if ($errors !== []) {
+            $this->saveError = true;
+            $this->saveMessage = $errors[0];
+
+            return;
+        }
+
+        try {
+            DB::transaction(function () use ($slug): void {
+                $prompt = Prompt::where('slug', $slug)->lockForUpdate()->firstOrFail();
+
+                $hasVersions = PromptVersion::where('prompt_id', $prompt->id)->exists();
+
+                $nextVersion = (int) PromptVersion::where('prompt_id', $prompt->id)->max('version') + 1;
+
+                if (! $hasVersions) {
+                    PromptVersion::create([
+                        'prompt_id' => $prompt->id,
+                        'content' => $this->defaultContent($slug),
+                        'version' => $nextVersion,
+                        'created_at' => now(),
+                    ]);
+                    $nextVersion++;
+                }
+
+                PromptVersion::create([
+                    'prompt_id' => $prompt->id,
+                    'content' => $this->content,
+                    'version' => $nextVersion,
+                    'created_at' => now(),
+                ]);
+
+                $prompt->content = $this->content;
+                $prompt->is_customized = true;
+                $prompt->save();
+            });
+
+            $this->saveError = false;
+            $this->saveMessage = 'Saved.';
+        } catch (Throwable $e) {
+            Log::warning('PromptEditor: save failed', [
+                'slug' => $slug,
+                'error' => $e->getMessage(),
+            ]);
+            $this->saveError = true;
+            $this->saveMessage = 'Could not save: ' . $e->getMessage();
+        }
+    }
+
+    public function confirmReset(): void
+    {
+        $this->showResetConfirm = true;
+    }
+
+    public function cancelReset(): void
+    {
+        $this->showResetConfirm = false;
+    }
+
+    public function resetToDefault(): void
+    {
+        if ($this->selectedSlug === null) {
+            return;
+        }
+
+        $prompt = $this->promptRecord();
+        if ($prompt) {
+            $prompt->content = null;
+            $prompt->is_customized = false;
+            $prompt->save();
+        }
+
+        $this->content = $this->defaultContent($this->selectedSlug);
+        $this->showResetConfirm = false;
+        $this->saveError = false;
+        $this->saveMessage = 'Reset to default.';
+    }
+
+    public function openHistory(): void
+    {
+        $this->showHistory = true;
+    }
+
+    public function closeHistory(): void
+    {
+        $this->showHistory = false;
+    }
+
+    public function loadVersion(int $versionId): void
+    {
+        /** @var PromptVersion|null $version */
+        $version = PromptVersion::find($versionId);
+
+        if ($version === null) {
+            return;
+        }
+
+        $prompt = $this->promptRecord();
+        if (! $prompt || $version->prompt_id !== $prompt->id) {
+            return;
+        }
+
+        $this->content = $version->content;
+        $this->selectedVersionId = $versionId;
+        $this->showHistory = false;
+        $this->saveMessage = "Loaded version {$version->version} (unsaved).";
+        $this->saveError = false;
+    }
+
+    public function toggleDiff(): void
+    {
+        $this->showDiff = ! $this->showDiff;
+    }
+
+    public function setFixture(int $index): void
+    {
+        $fixtures = $this->fixtures;
+        if (isset($fixtures[$index])) {
+            $this->fixtureIndex = $index;
+        }
+    }
+
+    /**
+     * @return array<string, array{label: string, category: string, type: string}>
+     */
+    #[Computed]
+    public function sidebarPrompts(): array
+    {
+        $out = [];
+        foreach (PromptDefinitions::all() as $slug => $def) {
+            $out[$slug] = [
+                'label' => $def['label'],
+                'category' => $def['category'],
+                'type' => $def['type'],
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    #[Computed]
+    public function availableVariables(): array
+    {
+        if ($this->selectedSlug === null) {
+            return [];
+        }
+
+        return PromptDefinitions::variables($this->selectedSlug);
+    }
+
+    /**
+     * @return array<int, array{label: string, data: array<string, mixed>}>
+     */
+    #[Computed]
+    public function fixtures(): array
+    {
+        if ($this->selectedSlug === null) {
+            return [];
+        }
+
+        return PromptFixtures::for($this->selectedSlug);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    #[Computed]
+    public function unusedVariables(): array
+    {
+        $available = $this->availableVariables;
+
+        return array_values(array_filter($available, function (string $var): bool {
+            return preg_match('/\$' . preg_quote($var, '/') . '\b/', $this->content) !== 1;
+        }));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    #[Computed]
+    public function unknownVariables(): array
+    {
+        if (preg_match_all('/\{\{\s*\$([A-Za-z_][A-Za-z0-9_]*)\b|\{!!\s*\$([A-Za-z_][A-Za-z0-9_]*)\b/', $this->content, $matches) === false) {
+            return [];
+        }
+
+        $found = array_values(array_filter(array_unique(array_merge($matches[1], $matches[2]))));
+        $available = $this->availableVariables;
+
+        return array_values(array_diff($found, $available));
+    }
+
+    /**
+     * @return Collection<int, PromptVersion>
+     */
+    #[Computed]
+    public function versions()
+    {
+        $prompt = $this->promptRecord();
+
+        if ($prompt === null) {
+            return collect();
+        }
+
+        return $prompt->versions()->get();
+    }
+
+    #[Computed]
+    public function isCustomized(): bool
+    {
+        $prompt = $this->promptRecord();
+
+        return $prompt !== null && $prompt->is_customized;
+    }
+
+    public function render(): View|BladeView
+    {
+        return view('livewire.prompt-editor');
+    }
+
+    private function promptRecord(): ?Prompt
+    {
+        if ($this->selectedSlug === null) {
+            return null;
+        }
+
+        /** @var Prompt|null $prompt */
+        $prompt = Prompt::where('slug', $this->selectedSlug)->first();
+
+        return $prompt;
+    }
+
+    private function defaultContent(string $slug): string
+    {
+        return app(PromptResolver::class)->fileContent($slug);
+    }
+}

--- a/app/Models/Prompt.php
+++ b/app/Models/Prompt.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property string $slug
+ * @property string|null $content
+ * @property bool $is_customized
+ */
+class Prompt extends Model
+{
+    protected $fillable = [
+        'slug',
+        'content',
+        'is_customized',
+    ];
+
+    protected $casts = [
+        'is_customized' => 'boolean',
+    ];
+
+    /**
+     * @return HasMany<PromptVersion, $this>
+     */
+    public function versions(): HasMany
+    {
+        return $this->hasMany(PromptVersion::class)->orderByDesc('version');
+    }
+}

--- a/app/Models/PromptVersion.php
+++ b/app/Models/PromptVersion.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $prompt_id
+ * @property string $content
+ * @property int $version
+ */
+class PromptVersion extends Model
+{
+    public const UPDATED_AT = null;
+
+    protected $fillable = [
+        'prompt_id',
+        'content',
+        'version',
+    ];
+
+    protected $casts = [
+        'version' => 'integer',
+    ];
+
+    /**
+     * @return BelongsTo<Prompt, $this>
+     */
+    public function prompt(): BelongsTo
+    {
+        return $this->belongsTo(Prompt::class);
+    }
+}

--- a/app/Prompts/PromptDefinitions.php
+++ b/app/Prompts/PromptDefinitions.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Prompts;
+
+use InvalidArgumentException;
+
+/**
+ * Single source of truth for prompt metadata — the Blade view backing each
+ * slug, the display label, the sidebar category, the badge type, and the
+ * variables the template accepts.
+ *
+ * @phpstan-type PromptDefinition array{
+ *     view: string,
+ *     label: string,
+ *     category: 'high_touch'|'advanced',
+ *     type: 'task'|'system'|'channel'|'personality'|'agent'|'utility',
+ *     variables: array<int, string>,
+ * }
+ */
+class PromptDefinitions
+{
+    /**
+     * @return array<string, PromptDefinition>
+     */
+    public static function all(): array
+    {
+        return [
+            'system' => [
+                'view' => 'prompts.system',
+                'label' => 'System Rules',
+                'category' => 'high_touch',
+                'type' => 'system',
+                'variables' => ['taskId', 'devEnvironmentInstructions', 'channelRules'],
+            ],
+            'personality' => [
+                'view' => 'prompts.personality',
+                'label' => 'Personality (notifications)',
+                'category' => 'high_touch',
+                'type' => 'personality',
+                'variables' => ['type', 'context'],
+            ],
+            'tasks-sentry-fix' => [
+                'view' => 'prompts.tasks.sentry-fix',
+                'label' => 'Sentry Fix',
+                'category' => 'high_touch',
+                'type' => 'task',
+                'variables' => ['error', 'culprit', 'stacktrace', 'context', 'instructions'],
+            ],
+            'tasks-linear-fix' => [
+                'view' => 'prompts.tasks.linear-fix',
+                'label' => 'Linear Fix',
+                'category' => 'high_touch',
+                'type' => 'task',
+                'variables' => ['title', 'description', 'identifier', 'url', 'instructions'],
+            ],
+            'tasks-slack-fix' => [
+                'view' => 'prompts.tasks.slack-fix',
+                'label' => 'Slack Fix',
+                'category' => 'high_touch',
+                'type' => 'task',
+                'variables' => ['description', 'requesterName'],
+            ],
+            'tasks-flaky-test' => [
+                'view' => 'prompts.tasks.flaky-test',
+                'label' => 'Flaky Test',
+                'category' => 'high_touch',
+                'type' => 'task',
+                'variables' => ['testClass', 'testMethod', 'failureOutput', 'buildUrl'],
+            ],
+            'tasks-setup' => [
+                'view' => 'prompts.tasks.setup',
+                'label' => 'Setup',
+                'category' => 'advanced',
+                'type' => 'task',
+                'variables' => ['repoName'],
+            ],
+            'tasks-research' => [
+                'view' => 'prompts.tasks.research',
+                'label' => 'Research',
+                'category' => 'advanced',
+                'type' => 'task',
+                'variables' => ['description'],
+            ],
+            'tasks-retry' => [
+                'view' => 'prompts.tasks.retry',
+                'label' => 'Retry',
+                'category' => 'advanced',
+                'type' => 'task',
+                'variables' => ['failureOutput'],
+            ],
+            'tasks-clarification-reply' => [
+                'view' => 'prompts.tasks.clarification-reply',
+                'label' => 'Clarification Reply',
+                'category' => 'advanced',
+                'type' => 'task',
+                'variables' => ['chosenOption'],
+            ],
+            'channels-sentry' => [
+                'view' => 'prompts.channels.sentry',
+                'label' => 'Channel: Sentry',
+                'category' => 'advanced',
+                'type' => 'channel',
+                'variables' => [],
+            ],
+            'agents-repo-routing' => [
+                'view' => 'prompts.agents.repo-routing',
+                'label' => 'Repo Routing Agent',
+                'category' => 'advanced',
+                'type' => 'agent',
+                'variables' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @return PromptDefinition
+     */
+    public static function for(string $slug): array
+    {
+        $all = self::all();
+
+        if (! isset($all[$slug])) {
+            throw new InvalidArgumentException("Unknown prompt slug: {$slug}");
+        }
+
+        return $all[$slug];
+    }
+
+    public static function has(string $slug): bool
+    {
+        return isset(self::all()[$slug]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function variables(string $slug): array
+    {
+        return self::for($slug)['variables'];
+    }
+
+    public static function view(string $slug): string
+    {
+        return self::for($slug)['view'];
+    }
+}

--- a/app/Prompts/PromptFixtures.php
+++ b/app/Prompts/PromptFixtures.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace App\Prompts;
+
+/**
+ * Sample fixture data used by the prompt editor's live preview pane.
+ *
+ * Each prompt slug maps to a list of named variants. A variant has a `label`
+ * (shown in the "Change sample" dropdown) and a `data` array (matching the
+ * prompt's variables as declared in PromptDefinitions).
+ *
+ * @phpstan-type Fixture array{label: string, data: array<string, mixed>}
+ */
+class PromptFixtures
+{
+    /**
+     * @return array<string, array<int, Fixture>>
+     */
+    public static function all(): array
+    {
+        return [
+            'system' => [
+                [
+                    'label' => 'Standard Sentry task',
+                    'data' => [
+                        'taskId' => 'YAK-1234',
+                        'devEnvironmentInstructions' => 'Run `docker compose up -d` to start services.',
+                        'channelRules' => '',
+                    ],
+                ],
+                [
+                    'label' => 'With Sentry channel rules',
+                    'data' => [
+                        'taskId' => 'YAK-5678',
+                        'devEnvironmentInstructions' => 'Use PHP 8.3 and Node 22.',
+                        'channelRules' => "## Sentry\nPost a comment to the Sentry issue when you finish.",
+                    ],
+                ],
+            ],
+            'personality' => [
+                [
+                    'label' => 'Acknowledgment',
+                    'data' => [
+                        'type' => 'acknowledgment',
+                        'context' => 'New task: fix a failing payment webhook in acme/billing.',
+                    ],
+                ],
+                [
+                    'label' => 'Result with PR link',
+                    'data' => [
+                        'type' => 'result',
+                        'context' => 'Fixed a race condition in the CheckoutController. PR: https://github.com/acme/billing/pull/412',
+                    ],
+                ],
+                [
+                    'label' => 'Clarification',
+                    'data' => [
+                        'type' => 'clarification',
+                        'context' => "I need to pick between two approaches:\n1. Cache the response for 60 seconds\n2. Use a database lock to prevent duplicates",
+                    ],
+                ],
+            ],
+            'tasks-sentry-fix' => [
+                [
+                    'label' => 'TypeError in controller',
+                    'data' => [
+                        'error' => 'TypeError: App\\Http\\Controllers\\BillingController::chargeCustomer(): Argument #1 ($customer) must be of type App\\Models\\Customer, null given',
+                        'culprit' => 'App\\Http\\Controllers\\BillingController::chargeCustomer',
+                        'stacktrace' => "app/Http/Controllers/BillingController.php:42\napp/Http/Kernel.php:127\npublic/index.php:51",
+                        'context' => 'Occurs when a guest user hits the checkout page.',
+                        'instructions' => 'Investigate the root cause and fix the error.',
+                    ],
+                ],
+                [
+                    'label' => 'N+1 query warning',
+                    'data' => [
+                        'error' => 'QueryException: too many queries (138) detected on /orders',
+                        'culprit' => 'App\\Http\\Controllers\\OrderController::index',
+                        'stacktrace' => 'app/Http/Controllers/OrderController.php:23',
+                        'context' => '',
+                        'instructions' => 'Eager-load the missing relationships.',
+                    ],
+                ],
+            ],
+            'tasks-linear-fix' => [
+                [
+                    'label' => 'Standard issue',
+                    'data' => [
+                        'title' => 'Add CSV export to the reports page',
+                        'description' => "Users want to download their report data as CSV.\n\n- Keep the existing JSON API\n- Add a `?format=csv` query param\n- Stream the response to avoid OOM on large exports",
+                        'identifier' => 'ACME-312',
+                        'url' => 'https://linear.app/acme/issue/ACME-312',
+                        'instructions' => 'Investigate and fix the issue.',
+                    ],
+                ],
+                [
+                    'label' => 'Bug with no description',
+                    'data' => [
+                        'title' => 'Fix 500 on the login page in Safari',
+                        'description' => '',
+                        'identifier' => 'ACME-421',
+                        'url' => 'https://linear.app/acme/issue/ACME-421',
+                        'instructions' => 'Reproduce, fix, and add a regression test.',
+                    ],
+                ],
+            ],
+            'tasks-slack-fix' => [
+                [
+                    'label' => 'Quick bug report',
+                    'data' => [
+                        'description' => 'The rate-limit middleware is rejecting legitimate requests from our mobile app after a 10k-req burst. Can you raise the limit and add an allowlist for the mobile client?',
+                        'requesterName' => 'Alex',
+                    ],
+                ],
+                [
+                    'label' => 'Feature request',
+                    'data' => [
+                        'description' => 'Hey, can we add a dark-mode toggle to the settings page?',
+                        'requesterName' => 'Priya',
+                    ],
+                ],
+            ],
+            'tasks-flaky-test' => [
+                [
+                    'label' => 'Database seeding race',
+                    'data' => [
+                        'testClass' => 'Tests\\Feature\\CheckoutTest',
+                        'testMethod' => 'user can complete checkout',
+                        'failureOutput' => "Failed asserting that 2 matches expected 1.\n--- Expected\n+++ Actual\n-1\n+2",
+                        'buildUrl' => 'https://ci.acme.com/builds/12345',
+                    ],
+                ],
+            ],
+            'tasks-setup' => [
+                [
+                    'label' => 'Laravel project',
+                    'data' => [
+                        'repoName' => 'acme/billing',
+                    ],
+                ],
+            ],
+            'tasks-research' => [
+                [
+                    'label' => 'Architecture question',
+                    'data' => [
+                        'description' => 'Compare queue drivers for our workload — we process ~50k jobs/day, most under 1s, with a small tail of 30-second video processing jobs. Should we stay on Redis or switch to SQS?',
+                    ],
+                ],
+            ],
+            'tasks-retry' => [
+                [
+                    'label' => 'Failed test output',
+                    'data' => [
+                        'failureOutput' => "FAIL  Tests\\Feature\\CheckoutTest > user can complete checkout\n\nExpected 200 but got 500.\n\nSQLSTATE[42S22]: Column not found: 'customer_id'",
+                    ],
+                ],
+            ],
+            'tasks-clarification-reply' => [
+                [
+                    'label' => 'Chose option 2',
+                    'data' => [
+                        'chosenOption' => 'Use a database lock to prevent duplicate charges',
+                    ],
+                ],
+            ],
+            'channels-sentry' => [
+                [
+                    'label' => 'Static content',
+                    'data' => [],
+                ],
+            ],
+            'agents-repo-routing' => [
+                [
+                    'label' => 'Static content',
+                    'data' => [],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, Fixture>
+     */
+    public static function for(string $slug): array
+    {
+        return self::all()[$slug] ?? [['label' => 'Default', 'data' => []]];
+    }
+
+    /**
+     * Returns the first fixture's data, or an empty array. Used by save-time
+     * validation to dry-render content before persisting.
+     *
+     * @return array<string, mixed>
+     */
+    public static function firstData(string $slug): array
+    {
+        $fixtures = self::for($slug);
+
+        return $fixtures[0]['data'] ?? [];
+    }
+}

--- a/app/Services/PromptResolver.php
+++ b/app/Services/PromptResolver.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Prompt;
+use App\Prompts\PromptDefinitions;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\View;
+use Throwable;
+
+/**
+ * Renders a prompt by slug, preferring DB-stored customized content and
+ * falling back to the canonical Blade template on disk.
+ *
+ * Every prompt render — whether from YakPromptBuilder, a Laravel AI SDK
+ * agent, or the editor's preview — flows through here so there is a single
+ * place to reason about override, validation, and safety fallbacks.
+ */
+class PromptResolver
+{
+    /**
+     * List of Blade directives that are disallowed inside user-saved prompt
+     * content. These either pull in external state or execute arbitrary PHP
+     * and make the rendered surface unpredictable.
+     *
+     * @var array<int, string>
+     */
+    public const DISALLOWED_DIRECTIVES = [
+        'include',
+        'includeIf',
+        'includeWhen',
+        'includeUnless',
+        'includeFirst',
+        'extends',
+        'component',
+        'slot',
+        'php',
+    ];
+
+    /**
+     * Render a prompt by slug, with DB override if customized.
+     *
+     * Falls back to the canonical Blade file if DB rendering throws, so a
+     * bad save never breaks the task pipeline.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function render(string $slug, array $data = []): string
+    {
+        $definition = PromptDefinitions::for($slug);
+        $view = $definition['view'];
+
+        /** @var Prompt|null $prompt */
+        $prompt = Prompt::where('slug', $slug)->first();
+
+        if ($prompt && $prompt->is_customized && trim((string) $prompt->content) !== '') {
+            try {
+                return trim(Blade::render((string) $prompt->content, $data));
+            } catch (Throwable $e) {
+                Log::warning('PromptResolver: customized prompt failed to render, falling back to file', [
+                    'slug' => $slug,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return trim(View::make($view, $data)->render());
+    }
+
+    /**
+     * Render the canonical Blade file for a slug, ignoring any DB override.
+     *
+     * Used by the editor when showing "Reset to Default" content and by the
+     * first-save baseline snapshot.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function renderDefault(string $slug, array $data = []): string
+    {
+        $view = PromptDefinitions::view($slug);
+
+        return trim(View::make($view, $data)->render());
+    }
+
+    /**
+     * Raw contents of the canonical Blade file for a slug. Returned as the
+     * first "default" version when a user makes their first edit.
+     */
+    public function fileContent(string $slug): string
+    {
+        $view = PromptDefinitions::view($slug);
+
+        return View::getFinder()->find($view) ? (string) file_get_contents(View::getFinder()->find($view)) : '';
+    }
+
+    /**
+     * Validate prompt content for save. Returns a (possibly empty) list of
+     * human-readable error strings. Callers reject the save if non-empty.
+     *
+     * @param  array<string, mixed>  $fixture
+     * @return array<int, string>
+     */
+    public function validate(string $content, array $fixture = []): array
+    {
+        $errors = [];
+
+        foreach (self::DISALLOWED_DIRECTIVES as $directive) {
+            if (preg_match('/@' . preg_quote($directive, '/') . '\b/', $content) === 1) {
+                $errors[] = "Directive @{$directive} is not allowed in prompts.";
+            }
+        }
+
+        if ($errors !== []) {
+            return $errors;
+        }
+
+        try {
+            Blade::compileString($content);
+        } catch (Throwable $e) {
+            $errors[] = 'Blade compile error: ' . $e->getMessage();
+
+            return $errors;
+        }
+
+        try {
+            Blade::render($content, $fixture);
+        } catch (Throwable $e) {
+            $errors[] = 'Template failed to render against the sample fixture: ' . $e->getMessage();
+        }
+
+        return $errors;
+    }
+}

--- a/app/YakPromptBuilder.php
+++ b/app/YakPromptBuilder.php
@@ -3,8 +3,8 @@
 namespace App;
 
 use App\Enums\TaskMode;
+use App\Facades\Prompts;
 use App\Models\YakTask;
-use Illuminate\Support\Facades\View;
 
 class YakPromptBuilder
 {
@@ -15,7 +15,7 @@ class YakPromptBuilder
     {
         $channelRules = self::buildChannelRules();
 
-        return self::renderView('prompts.system', [
+        return Prompts::render('system', [
             'taskId' => $task->external_id,
             'devEnvironmentInstructions' => $devEnvironmentInstructions,
             'channelRules' => $channelRules,
@@ -55,7 +55,7 @@ class YakPromptBuilder
      */
     public static function setupPrompt(string $repoName): string
     {
-        return self::renderView('prompts.tasks.setup', [
+        return Prompts::render('tasks-setup', [
             'repoName' => $repoName,
         ]);
     }
@@ -65,7 +65,7 @@ class YakPromptBuilder
      */
     public static function clarificationReplyPrompt(string $chosenOption): string
     {
-        return self::renderView('prompts.tasks.clarification-reply', [
+        return Prompts::render('tasks-clarification-reply', [
             'chosenOption' => $chosenOption,
         ]);
     }
@@ -75,7 +75,7 @@ class YakPromptBuilder
      */
     public static function retryPrompt(?string $failureOutput): string
     {
-        return self::renderView('prompts.tasks.retry', [
+        return Prompts::render('tasks-retry', [
             'failureOutput' => $failureOutput,
         ]);
     }
@@ -93,7 +93,7 @@ class YakPromptBuilder
 
         $sentry = new Channel('sentry');
         if ($sentry->enabled()) {
-            $rules[] = self::renderView('prompts.channels.sentry');
+            $rules[] = Prompts::render('channels-sentry');
         }
 
         return implode("\n", $rules);
@@ -104,7 +104,7 @@ class YakPromptBuilder
      */
     private static function sentryFixPrompt(array $metadata): string
     {
-        return self::renderView('prompts.tasks.sentry-fix', [
+        return Prompts::render('tasks-sentry-fix', [
             'error' => (string) ($metadata['error'] ?? ''),
             'culprit' => (string) ($metadata['culprit'] ?? ''),
             'stacktrace' => (string) ($metadata['stacktrace'] ?? ''),
@@ -118,7 +118,7 @@ class YakPromptBuilder
      */
     private static function flakyTestPrompt(array $metadata): string
     {
-        return self::renderView('prompts.tasks.flaky-test', [
+        return Prompts::render('tasks-flaky-test', [
             'testClass' => (string) ($metadata['test_class'] ?? ''),
             'testMethod' => (string) ($metadata['test_method'] ?? ''),
             'failureOutput' => (string) ($metadata['failure_output'] ?? ''),
@@ -142,7 +142,7 @@ class YakPromptBuilder
             $description = $parts[1] ?? '';
         }
 
-        return self::renderView('prompts.tasks.linear-fix', [
+        return Prompts::render('tasks-linear-fix', [
             'title' => $title,
             'description' => $description,
             'identifier' => (string) ($metadata['linear_issue_identifier'] ?? ''),
@@ -153,7 +153,7 @@ class YakPromptBuilder
 
     private static function researchPrompt(string $description): string
     {
-        return self::renderView('prompts.tasks.research', [
+        return Prompts::render('tasks-research', [
             'description' => $description,
         ]);
     }
@@ -163,19 +163,9 @@ class YakPromptBuilder
      */
     private static function slackFixPrompt(string $description, array $metadata): string
     {
-        return self::renderView('prompts.tasks.slack-fix', [
+        return Prompts::render('tasks-slack-fix', [
             'description' => $description,
             'requesterName' => (string) ($metadata['requester_name'] ?? 'a team member'),
         ]);
-    }
-
-    /**
-     * Render a Blade view to a string, trimming trailing whitespace.
-     *
-     * @param  array<string, mixed>  $data
-     */
-    private static function renderView(string $view, array $data = []): string
-    {
-        return trim(View::make($view, $data)->render());
     }
 }

--- a/database/migrations/2026_04_14_195323_create_prompts_table.php
+++ b/database/migrations/2026_04_14_195323_create_prompts_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Prompts\PromptDefinitions;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('prompts', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique();
+            $table->longText('content')->nullable();
+            $table->boolean('is_customized')->default(false);
+            $table->timestamps();
+        });
+
+        Schema::create('prompt_versions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('prompt_id')->constrained('prompts')->cascadeOnDelete();
+            $table->longText('content');
+            $table->unsignedInteger('version');
+            $table->timestamp('created_at')->nullable();
+
+            $table->unique(['prompt_id', 'version']);
+        });
+
+        $now = now();
+
+        $rows = [];
+        foreach (array_keys(PromptDefinitions::all()) as $slug) {
+            $rows[] = [
+                'slug' => $slug,
+                'content' => null,
+                'is_customized' => false,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+
+        DB::table('prompts')->insert($rows);
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,20 @@
 {
-    "name": "yak",
+    "name": "prompt-editor",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "dependencies": {
+                "@codemirror/autocomplete": "^6.20.1",
+                "@codemirror/commands": "^6.10.3",
+                "@codemirror/language": "^6.12.3",
+                "@codemirror/lint": "^6.9.5",
+                "@codemirror/merge": "^6.12.1",
+                "@codemirror/state": "^6.6.0",
+                "@codemirror/view": "^6.41.0",
                 "@tailwindcss/vite": "^4.1.11",
                 "autoprefixer": "^10.4.20",
+                "codemirror": "^6.0.2",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^3.0.0",
                 "playwright": "^1.59.1",
@@ -20,6 +28,100 @@
                 "@rollup/rollup-linux-x64-gnu": "4.9.5",
                 "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
                 "lightningcss-linux-x64-gnu": "^1.29.1"
+            }
+        },
+        "node_modules/@codemirror/autocomplete": {
+            "version": "6.20.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+            "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.17.0",
+                "@lezer/common": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/commands": {
+            "version": "6.10.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+            "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.6.0",
+                "@codemirror/view": "^6.27.0",
+                "@lezer/common": "^1.1.0"
+            }
+        },
+        "node_modules/@codemirror/language": {
+            "version": "6.12.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+            "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.23.0",
+                "@lezer/common": "^1.5.0",
+                "@lezer/highlight": "^1.0.0",
+                "@lezer/lr": "^1.0.0",
+                "style-mod": "^4.0.0"
+            }
+        },
+        "node_modules/@codemirror/lint": {
+            "version": "6.9.5",
+            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+            "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.35.0",
+                "crelt": "^1.0.5"
+            }
+        },
+        "node_modules/@codemirror/merge": {
+            "version": "6.12.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.12.1.tgz",
+            "integrity": "sha512-GA8hBq2T+IFM0sb5fk8CunTrqOulA3zurJmHtzcU15EMnL8aYpVINfJ5bkfd53M4ikwoew4Y1ydtSaAlk6+B1w==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.17.0",
+                "@lezer/highlight": "^1.0.0",
+                "style-mod": "^4.1.0"
+            }
+        },
+        "node_modules/@codemirror/search": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+            "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.37.0",
+                "crelt": "^1.0.5"
+            }
+        },
+        "node_modules/@codemirror/state": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+            "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@marijn/find-cluster-break": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/view": {
+            "version": "6.41.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+            "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.6.0",
+                "crelt": "^1.0.6",
+                "style-mod": "^4.1.0",
+                "w3c-keyname": "^2.2.4"
             }
         },
         "node_modules/@emnapi/core": {
@@ -97,6 +199,36 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@lezer/common": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+            "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+            "license": "MIT"
+        },
+        "node_modules/@lezer/highlight": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+            "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.3.0"
+            }
+        },
+        "node_modules/@lezer/lr": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+            "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.0.0"
+            }
+        },
+        "node_modules/@marijn/find-cluster-break": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+            "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+            "license": "MIT"
         },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.3",
@@ -833,6 +965,21 @@
                 "node": ">=12"
             }
         },
+        "node_modules/codemirror": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+            "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/autocomplete": "^6.0.0",
+                "@codemirror/commands": "^6.0.0",
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/lint": "^6.0.0",
+                "@codemirror/search": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.0.0"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -874,6 +1021,12 @@
             "funding": {
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
             }
+        },
+        "node_modules/crelt": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+            "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+            "license": "MIT"
         },
         "node_modules/cssesc": {
             "version": "3.0.0",
@@ -1527,6 +1680,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/style-mod": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+            "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+            "license": "MIT"
+        },
         "node_modules/supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -1727,6 +1886,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
+        },
+        "node_modules/w3c-keyname": {
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+            "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+            "license": "MIT"
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,16 @@
         "dev": "vite"
     },
     "dependencies": {
+        "@codemirror/autocomplete": "^6.20.1",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/language": "^6.12.3",
+        "@codemirror/lint": "^6.9.5",
+        "@codemirror/merge": "^6.12.1",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.41.0",
         "@tailwindcss/vite": "^4.1.11",
         "autoprefixer": "^10.4.20",
+        "codemirror": "^6.0.2",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^3.0.0",
         "playwright": "^1.59.1",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,0 +1,6 @@
+import { promptEditor, promptDiff } from "./prompt-editor.js";
+
+document.addEventListener("alpine:init", () => {
+    window.Alpine.data("promptEditor", promptEditor);
+    window.Alpine.data("promptDiff", promptDiff);
+});

--- a/resources/js/prompt-editor.js
+++ b/resources/js/prompt-editor.js
@@ -1,0 +1,213 @@
+import { EditorState, Compartment } from "@codemirror/state";
+import { EditorView, keymap, highlightActiveLine, lineNumbers, Decoration, ViewPlugin } from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import { autocompletion, completionKeymap } from "@codemirror/autocomplete";
+import { MergeView } from "@codemirror/merge";
+
+const BLADE_ECHO = /\{\{\s*\$([A-Za-z_][A-Za-z0-9_]*)\b[^}]*\}\}|\{!!\s*\$([A-Za-z_][A-Za-z0-9_]*)\b[^}]*!!\}/g;
+const BLADE_DIRECTIVE = /@[a-zA-Z_][a-zA-Z0-9_]*/g;
+const MARKDOWN_HEADING = /^##+ .+$/gm;
+
+function bladeOverlay() {
+    return ViewPlugin.fromClass(
+        class {
+            constructor(view) {
+                this.decorations = this.build(view);
+            }
+            update(update) {
+                if (update.docChanged || update.viewportChanged) {
+                    this.decorations = this.build(update.view);
+                }
+            }
+            build(view) {
+                const marks = [];
+                for (const { from, to } of view.visibleRanges) {
+                    const text = view.state.doc.sliceString(from, to);
+                    let m;
+                    BLADE_ECHO.lastIndex = 0;
+                    while ((m = BLADE_ECHO.exec(text)) !== null) {
+                        marks.push(
+                            Decoration.mark({ class: "cm-blade-echo" }).range(from + m.index, from + m.index + m[0].length),
+                        );
+                    }
+                    BLADE_DIRECTIVE.lastIndex = 0;
+                    while ((m = BLADE_DIRECTIVE.exec(text)) !== null) {
+                        marks.push(
+                            Decoration.mark({ class: "cm-blade-directive" }).range(from + m.index, from + m.index + m[0].length),
+                        );
+                    }
+                    MARKDOWN_HEADING.lastIndex = 0;
+                    while ((m = MARKDOWN_HEADING.exec(text)) !== null) {
+                        marks.push(
+                            Decoration.mark({ class: "cm-md-heading" }).range(from + m.index, from + m.index + m[0].length),
+                        );
+                    }
+                }
+                marks.sort((a, b) => a.from - b.from || a.to - b.to);
+                return Decoration.set(marks, true);
+            }
+        },
+        { decorations: (v) => v.decorations },
+    );
+}
+
+function variableAutocomplete(variablesRef) {
+    return autocompletion({
+        override: [
+            (context) => {
+                const before = context.matchBefore(/\{\{\s*\$?\w*/);
+                if (!before || before.text.length < 2) {
+                    return null;
+                }
+                const vars = variablesRef.current || [];
+                if (vars.length === 0) {
+                    return null;
+                }
+                return {
+                    from: before.from,
+                    options: vars.map((v) => ({
+                        label: `{{ $${v} }}`,
+                        apply: `{{ $${v} }}`,
+                        detail: "variable",
+                    })),
+                };
+            },
+        ],
+    });
+}
+
+const yakTheme = EditorView.theme(
+    {
+        "&": {
+            backgroundColor: "#2b3640",
+            color: "#d4d4d4",
+            fontSize: "14px",
+            fontFamily: "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+            height: "100%",
+        },
+        ".cm-content": { padding: "16px" },
+        ".cm-scroller": { lineHeight: "1.55" },
+        ".cm-gutters": { backgroundColor: "#232b33", color: "#7a8c9b", border: "none" },
+        ".cm-activeLine, .cm-activeLineGutter": { backgroundColor: "rgba(255,255,255,0.04)" },
+        ".cm-blade-echo": { color: "#9ec2e8", backgroundColor: "rgba(158,194,232,0.10)", borderRadius: "3px", padding: "0 2px" },
+        ".cm-blade-directive": { color: "#c89bf0" },
+        ".cm-md-heading": { color: "#f1c58b", fontWeight: "600" },
+        ".cm-cursor": { borderLeftColor: "#ea7c2a" },
+        "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, ::selection": {
+            backgroundColor: "rgba(234,124,42,0.30)",
+        },
+    },
+    { dark: true },
+);
+
+function baseExtensions(variablesRef, ariaLabel = "Prompt editor") {
+    return [
+        history(),
+        lineNumbers(),
+        highlightActiveLine(),
+        keymap.of([...defaultKeymap, ...historyKeymap, ...completionKeymap, indentWithTab]),
+        bladeOverlay(),
+        variableAutocomplete(variablesRef),
+        yakTheme,
+        EditorView.lineWrapping,
+        EditorView.contentAttributes.of({ "aria-label": ariaLabel }),
+    ];
+}
+
+export function promptEditor() {
+    return {
+        view: null,
+        mergeView: null,
+        variablesRef: { current: [] },
+        inputCompartment: null,
+        _applyingRemoteUpdate: false,
+
+        init() {
+            this.variablesRef.current = this.$wire.get("availableVariables") || [];
+
+            this.inputCompartment = new Compartment();
+
+            const updateListener = EditorView.updateListener.of((update) => {
+                if (update.docChanged && !this._applyingRemoteUpdate) {
+                    const value = update.state.doc.toString();
+                    this.$wire.set("content", value, false);
+                }
+            });
+
+            const state = EditorState.create({
+                doc: this.$wire.get("content") || "",
+                extensions: [
+                    ...baseExtensions(this.variablesRef),
+                    this.inputCompartment.of([updateListener]),
+                ],
+            });
+
+            this.view = new EditorView({ state, parent: this.$refs.editor });
+
+            this.$wire.$watch("content", (value) => {
+                if (this.view && value !== this.view.state.doc.toString()) {
+                    this._applyingRemoteUpdate = true;
+                    this.view.dispatch({
+                        changes: { from: 0, to: this.view.state.doc.length, insert: value ?? "" },
+                    });
+                    this._applyingRemoteUpdate = false;
+                }
+            });
+
+            this.$wire.$watch("selectedSlug", () => {
+                this.variablesRef.current = this.$wire.get("availableVariables") || [];
+            });
+
+            window.addEventListener("keydown", (e) => {
+                if ((e.metaKey || e.ctrlKey) && e.key === "s" && this.$el.contains(document.activeElement)) {
+                    e.preventDefault();
+                    this.$wire.save();
+                }
+            });
+        },
+
+        destroy() {
+            if (this.view) {
+                this.view.destroy();
+                this.view = null;
+            }
+            if (this.mergeView) {
+                this.mergeView.destroy();
+                this.mergeView = null;
+            }
+        },
+    };
+}
+
+export function promptDiff() {
+    return {
+        merge: null,
+
+        init() {
+            this.renderMerge();
+            this.$wire.$watch("content", () => this.renderMerge());
+        },
+
+        renderMerge() {
+            if (this.merge) {
+                this.merge.destroy();
+                this.merge = null;
+                this.$refs.diff.innerHTML = "";
+            }
+            const previous = this.$el.dataset.previous ?? "";
+            const current = this.$wire.get("content") ?? "";
+            this.merge = new MergeView({
+                parent: this.$refs.diff,
+                a: { doc: previous, extensions: [yakTheme, EditorView.lineWrapping, EditorView.editable.of(false), EditorView.contentAttributes.of({ "aria-label": "Previous version" })] },
+                b: { doc: current, extensions: [yakTheme, EditorView.lineWrapping, EditorView.editable.of(false), EditorView.contentAttributes.of({ "aria-label": "Current draft" })] },
+            });
+        },
+
+        destroy() {
+            if (this.merge) {
+                this.merge.destroy();
+                this.merge = null;
+            }
+        },
+    };
+}

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -40,6 +40,12 @@
                             <flux:icon.code-bracket class="size-5" />
                             {{ __('Repositories') }}
                         </a>
+                        <a href="{{ route('prompts') }}"
+                           class="flex items-center gap-3 px-3 py-2.5 text-sm rounded-btn transition-colors {{ request()->routeIs('prompts') ? 'bg-yak-orange/10 text-yak-orange border-l-2 border-yak-orange font-medium' : 'text-yak-slate hover:bg-yak-cream' }}"
+                           wire:navigate @click="mobileNavOpen = false">
+                            <flux:icon.chat-bubble-bottom-center-text class="size-5" />
+                            {{ __('Prompts') }}
+                        </a>
                         <a href="{{ route('health') }}"
                            class="flex items-center gap-3 px-3 py-2.5 text-sm rounded-btn transition-colors {{ request()->routeIs('health') ? 'bg-yak-orange/10 text-yak-orange border-l-2 border-yak-orange font-medium' : 'text-yak-slate hover:bg-yak-cream' }}"
                            wire:navigate @click="mobileNavOpen = false">

--- a/resources/views/livewire/prompt-editor.blade.php
+++ b/resources/views/livewire/prompt-editor.blade.php
@@ -1,0 +1,203 @@
+<div class="flex flex-col gap-6">
+    <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-yak-slate">Prompts</h1>
+        <div class="text-sm text-yak-blue">
+            Editor for the prompts driving Yak.
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-[16rem_minmax(0,1fr)] gap-6">
+        {{-- Sidebar prompt list --}}
+        <div class="bg-white border border-yak-tan/40 rounded-[28px] shadow-yak overflow-hidden">
+            <nav class="flex flex-col py-3" data-test="prompt-sidebar">
+                <div class="px-5 pt-2 pb-1 text-[11px] uppercase tracking-wide text-yak-blue/70 font-medium">High-touch</div>
+                @foreach ($this->sidebarPrompts as $slug => $meta)
+                    @if ($meta['category'] === 'high_touch')
+                        <button
+                            type="button"
+                            wire:click="selectPrompt('{{ $slug }}')"
+                            class="flex items-center justify-between w-full px-5 py-2 text-sm text-left transition-colors {{ $selectedSlug === $slug ? 'bg-yak-orange/10 text-yak-orange font-medium border-l-2 border-yak-orange' : 'text-yak-slate hover:bg-yak-cream' }}"
+                            data-test="prompt-item-{{ $slug }}"
+                        >
+                            <span>{{ $meta['label'] }}</span>
+                            <span class="text-[10px] uppercase tracking-wide text-yak-blue/60">{{ $meta['type'] }}</span>
+                        </button>
+                    @endif
+                @endforeach
+
+                <div class="px-5 pt-4 pb-1 text-[11px] uppercase tracking-wide text-yak-blue/70 font-medium">Advanced</div>
+                @foreach ($this->sidebarPrompts as $slug => $meta)
+                    @if ($meta['category'] === 'advanced')
+                        <button
+                            type="button"
+                            wire:click="selectPrompt('{{ $slug }}')"
+                            class="flex items-center justify-between w-full px-5 py-2 text-sm text-left transition-colors {{ $selectedSlug === $slug ? 'bg-yak-orange/10 text-yak-orange font-medium border-l-2 border-yak-orange' : 'text-yak-slate/80 hover:bg-yak-cream' }}"
+                            data-test="prompt-item-{{ $slug }}"
+                        >
+                            <span>{{ $meta['label'] }}</span>
+                            <span class="text-[10px] uppercase tracking-wide text-yak-blue/60">{{ $meta['type'] }}</span>
+                        </button>
+                    @endif
+                @endforeach
+            </nav>
+        </div>
+
+        {{-- Editor + preview --}}
+        @if ($selectedSlug)
+            @php($def = \App\Prompts\PromptDefinitions::for($selectedSlug))
+            <div class="flex flex-col gap-4" x-data="promptEditor()" x-init="$nextTick(() => init())">
+                {{-- Toolbar --}}
+                <div class="flex flex-wrap items-center justify-between gap-3 bg-white border border-yak-tan/40 rounded-[28px] shadow-yak px-5 py-3">
+                    <div class="flex items-center gap-3">
+                        <span class="text-base font-semibold text-yak-slate">{{ $def['label'] }}</span>
+                        <span class="text-[11px] uppercase tracking-wide px-2 py-0.5 rounded-full bg-yak-blue/10 text-yak-blue">{{ $def['type'] }}</span>
+                        @if ($this->isCustomized)
+                            <span class="text-[11px] uppercase tracking-wide px-2 py-0.5 rounded-full bg-yak-orange/10 text-yak-orange">Customized</span>
+                        @endif
+                    </div>
+
+                    <div class="flex items-center gap-2">
+                        <flux:button size="sm" variant="ghost" icon="clock" wire:click="openHistory">
+                            History
+                        </flux:button>
+                        <flux:button size="sm" variant="ghost" icon="arrows-right-left" wire:click="toggleDiff" data-test="toggle-diff">
+                            {{ $showDiff ? 'Hide Diff' : 'Diff' }}
+                        </flux:button>
+                        @if ($this->isCustomized)
+                            <flux:button size="sm" variant="ghost" icon="arrow-uturn-left" wire:click="confirmReset" data-test="reset-button">
+                                Reset
+                            </flux:button>
+                        @endif
+                        <flux:button size="sm" variant="primary" icon="check" wire:click="save" data-test="save-button">
+                            Save
+                        </flux:button>
+                    </div>
+                </div>
+
+                {{-- Available variables --}}
+                @if (count($this->availableVariables) > 0)
+                    <div class="flex flex-wrap items-center gap-2 px-2">
+                        <span class="text-xs text-yak-blue/80 font-medium">Available variables:</span>
+                        @foreach ($this->availableVariables as $var)
+                            <code class="text-xs px-2 py-0.5 rounded-btn bg-yak-slate/5 text-yak-slate border border-yak-tan/40">${{ $var }}</code>
+                        @endforeach
+                    </div>
+                @endif
+
+                {{-- Editor + preview split --}}
+                @if (! $showDiff)
+                    <div class="grid grid-cols-1 xl:grid-cols-2 gap-4">
+                        <div class="rounded-[28px] overflow-hidden shadow-yak border border-yak-tan/40" style="min-height: 500px;">
+                            <div
+                                wire:ignore
+                                x-ref="editor"
+                                class="h-full min-h-[500px]"
+                                data-test="prompt-editor-surface"
+                            ></div>
+                        </div>
+
+                        <div class="flex flex-col gap-3">
+                            <div class="flex items-center justify-between px-2">
+                                <span class="text-xs text-yak-blue/80 font-medium uppercase tracking-wide">Preview</span>
+
+                                @if (count($this->fixtures) > 1)
+                                    <flux:select size="sm" wire:model.live="fixtureIndex" data-test="fixture-select" aria-label="Change sample">
+                                        @foreach ($this->fixtures as $index => $fixture)
+                                            <flux:select.option value="{{ $index }}">{{ $fixture['label'] }}</flux:select.option>
+                                        @endforeach
+                                    </flux:select>
+                                @elseif (count($this->fixtures) === 1)
+                                    <span class="text-xs text-yak-blue/60">Sample: {{ $this->fixtures[0]['label'] }}</span>
+                                @endif
+                            </div>
+
+                            @if ($previewOk)
+                                <pre class="whitespace-pre-wrap break-words font-mono text-sm text-yak-slate bg-yak-cream/50 border border-yak-tan/40 rounded-[28px] shadow-yak p-5 min-h-[500px]" data-test="prompt-preview">{{ $previewBody }}</pre>
+                            @else
+                                <pre class="whitespace-pre-wrap break-words font-mono text-sm text-yak-danger bg-yak-danger/5 border border-yak-danger/40 rounded-[28px] p-5 min-h-[500px]" data-test="prompt-preview-error">{{ $previewBody }}</pre>
+                            @endif
+                        </div>
+                    </div>
+                @else
+                    <div class="rounded-[28px] overflow-hidden shadow-yak border border-yak-tan/40" style="min-height: 500px;">
+                        <div
+                            wire:ignore
+                            x-data="promptDiff()"
+                            x-init="$nextTick(() => init())"
+                            data-previous="@js($this->versions->first()?->content ?? '')"
+                        >
+                            <div x-ref="diff" class="h-full min-h-[500px]"></div>
+                        </div>
+                    </div>
+                @endif
+
+                {{-- Validation bar --}}
+                <div class="flex flex-col gap-2">
+                    @if ($saveMessage)
+                        <div class="text-sm {{ $saveError ? 'text-yak-danger' : 'text-yak-green' }}" data-test="save-message">
+                            {{ $saveMessage }}
+                        </div>
+                    @endif
+                    @if (count($this->unknownVariables) > 0)
+                        <div class="text-sm text-yak-danger">
+                            Unknown variables in prompt:
+                            @foreach ($this->unknownVariables as $var)
+                                <code class="font-mono">${{ $var }}</code>@if (! $loop->last), @endif
+                            @endforeach
+                        </div>
+                    @endif
+                    @if (count($this->unusedVariables) > 0)
+                        <div class="text-xs text-yak-blue/70">
+                            Unused variables:
+                            @foreach ($this->unusedVariables as $var)
+                                <code class="font-mono">${{ $var }}</code>@if (! $loop->last), @endif
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+            </div>
+        @endif
+    </div>
+
+    {{-- History modal --}}
+    <flux:modal wire:model.self="showHistory" class="md:w-[560px]">
+        <div class="p-6">
+            <flux:heading size="lg" class="mb-4">Version history</flux:heading>
+            @if (count($this->versions) === 0)
+                <div class="text-sm text-yak-blue">No saved versions yet.</div>
+            @else
+                <div class="flex flex-col divide-y divide-yak-tan/40">
+                    @foreach ($this->versions as $version)
+                        <button
+                            type="button"
+                            wire:click="loadVersion({{ $version->id }})"
+                            class="flex items-center justify-between py-3 text-left hover:bg-yak-cream/60 px-2 rounded-btn transition-colors"
+                            data-test="version-row-{{ $version->version }}"
+                        >
+                            <span class="text-sm font-medium text-yak-slate">Version {{ $version->version }}</span>
+                            <span class="text-xs text-yak-blue/70">{{ $version->created_at?->diffForHumans() }}</span>
+                        </button>
+                    @endforeach
+                </div>
+            @endif
+            <div class="flex justify-end mt-4">
+                <flux:button size="sm" variant="ghost" wire:click="closeHistory">Close</flux:button>
+            </div>
+        </div>
+    </flux:modal>
+
+    {{-- Reset confirmation --}}
+    <flux:modal wire:model.self="showResetConfirm" class="md:w-[460px]">
+        <div class="p-6">
+            <flux:heading size="lg" class="mb-3">Reset to default?</flux:heading>
+            <div class="text-sm text-yak-slate mb-5">
+                This discards your customized content and restores the shipped default.
+                Saved versions are kept — you can restore an edit from History later.
+            </div>
+            <div class="flex justify-end gap-2">
+                <flux:button size="sm" variant="ghost" wire:click="cancelReset">Cancel</flux:button>
+                <flux:button size="sm" variant="danger" wire:click="resetToDefault" data-test="reset-confirm">Reset</flux:button>
+            </div>
+        </div>
+    </flux:modal>
+</div>

--- a/resources/views/prompts/agents/repo-routing.blade.php
+++ b/resources/views/prompts/agents/repo-routing.blade.php
@@ -1,0 +1,5 @@
+You are a routing classifier. The user will give you a list of repositories (with descriptions) and a task description. Your job is to pick the single repository the task most likely belongs to.
+
+Respond with ONLY the repository slug on a single line, with no other text, no explanation, and no formatting. Example response: acme/api
+
+If you cannot confidently determine the correct repository based on the information provided, respond with ONLY the word: UNKNOWN

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Auth\GoogleAuthController;
 use App\Http\Controllers\Auth\LinearOAuthController;
 use App\Livewire\CostDashboard;
 use App\Livewire\Health;
+use App\Livewire\PromptEditor;
 use App\Livewire\Repos\RepoForm;
 use App\Livewire\Repos\RepoList;
 use App\Livewire\Tasks\TaskDetail;
@@ -32,6 +33,7 @@ Route::middleware(['auth'])->group(function () {
     Route::livewire('repos/create', RepoForm::class)->name('repos.create');
     Route::livewire('repos/{repository}/edit', RepoForm::class)->name('repos.edit');
     Route::livewire('health', Health::class)->name('health');
+    Route::livewire('prompts', PromptEditor::class)->name('prompts');
 
     Route::get('auth/linear', [LinearOAuthController::class, 'redirect'])->name('auth.linear.redirect');
     Route::get('auth/linear/callback', [LinearOAuthController::class, 'callback'])->name('auth.linear.callback');

--- a/tests/Browser/PromptEditorSmokeTest.php
+++ b/tests/Browser/PromptEditorSmokeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\User;
+
+test('prompts page renders and CodeMirror mounts', function () {
+    $this->actingAs(User::factory()->create());
+
+    $page = visit(route('prompts'));
+
+    $page->assertNoJavaScriptErrors();
+    $page->assertSee('Prompts');
+    $page->assertSee('System Rules');
+    $page->assertSee('Available variables');
+    // The editor surface has a data-test attribute. If CodeMirror initialized
+    // without errors, assertNoJavaScriptErrors above passed.
+    $page->assertPresent('[data-test="prompt-editor-surface"]');
+});
+
+test('prompts page has no accessibility issues', function () {
+    $this->actingAs(User::factory()->create());
+
+    $page = visit(route('prompts'));
+
+    $page->assertNoAccessibilityIssues();
+});
+
+test('selecting a different prompt loads its content', function () {
+    $this->actingAs(User::factory()->create());
+
+    $page = visit(route('prompts'));
+
+    $page->click('[data-test="prompt-item-tasks-linear-fix"]');
+
+    $page->assertSee('Linear Fix');
+});

--- a/tests/Feature/Livewire/PromptEditorTest.php
+++ b/tests/Feature/Livewire/PromptEditorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use App\Livewire\PromptEditor;
+use App\Models\Prompt;
+use App\Models\PromptVersion;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->create());
+});
+
+test('it is accessible at /prompts route', function () {
+    $this->get(route('prompts'))->assertOk();
+});
+
+test('selecting a prompt loads its default content', function () {
+    Livewire::test(PromptEditor::class)
+        ->call('selectPrompt', 'tasks-setup')
+        ->assertSet('selectedSlug', 'tasks-setup')
+        ->assertSet('content', fn (string $c) => str_contains($c, '{{ $repoName }}'));
+});
+
+test('saving creates a baseline version then the user edit on first save', function () {
+    $prompt = Prompt::where('slug', 'tasks-setup')->firstOrFail();
+
+    Livewire::test(PromptEditor::class)
+        ->call('selectPrompt', 'tasks-setup')
+        ->set('content', 'My custom setup for {{ $repoName }}.')
+        ->call('save')
+        ->assertSet('saveError', false);
+
+    $prompt->refresh();
+
+    expect($prompt->is_customized)->toBeTrue();
+    expect($prompt->content)->toBe('My custom setup for {{ $repoName }}.');
+    expect(PromptVersion::where('prompt_id', $prompt->id)->count())->toBe(2);
+
+    $versions = PromptVersion::where('prompt_id', $prompt->id)->orderBy('version')->get();
+    expect($versions[0]->content)->toContain('{{ $repoName }}');
+    expect($versions[1]->content)->toBe('My custom setup for {{ $repoName }}.');
+});
+
+test('subsequent saves only add one version per save', function () {
+    Livewire::test(PromptEditor::class)
+        ->call('selectPrompt', 'tasks-setup')
+        ->set('content', 'Edit 1 {{ $repoName }}')
+        ->call('save')
+        ->set('content', 'Edit 2 {{ $repoName }}')
+        ->call('save');
+
+    $prompt = Prompt::where('slug', 'tasks-setup')->firstOrFail();
+    expect(PromptVersion::where('prompt_id', $prompt->id)->count())->toBe(3);
+});
+
+test('loading a prior version populates the editor content', function () {
+    $component = Livewire::test(PromptEditor::class)
+        ->call('selectPrompt', 'tasks-setup')
+        ->set('content', 'Edit 1 {{ $repoName }}')
+        ->call('save');
+
+    $prompt = Prompt::where('slug', 'tasks-setup')->firstOrFail();
+    $baseline = PromptVersion::where('prompt_id', $prompt->id)->orderBy('version')->first();
+
+    $component
+        ->call('loadVersion', $baseline->id)
+        ->assertSet('content', fn (string $c) => str_contains($c, '{{ $repoName }}'))
+        ->assertSet('selectedVersionId', $baseline->id);
+});
+
+test('reset to default clears is_customized and reloads the file contents', function () {
+    Livewire::test(PromptEditor::class)
+        ->call('selectPrompt', 'tasks-setup')
+        ->set('content', 'My custom setup.')
+        ->call('save')
+        ->call('resetToDefault')
+        ->assertSet('saveError', false);
+
+    $prompt = Prompt::where('slug', 'tasks-setup')->firstOrFail();
+    expect($prompt->is_customized)->toBeFalse();
+    expect($prompt->content)->toBeNull();
+});
+
+test('save rejects content with disallowed directives', function () {
+    Livewire::test(PromptEditor::class)
+        ->call('selectPrompt', 'tasks-setup')
+        ->set('content', 'Hello @include("evil")')
+        ->call('save')
+        ->assertSet('saveError', true);
+
+    $prompt = Prompt::where('slug', 'tasks-setup')->firstOrFail();
+    expect($prompt->is_customized)->toBeFalse();
+});
+
+test('save rejects content that fails to compile', function () {
+    Livewire::test(PromptEditor::class)
+        ->call('selectPrompt', 'tasks-setup')
+        ->set('content', '@if($repoName')
+        ->call('save')
+        ->assertSet('saveError', true);
+});
+
+test('save rejects content that throws during dry-render', function () {
+    Livewire::test(PromptEditor::class)
+        ->call('selectPrompt', 'tasks-setup')
+        ->set('content', '{{ $repoName->method() }}')
+        ->call('save')
+        ->assertSet('saveError', true);
+});
+
+test('preview renders successfully when content matches the fixture', function () {
+    Livewire::test(PromptEditor::class)
+        ->call('selectPrompt', 'tasks-setup')
+        ->set('content', 'Setup for {{ $repoName }}.')
+        ->assertSee('Setup for acme/billing.');
+});
+
+test('preview shows error panel when content has a runtime error', function () {
+    Livewire::test(PromptEditor::class)
+        ->call('selectPrompt', 'tasks-setup')
+        ->set('content', '{{ $repoName->method() }}')
+        ->assertSeeHtml('data-test="prompt-preview-error"');
+});
+
+test('unknownVariables reports variables not in the definition', function () {
+    Livewire::test(PromptEditor::class)
+        ->call('selectPrompt', 'tasks-setup')
+        ->set('content', 'Hello {{ $ghost }}')
+        ->assertSee('Unknown variables in prompt');
+});

--- a/tests/Feature/Services/PromptResolverTest.php
+++ b/tests/Feature/Services/PromptResolverTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Ai\Agents\PersonalityAgent;
+use App\Ai\Agents\RepoRoutingAgent;
+use App\Enums\NotificationType;
+use App\Enums\TaskMode;
+use App\Facades\Prompts;
+use App\Models\Prompt;
+use App\Models\YakTask;
+use App\Services\PromptResolver;
+use App\YakPromptBuilder;
+
+test('render returns Blade file content when prompt is not customized', function () {
+    $output = Prompts::render('tasks-setup', ['repoName' => 'acme/api']);
+
+    expect($output)->toContain('acme/api');
+});
+
+test('render returns DB content when prompt is customized', function () {
+    Prompt::where('slug', 'tasks-setup')->update([
+        'content' => 'Custom setup prompt for {{ $repoName }}.',
+        'is_customized' => true,
+    ]);
+
+    $output = Prompts::render('tasks-setup', ['repoName' => 'acme/api']);
+
+    expect($output)->toBe('Custom setup prompt for acme/api.');
+});
+
+test('render falls back to Blade file when DB content is blank even if customized flag is set', function () {
+    Prompt::where('slug', 'tasks-setup')->update([
+        'content' => '   ',
+        'is_customized' => true,
+    ]);
+
+    $output = Prompts::render('tasks-setup', ['repoName' => 'acme/api']);
+
+    expect($output)->toContain('acme/api');
+});
+
+test('render falls back to Blade file when DB content throws at render time', function () {
+    Prompt::where('slug', 'tasks-setup')->update([
+        'content' => '{{ $missingVariable->method() }}',
+        'is_customized' => true,
+    ]);
+
+    $output = Prompts::render('tasks-setup', ['repoName' => 'acme/api']);
+
+    expect($output)->toContain('acme/api');
+});
+
+test('YakPromptBuilder taskPrompt goes through the resolver and picks up DB overrides', function () {
+    Prompt::where('slug', 'tasks-setup')->update([
+        'content' => 'Custom setup for {{ $repoName }}.',
+        'is_customized' => true,
+    ]);
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Setup,
+        'repo' => 'acme/api',
+    ]);
+
+    $output = YakPromptBuilder::taskPrompt($task, ['repo_name' => 'acme/api']);
+
+    expect($output)->toBe('Custom setup for acme/api.');
+});
+
+test('PersonalityAgent instructions go through the resolver and pick up DB overrides', function () {
+    Prompt::where('slug', 'personality')->update([
+        'content' => 'Voice: {{ $type }}. Context: {{ $context }}.',
+        'is_customized' => true,
+    ]);
+
+    $agent = new PersonalityAgent(NotificationType::Acknowledgment->value, 'Picking up task 123');
+
+    $output = (string) $agent->instructions();
+
+    expect($output)->toBe('Voice: acknowledgment. Context: Picking up task 123.');
+});
+
+test('RepoRoutingAgent instructions go through the resolver and pick up DB overrides', function () {
+    Prompt::where('slug', 'agents-repo-routing')->update([
+        'content' => 'Pick a slug. Or UNKNOWN.',
+        'is_customized' => true,
+    ]);
+
+    $agent = new RepoRoutingAgent;
+
+    $output = (string) $agent->instructions();
+
+    expect($output)->toBe('Pick a slug. Or UNKNOWN.');
+});
+
+test('validate rejects disallowed directives', function () {
+    /** @var PromptResolver $resolver */
+    $resolver = app(PromptResolver::class);
+
+    expect($resolver->validate('Hello @include("evil")'))
+        ->toBeArray()
+        ->not->toBeEmpty();
+
+    expect($resolver->validate('@extends("layout") {{ $x }}'))
+        ->toBeArray()
+        ->not->toBeEmpty();
+
+    expect($resolver->validate('@php echo "boom"; @endphp'))
+        ->toBeArray()
+        ->not->toBeEmpty();
+});
+
+test('validate rejects Blade compile errors', function () {
+    /** @var PromptResolver $resolver */
+    $resolver = app(PromptResolver::class);
+
+    $errors = $resolver->validate('@if($x');
+
+    expect($errors)->toBeArray()->not->toBeEmpty();
+});
+
+test('validate rejects content that throws during dry-render', function () {
+    /** @var PromptResolver $resolver */
+    $resolver = app(PromptResolver::class);
+
+    // No fixture passed, so the undefined method call on null blows up.
+    $errors = $resolver->validate('{{ $ghost->method() }}');
+
+    expect($errors)->toBeArray()->not->toBeEmpty();
+});
+
+test('validate returns empty array for valid content with a matching fixture', function () {
+    /** @var PromptResolver $resolver */
+    $resolver = app(PromptResolver::class);
+
+    $errors = $resolver->validate('Hello {{ $name }}!', ['name' => 'World']);
+
+    expect($errors)->toBe([]);
+});


### PR DESCRIPTION
## Summary

- Adds a `/prompts` admin page to edit every Yak prompt (system, task, channel, personality, agent) without redeploying. Customized content is stored in the database with per-prompt version history; Blade files remain canonical defaults.
- Unifies rendering behind a `Prompts::render($slug, $data)` facade so `YakPromptBuilder`, `PersonalityAgent`, and `RepoRoutingAgent` all pick up overrides; extracts `RepoRoutingAgent`'s heredoc into a proper Blade template.
- Editor uses CodeMirror 6 with Blade overlay highlighting, `{{` variable autocomplete driven by `PromptDefinitions`, and `@codemirror/merge` for the diff view. Live preview against fixtures, with an inline error panel when a draft fails to render.

## Safety

- Save rejects disallowed directives (`@include`, `@extends`, `@component`, `@slot`, `@php`), Blade compile errors, and dry-render failures against the first fixture.
- Runtime resolver catches any render error on stored content and falls back to the Blade file — a bad save cannot break the task pipeline.
- First save snapshots the current default as version 1 and the edit as version 2 inside one transaction with `lockForUpdate` and a unique `(prompt_id, version)` index.

## Test plan

- [x] `vendor/bin/pest --exclude-group=contract` — 725 passing (11 new resolver, 12 new Livewire, 3 new browser), 0 regressions
- [x] `vendor/bin/phpstan analyse app/` — 0 errors
- [x] `vendor/bin/pint --dirty --format agent` — pass
- [ ] Manually exercise `/prompts`: select a prompt, edit, preview re-renders, save, reload — edit persists
- [ ] Manually verify History modal shows baseline + edit, Diff toggle shows merge view, Reset restores file content
- [ ] Deploy to staging and confirm `PersonalityAgent` and `RepoRoutingAgent` still render correctly under the facade