### PR TITLE
feat(skills): add Skills settings page for managing Claude Code plugins

### DIFF
--- a/app/Agents/ClaudeCodeRunner.php
+++ b/app/Agents/ClaudeCodeRunner.php
@@ -2,6 +2,7 @@
 
 namespace App\Agents;
 
+use App\ClaudeCli;
 use App\Contracts\AgentRunner;
 use App\DataTransferObjects\AgentRunRequest;
 use App\DataTransferObjects\AgentRunResult;
@@ -182,22 +183,18 @@ class ClaudeCodeRunner implements AgentRunner
      */
     private function wrapCommand(string $command): string
     {
-        $envParts = ['HOME=/home/yak'];
+        $extraEnv = [];
 
         $passthrough = config('yak.agent_passthrough_env', '');
         foreach (array_filter(explode(',', $passthrough)) as $name) {
             $name = trim($name);
             $value = getenv($name);
             if ($value !== false) {
-                $envParts[] = sprintf('%s=%s', $name, escapeshellarg($value));
+                $extraEnv[$name] = $value;
             }
         }
 
-        return sprintf(
-            'sudo runuser -u yak -- env %s bash -c %s',
-            implode(' ', $envParts),
-            escapeshellarg($command),
-        );
+        return app(ClaudeCli::class)->buildWrappedCommand($command, $extraEnv);
     }
 
     private function buildCommand(AgentRunRequest $request, bool $streaming): string

--- a/app/ClaudeCli.php
+++ b/app/ClaudeCli.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App;
+
+use App\Exceptions\ClaudeCliException;
+use Illuminate\Contracts\Process\ProcessResult;
+use Illuminate\Process\Exceptions\ProcessTimedOutException;
+use Illuminate\Support\Facades\Process;
+use Symfony\Component\Process\Exception\ProcessTimedOutException as SymfonyProcessTimedOutException;
+
+class ClaudeCli
+{
+    public function exec(string $args, int $timeout = 60): ProcessResult
+    {
+        $command = $this->buildWrappedCommand('claude ' . $args);
+
+        try {
+            return Process::timeout($timeout)->run($command);
+        } catch (ProcessTimedOutException|SymfonyProcessTimedOutException $e) {
+            throw new ClaudeCliException("claude {$args} timed out after {$timeout}s", previous: $e);
+        }
+    }
+
+    /**
+     * Build a shell command that runs $innerCommand as the yak user with
+     * HOME pre-set and any additional environment variables supplied. Kept
+     * public so other call sites (e.g. ClaudeCodeRunner) can share the
+     * exact same env contract as exec().
+     *
+     * @param  array<string, string>  $extraEnv
+     */
+    public function buildWrappedCommand(string $innerCommand, array $extraEnv = []): string
+    {
+        $envParts = ['HOME=/home/yak'];
+
+        foreach ($extraEnv as $name => $value) {
+            $envParts[] = sprintf('%s=%s', $name, escapeshellarg((string) $value));
+        }
+
+        return sprintf(
+            'sudo runuser -u yak -- env %s bash -c %s',
+            implode(' ', $envParts),
+            escapeshellarg($innerCommand),
+        );
+    }
+}

--- a/app/DataTransferObjects/BundledSkill.php
+++ b/app/DataTransferObjects/BundledSkill.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+final readonly class BundledSkill
+{
+    public function __construct(
+        public string $name,
+        public string $description,
+        public string $path,
+    ) {}
+}

--- a/app/DataTransferObjects/InstalledPlugin.php
+++ b/app/DataTransferObjects/InstalledPlugin.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+use Carbon\Carbon;
+
+final readonly class InstalledPlugin
+{
+    public function __construct(
+        public string $name,
+        public string $marketplace,
+        public string $scope,
+        public string $installPath,
+        public string $version,
+        public ?string $gitCommitSha,
+        public Carbon $installedAt,
+        public ?Carbon $lastUpdated,
+        public bool $enabled = true,
+    ) {}
+
+    public function key(): string
+    {
+        return "{$this->name}@{$this->marketplace}";
+    }
+}

--- a/app/DataTransferObjects/Marketplace.php
+++ b/app/DataTransferObjects/Marketplace.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+use Carbon\Carbon;
+
+final readonly class Marketplace
+{
+    public function __construct(
+        public string $name,
+        public string $source,
+        public ?Carbon $lastUpdated,
+    ) {}
+}

--- a/app/DataTransferObjects/MarketplacePlugin.php
+++ b/app/DataTransferObjects/MarketplacePlugin.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+final readonly class MarketplacePlugin
+{
+    public function __construct(
+        public string $name,
+        public string $description,
+        public string $marketplace,
+        public ?string $category,
+        public ?string $homepage,
+        public ?string $sourceUrl,
+        public ?string $author,
+    ) {}
+
+    public function key(): string
+    {
+        return "{$this->name}@{$this->marketplace}";
+    }
+
+    public function link(): ?string
+    {
+        return $this->homepage ?? $this->sourceUrl;
+    }
+}

--- a/app/Exceptions/ClaudeCliException.php
+++ b/app/Exceptions/ClaudeCliException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Exceptions;
+
+class ClaudeCliException extends \RuntimeException {}

--- a/app/Livewire/Settings/Skills.php
+++ b/app/Livewire/Settings/Skills.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Livewire\Settings;
+
+use App\DataTransferObjects\BundledSkill;
+use App\DataTransferObjects\InstalledPlugin;
+use App\DataTransferObjects\Marketplace;
+use App\DataTransferObjects\MarketplacePlugin;
+use App\Exceptions\ClaudeCliException;
+use App\Services\MarketplaceReader;
+use App\Services\SkillManager;
+use Flux\Flux;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Title;
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+
+#[Title('Skills')]
+class Skills extends Component
+{
+    public string $search = '';
+
+    public string $filter = 'all';
+
+    public bool $showInstallFromUrl = false;
+
+    #[Validate('required|string|min:3')]
+    public string $installUrl = '';
+
+    #[Validate('nullable|string|min:3')]
+    public string $newMarketplace = '';
+
+    /**
+     * @return Collection<int, InstalledPlugin>
+     */
+    #[Computed]
+    public function installed(): Collection
+    {
+        return $this->filterBySearch(
+            app(SkillManager::class)->listInstalled(),
+            fn ($p) => $p->name,
+        );
+    }
+
+    /**
+     * @return Collection<int, BundledSkill>
+     */
+    #[Computed]
+    public function bundled(): Collection
+    {
+        return $this->filterBySearch(
+            app(SkillManager::class)->listBundledSkills(),
+            fn ($s) => $s->name . ' ' . $s->description,
+        );
+    }
+
+    /**
+     * @return Collection<int, MarketplacePlugin>
+     */
+    #[Computed]
+    public function available(): Collection
+    {
+        $installedKeys = app(SkillManager::class)->listInstalled()->map->key()->all();
+
+        $available = app(MarketplaceReader::class)->listAll()
+            ->reject(fn ($p) => in_array($p->key(), $installedKeys, true))
+            ->values();
+
+        return $this->filterBySearch($available, fn ($p) => $p->name . ' ' . $p->description);
+    }
+
+    /**
+     * @return Collection<int, Marketplace>
+     */
+    #[Computed]
+    public function marketplaces(): Collection
+    {
+        return app(SkillManager::class)->listMarketplaces();
+    }
+
+    /**
+     * @template TItem
+     *
+     * @param  Collection<int, TItem>  $items
+     * @param  \Closure(TItem): string  $haystackFn
+     * @return Collection<int, TItem>
+     */
+    private function filterBySearch(Collection $items, \Closure $haystackFn): Collection
+    {
+        if ($this->search === '') {
+            return $items;
+        }
+
+        $needle = mb_strtolower($this->search);
+
+        return $items->filter(fn ($item) => str_contains(mb_strtolower($haystackFn($item)), $needle))->values();
+    }
+
+    public function install(string $name, ?string $marketplace = null): void
+    {
+        $this->runSafely(
+            fn () => app(SkillManager::class)->install($name, $marketplace),
+            "Installed {$name}.",
+        );
+    }
+
+    public function installFromUrl(): void
+    {
+        $this->validateOnly('installUrl');
+
+        $this->runSafely(
+            fn () => app(SkillManager::class)->installFromUrl($this->installUrl),
+            'Plugin installed.',
+            onSuccess: function () {
+                $this->installUrl = '';
+                $this->showInstallFromUrl = false;
+            },
+        );
+    }
+
+    public function uninstall(string $name): void
+    {
+        $this->runSafely(
+            fn () => app(SkillManager::class)->uninstall($name),
+            "Uninstalled {$name}.",
+        );
+    }
+
+    public function toggle(string $name, bool $enable): void
+    {
+        $this->runSafely(
+            fn () => $enable
+                ? app(SkillManager::class)->enable($name)
+                : app(SkillManager::class)->disable($name),
+            $enable ? "Enabled {$name}." : "Disabled {$name}.",
+        );
+    }
+
+    public function updatePlugin(string $name): void
+    {
+        $this->runSafely(
+            fn () => app(SkillManager::class)->update($name),
+            "Updated {$name}.",
+        );
+    }
+
+    public function addMarketplace(): void
+    {
+        $this->validate(['newMarketplace' => ['required', 'string', 'min:3']]);
+
+        $this->runSafely(
+            fn () => app(SkillManager::class)->addMarketplace($this->newMarketplace),
+            'Marketplace added.',
+            onSuccess: fn () => $this->newMarketplace = '',
+        );
+    }
+
+    public function removeMarketplace(string $name): void
+    {
+        $this->runSafely(
+            fn () => app(SkillManager::class)->removeMarketplace($name),
+            "Removed marketplace {$name}.",
+        );
+    }
+
+    public function refreshMarketplaces(): void
+    {
+        $this->runSafely(
+            fn () => app(SkillManager::class)->refreshMarketplaces(),
+            'Marketplaces refreshed.',
+        );
+    }
+
+    private function runSafely(\Closure $action, string $successMessage, ?\Closure $onSuccess = null): void
+    {
+        try {
+            $action();
+
+            if ($onSuccess !== null) {
+                $onSuccess();
+            }
+
+            unset($this->installed, $this->bundled, $this->available, $this->marketplaces);
+
+            Flux::toast(variant: 'success', text: $successMessage);
+        } catch (ClaudeCliException $e) {
+            Flux::toast(variant: 'danger', text: $e->getMessage());
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.settings.skills');
+    }
+}

--- a/app/Services/MarketplaceReader.php
+++ b/app/Services/MarketplaceReader.php
@@ -32,7 +32,7 @@ class MarketplaceReader
 
     /**
      * @param  array<string, mixed>  $info
-     * @return list<MarketplacePlugin>
+     * @return array<int, MarketplacePlugin>
      */
     private function readMarketplace(string $name, array $info): array
     {

--- a/app/Services/MarketplaceReader.php
+++ b/app/Services/MarketplaceReader.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Services;
+
+use App\DataTransferObjects\MarketplacePlugin;
+use Illuminate\Support\Collection;
+
+class MarketplaceReader
+{
+    /**
+     * @return Collection<int, MarketplacePlugin>
+     */
+    public function listAll(): Collection
+    {
+        $knownPath = config('yak.plugins_dir') . '/known_marketplaces.json';
+
+        if (! is_file($knownPath)) {
+            return collect();
+        }
+
+        $known = json_decode((string) file_get_contents($knownPath), true);
+
+        if (! is_array($known)) {
+            return collect();
+        }
+
+        /** @var array<string, array<string, mixed>> $known */
+        return collect($known)
+            ->flatMap(fn (array $info, string $name) => $this->readMarketplace($name, $info))
+            ->values();
+    }
+
+    /**
+     * @param  array<string, mixed>  $info
+     * @return list<MarketplacePlugin>
+     */
+    private function readMarketplace(string $name, array $info): array
+    {
+        $installLocation = (string) ($info['installLocation'] ?? '');
+        $manifestPath = $installLocation . '/.claude-plugin/marketplace.json';
+
+        if (! is_file($manifestPath)) {
+            return [];
+        }
+
+        $data = json_decode((string) file_get_contents($manifestPath), true);
+
+        if (! is_array($data) || ! isset($data['plugins']) || ! is_array($data['plugins'])) {
+            return [];
+        }
+
+        $owner = (string) ($data['owner']['name'] ?? '');
+
+        /** @var array<int, array<string, mixed>> $plugins */
+        $plugins = $data['plugins'];
+
+        return array_map(function (array $plugin) use ($name, $owner) {
+            $author = (string) ($plugin['author']['name'] ?? $owner);
+
+            return new MarketplacePlugin(
+                name: (string) ($plugin['name'] ?? ''),
+                description: (string) ($plugin['description'] ?? ''),
+                marketplace: $name,
+                category: isset($plugin['category']) ? (string) $plugin['category'] : null,
+                homepage: isset($plugin['homepage']) ? (string) $plugin['homepage'] : null,
+                sourceUrl: $this->extractSourceUrl($plugin['source'] ?? null),
+                author: $author !== '' ? $author : null,
+            );
+        }, $plugins);
+    }
+
+    private function extractSourceUrl(mixed $source): ?string
+    {
+        if (is_string($source)) {
+            // Relative path inside the marketplace repo — no stable external URL.
+            return null;
+        }
+
+        if (! is_array($source)) {
+            return null;
+        }
+
+        $type = (string) ($source['source'] ?? '');
+
+        if ($type === 'url') {
+            return isset($source['url']) ? (string) $source['url'] : null;
+        }
+
+        if ($type === 'git-subdir') {
+            $repo = (string) ($source['url'] ?? '');
+            $path = (string) ($source['path'] ?? '');
+            $ref = (string) ($source['ref'] ?? 'main');
+
+            if ($repo === '') {
+                return null;
+            }
+
+            $base = str_contains($repo, '://')
+                ? rtrim($repo, '/')
+                : 'https://github.com/' . trim($repo, '/');
+
+            return rtrim($base, '/') . '/tree/' . $ref . '/' . ltrim($path, '/');
+        }
+
+        return null;
+    }
+}

--- a/app/Services/SkillManager.php
+++ b/app/Services/SkillManager.php
@@ -5,6 +5,8 @@ namespace App\Services;
 use App\ClaudeCli;
 use App\DataTransferObjects\BundledSkill;
 use App\DataTransferObjects\InstalledPlugin;
+use App\DataTransferObjects\Marketplace;
+use App\Exceptions\ClaudeCliException;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 
@@ -84,6 +86,70 @@ class SkillManager
                 );
             })
             ->values();
+    }
+
+    /**
+     * @return Collection<int, Marketplace>
+     */
+    public function listMarketplaces(): Collection
+    {
+        $path = config('yak.plugins_dir') . '/known_marketplaces.json';
+
+        if (! is_file($path)) {
+            return collect();
+        }
+
+        $data = json_decode((string) file_get_contents($path), true);
+
+        if (! is_array($data)) {
+            return collect();
+        }
+
+        /** @var array<string, array<string, mixed>> $data */
+        return collect($data)
+            ->map(function (array $info, string $name) {
+                $source = $info['source'] ?? null;
+
+                $sourceString = '';
+                if (is_array($source) && isset($source['repo'])) {
+                    $sourceString = (string) $source['repo'];
+                } elseif (is_string($source)) {
+                    $sourceString = $source;
+                }
+
+                return new Marketplace(
+                    name: $name,
+                    source: $sourceString,
+                    lastUpdated: isset($info['lastUpdated']) ? Carbon::parse((string) $info['lastUpdated']) : null,
+                );
+            })
+            ->values();
+    }
+
+    public function addMarketplace(string $source): void
+    {
+        $this->runOrThrow('plugins marketplace add ' . escapeshellarg($source), timeout: 120);
+    }
+
+    public function removeMarketplace(string $name): void
+    {
+        $this->runOrThrow('plugins marketplace remove ' . escapeshellarg($name));
+    }
+
+    public function refreshMarketplaces(): void
+    {
+        $this->runOrThrow('plugins marketplace update', timeout: 120);
+    }
+
+    private function runOrThrow(string $args, int $timeout = 60): void
+    {
+        $result = $this->cli->exec($args, $timeout);
+
+        if (! $result->successful()) {
+            $message = trim($result->errorOutput() ?: $result->output());
+
+            throw new ClaudeCliException("claude {$args} failed: {$message}");
+        }
     }
 
     private function extractFrontMatterField(string $markdown, string $field): ?string

--- a/app/Services/SkillManager.php
+++ b/app/Services/SkillManager.php
@@ -25,7 +25,6 @@ class SkillManager
             return collect();
         }
 
-        /** @var array{version?: int, plugins?: array<string, array<int, array<string, mixed>>>}|null $data */
         $data = json_decode((string) file_get_contents($path), true);
 
         if (! is_array($data) || ! isset($data['plugins']) || ! is_array($data['plugins'])) {

--- a/app/Services/SkillManager.php
+++ b/app/Services/SkillManager.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\ClaudeCli;
+use App\DataTransferObjects\BundledSkill;
 use App\DataTransferObjects\InstalledPlugin;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
@@ -51,6 +52,53 @@ class SkillManager
                 ), $installs);
             })
             ->values();
+    }
+
+    /**
+     * @return Collection<int, BundledSkill>
+     */
+    public function listBundledSkills(): Collection
+    {
+        $dir = config('yak.skills_dir');
+
+        if (! is_string($dir) || ! is_dir($dir)) {
+            return collect();
+        }
+
+        $entries = scandir($dir);
+
+        if ($entries === false) {
+            return collect();
+        }
+
+        return collect($entries)
+            ->reject(fn (string $name) => str_starts_with($name, '.'))
+            ->filter(fn (string $name) => is_file("{$dir}/{$name}/SKILL.md"))
+            ->map(function (string $name) use ($dir) {
+                $content = (string) file_get_contents("{$dir}/{$name}/SKILL.md");
+
+                return new BundledSkill(
+                    name: $name,
+                    description: $this->extractFrontMatterField($content, 'description') ?? '',
+                    path: "{$dir}/{$name}",
+                );
+            })
+            ->values();
+    }
+
+    private function extractFrontMatterField(string $markdown, string $field): ?string
+    {
+        if (! preg_match('/^---\s*\n(.*?)\n---/s', $markdown, $matches)) {
+            return null;
+        }
+
+        foreach (explode("\n", $matches[1]) as $line) {
+            if (preg_match("/^{$field}:\s*(.*?)\s*$/", $line, $fieldMatch)) {
+                return trim($fieldMatch[1], " \t'\"");
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/Services/SkillManager.php
+++ b/app/Services/SkillManager.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Services;
+
+use App\ClaudeCli;
+use App\DataTransferObjects\InstalledPlugin;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class SkillManager
+{
+    public function __construct(private ClaudeCli $cli) {}
+
+    /**
+     * @return Collection<int, InstalledPlugin>
+     */
+    public function listInstalled(): Collection
+    {
+        $path = config('yak.plugins_dir') . '/installed_plugins.json';
+
+        if (! is_file($path)) {
+            return collect();
+        }
+
+        /** @var array{version?: int, plugins?: array<string, array<int, array<string, mixed>>>}|null $data */
+        $data = json_decode((string) file_get_contents($path), true);
+
+        if (! is_array($data) || ! isset($data['plugins']) || ! is_array($data['plugins'])) {
+            return collect();
+        }
+
+        $disabled = $this->loadDisabledKeys();
+
+        /** @var array<string, array<int, array<string, mixed>>> $plugins */
+        $plugins = $data['plugins'];
+
+        return collect($plugins)
+            ->flatMap(function (array $installs, string $key) use ($disabled) {
+                [$name, $marketplace] = array_pad(explode('@', $key, 2), 2, '');
+
+                return array_map(fn (array $install) => new InstalledPlugin(
+                    name: $name,
+                    marketplace: $marketplace,
+                    scope: (string) ($install['scope'] ?? 'user'),
+                    installPath: (string) ($install['installPath'] ?? ''),
+                    version: (string) ($install['version'] ?? ''),
+                    gitCommitSha: isset($install['gitCommitSha']) ? (string) $install['gitCommitSha'] : null,
+                    installedAt: Carbon::parse((string) ($install['installedAt'] ?? 'now')),
+                    lastUpdated: isset($install['lastUpdated']) ? Carbon::parse((string) $install['lastUpdated']) : null,
+                    enabled: ! in_array($key, $disabled, true),
+                ), $installs);
+            })
+            ->values();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function loadDisabledKeys(): array
+    {
+        $path = config('yak.plugins_dir') . '/config.json';
+
+        if (! is_file($path)) {
+            return [];
+        }
+
+        $data = json_decode((string) file_get_contents($path), true);
+
+        if (! is_array($data)) {
+            return [];
+        }
+
+        $disabled = (array) ($data['disabledPlugins'] ?? []);
+
+        return array_values(array_filter($disabled, 'is_string'));
+    }
+}

--- a/app/Services/SkillManager.php
+++ b/app/Services/SkillManager.php
@@ -126,6 +126,40 @@ class SkillManager
             ->values();
     }
 
+    public function install(string $plugin, ?string $marketplace = null): void
+    {
+        $target = $marketplace !== null && $marketplace !== ''
+            ? "{$plugin}@{$marketplace}"
+            : $plugin;
+
+        $this->runOrThrow('plugins install ' . escapeshellarg($target), timeout: 180);
+    }
+
+    public function installFromUrl(string $urlOrPath): void
+    {
+        $this->runOrThrow('plugins install ' . escapeshellarg($urlOrPath), timeout: 180);
+    }
+
+    public function uninstall(string $plugin): void
+    {
+        $this->runOrThrow('plugins uninstall ' . escapeshellarg($plugin));
+    }
+
+    public function enable(string $plugin): void
+    {
+        $this->runOrThrow('plugins enable ' . escapeshellarg($plugin));
+    }
+
+    public function disable(string $plugin): void
+    {
+        $this->runOrThrow('plugins disable ' . escapeshellarg($plugin));
+    }
+
+    public function update(string $plugin): void
+    {
+        $this->runOrThrow('plugins update ' . escapeshellarg($plugin), timeout: 180);
+    }
+
     public function addMarketplace(string $source): void
     {
         $this->runOrThrow('plugins marketplace add ' . escapeshellarg($source), timeout: 120);

--- a/config/yak.php
+++ b/config/yak.php
@@ -48,6 +48,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Claude Code plugin / skill paths
+    |--------------------------------------------------------------------------
+    |
+    | Paths inside the Yak container where Claude Code stores user-scoped
+    | plugin state and Ansible-provisioned skills. Both sit under
+    | CLAUDE_CONFIG_DIR and follow Claude Code's conventions.
+    */
+
+    'plugins_dir' => env('YAK_PLUGINS_DIR', env('CLAUDE_CONFIG_DIR', '/home/yak/.claude') . '/plugins'),
+
+    'skills_dir' => env('YAK_SKILLS_DIR', env('CLAUDE_CONFIG_DIR', '/home/yak/.claude') . '/skills'),
+
+    /*
+    |--------------------------------------------------------------------------
     | API Keys
     |--------------------------------------------------------------------------
     */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "yak",
+    "name": "skills-ui",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -228,3 +228,97 @@ textarea:focus[data-flux-control],
 select:focus[data-flux-control] {
     @apply outline-hidden ring-2 ring-yak-orange ring-offset-2;
 }
+
+/* Skills page */
+.plugin-card {
+    background: #fff;
+    border: 1px solid color-mix(in srgb, var(--color-yak-tan) 40%, transparent);
+    border-radius: 14px;
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s;
+}
+
+.plugin-card:hover {
+    border-color: var(--color-yak-tan);
+    box-shadow: var(--shadow-elevation-1);
+    transform: translateY(-1px);
+}
+
+.skills-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 14px;
+}
+
+.skills-section-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 28px 0 14px;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-yak-blue);
+}
+
+.skills-section-title::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: color-mix(in srgb, var(--color-yak-tan) 35%, transparent);
+}
+
+.skills-count {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-yak-tan);
+    text-transform: none;
+    letter-spacing: 0;
+}
+
+.yak-toggle {
+    position: relative;
+    width: 28px;
+    height: 16px;
+    padding: 0;
+    border: none;
+    border-radius: 999px;
+    cursor: pointer;
+    flex-shrink: 0;
+    background: color-mix(in srgb, var(--color-yak-tan) 60%, transparent);
+    transition: background 0.15s;
+}
+
+.yak-toggle.on {
+    background: var(--color-yak-green);
+}
+
+.yak-toggle::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 12px;
+    height: 12px;
+    border-radius: 999px;
+    background: #fff;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+    transition: left 0.15s;
+}
+
+.yak-toggle.on::after {
+    left: 14px;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    font-size: 11.5px;
+    font-weight: 500;
+    padding: 3px 9px;
+    border-radius: 999px;
+}

--- a/resources/views/components/settings/layout.blade.php
+++ b/resources/views/components/settings/layout.blade.php
@@ -1,9 +1,12 @@
+@props(['heading' => '', 'subheading' => '', 'wide' => false])
+
 <div class="flex items-start max-md:flex-col">
     <div class="me-10 w-full pb-4 md:w-[220px]">
         <flux:navlist aria-label="{{ __('Settings') }}">
             <flux:navlist.item :href="route('profile.edit')" wire:navigate>{{ __('Profile') }}</flux:navlist.item>
             <flux:navlist.item :href="route('appearance.edit')" wire:navigate>{{ __('Appearance') }}</flux:navlist.item>
             <flux:navlist.item :href="route('settings.linear')" wire:navigate>{{ __('Linear') }}</flux:navlist.item>
+            <flux:navlist.item :href="route('settings.skills')" wire:navigate>{{ __('Skills') }}</flux:navlist.item>
         </flux:navlist>
     </div>
 
@@ -13,7 +16,7 @@
         <flux:heading>{{ $heading ?? '' }}</flux:heading>
         <flux:subheading>{{ $subheading ?? '' }}</flux:subheading>
 
-        <div class="mt-5 w-full max-w-lg">
+        <div @class(['mt-5 w-full', 'max-w-lg' => ! $wide])>
             {{ $slot }}
         </div>
     </div>

--- a/resources/views/livewire/settings/skills.blade.php
+++ b/resources/views/livewire/settings/skills.blade.php
@@ -1,0 +1,237 @@
+<section class="w-full">
+    <x-settings.layout
+        :heading="__('Skills')"
+        :subheading="__('Install and manage Claude Code plugins for the Yak agent.')"
+        wide
+    >
+        <flux:callout variant="secondary" icon="information-circle" class="mb-6"
+            heading="Plugins are shared across all Yak users. Changes take effect on the next task run, not mid-flight." />
+
+        {{-- Toolbar --}}
+        <div class="mb-6 flex flex-wrap items-center gap-3">
+            <flux:input
+                wire:model.live.debounce.200ms="search"
+                type="search"
+                icon="magnifying-glass"
+                placeholder="Search plugins…"
+                class="min-w-[220px] flex-1"
+            />
+
+            <div class="flex items-center gap-1 rounded-xl bg-yak-cream-dark p-[3px] text-[13px]">
+                @foreach (['all' => 'All', 'installed' => 'Installed', 'bundled' => 'Bundled', 'available' => 'Available'] as $value => $label)
+                    <button
+                        type="button"
+                        wire:click="$set('filter', @js($value))"
+                        @class([
+                            'rounded-lg px-3 py-1.5 font-medium',
+                            'bg-white text-yak-slate shadow-sm' => $filter === $value,
+                            'text-yak-blue hover:text-yak-slate' => $filter !== $value,
+                        ])
+                    >{{ $label }}</button>
+                @endforeach
+            </div>
+
+            <flux:button variant="primary" icon="plus" wire:click="$set('showInstallFromUrl', true)">
+                {{ __('Install from URL') }}
+            </flux:button>
+        </div>
+
+        {{-- Installed --}}
+        @if (in_array($filter, ['all', 'installed'], true))
+            <div class="skills-section-title">
+                <span>Installed</span>
+                <span class="skills-count">{{ $this->installed->count() }}</span>
+            </div>
+
+            @if ($this->installed->isEmpty())
+                <p class="text-sm text-yak-blue">No plugins installed yet.</p>
+            @else
+                <div class="skills-grid">
+                    @foreach ($this->installed as $plugin)
+                        @php($source = $this->marketplaces->firstWhere('name', $plugin->marketplace))
+                        <div class="plugin-card" wire:key="installed-{{ $plugin->key() }}">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="text-[15px] font-semibold text-yak-slate">{{ $plugin->name }}</div>
+                                <span class="font-mono rounded bg-yak-cream px-[6px] py-[2px] text-[11.5px] text-yak-blue whitespace-nowrap">
+                                    {{ $plugin->version ? mb_substr($plugin->version, 0, 7) : '—' }}
+                                </span>
+                            </div>
+
+                            <p class="text-[13.5px] leading-snug text-yak-blue m-0 flex-1">
+                                Installed {{ $plugin->installedAt->diffForHumans() }}@if ($plugin->lastUpdated), updated {{ $plugin->lastUpdated->diffForHumans() }}@endif.
+                            </p>
+
+                            <div class="mt-1 flex items-center justify-between border-t border-dashed border-yak-tan/40 pt-[10px]">
+                                <span class="text-[11px] text-yak-blue opacity-85">
+                                    {{ $plugin->marketplace }}
+                                </span>
+                                <div class="flex items-center gap-3">
+                                    <span @class([
+                                        'badge',
+                                        'badge-success' => $plugin->enabled,
+                                        'badge-faint' => ! $plugin->enabled,
+                                    ])>
+                                        {{ $plugin->enabled ? 'Enabled' : 'Disabled' }}
+                                    </span>
+                                    <button
+                                        type="button"
+                                        role="switch"
+                                        aria-checked="{{ $plugin->enabled ? 'true' : 'false' }}"
+                                        wire:click="toggle(@js($plugin->key()), @js(! $plugin->enabled))"
+                                        @class(['yak-toggle', 'on' => $plugin->enabled])
+                                        aria-label="Toggle {{ $plugin->name }}"
+                                    ></button>
+                                </div>
+                            </div>
+
+                            <div class="mt-1 flex items-center justify-end gap-3 text-[12px]">
+                                <flux:button size="xs" variant="ghost" wire:click="updatePlugin(@js($plugin->key()))">
+                                    Update
+                                </flux:button>
+                                <flux:button size="xs" variant="ghost" wire:click="uninstall(@js($plugin->key()))"
+                                    wire:confirm="Uninstall {{ $plugin->name }}?">
+                                    Uninstall
+                                </flux:button>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            @endif
+        @endif
+
+        {{-- Bundled --}}
+        @if (in_array($filter, ['all', 'bundled'], true) && $this->bundled->isNotEmpty())
+            <div class="skills-section-title">
+                <span>Bundled</span>
+                <span class="skills-count">{{ $this->bundled->count() }} · read-only</span>
+            </div>
+
+            <div class="rounded-xl border border-yak-tan/40 bg-white px-[14px] py-[6px]">
+                @foreach ($this->bundled as $skill)
+                    <div class="flex items-center gap-3 border-b border-yak-tan/25 py-3 last:border-b-0">
+                        <span class="badge badge-neutral">bundled</span>
+                        <span class="text-[13.5px] font-medium text-yak-slate">{{ $skill->name }}</span>
+                        <span class="ml-auto truncate text-[12.5px] text-yak-blue opacity-80">{{ $skill->description }}</span>
+                    </div>
+                @endforeach
+                <p class="px-[4px] py-[10px] text-[12px] italic text-yak-blue">
+                    Provisioned by Ansible. Edit <code class="rounded bg-yak-cream px-[5px] py-[1px] text-[11px]">ansible/roles/yak-container/tasks/main.yml</code> and redeploy to change.
+                </p>
+            </div>
+        @endif
+
+        {{-- Available --}}
+        @if (in_array($filter, ['all', 'available'], true) && $this->available->isNotEmpty())
+            <div class="skills-section-title">
+                <span>Available</span>
+                <span class="skills-count">
+                    @if ($this->marketplaces->isNotEmpty())
+                        from {{ $this->marketplaces->pluck('name')->join(', ') }}
+                    @else
+                        no marketplaces configured
+                    @endif
+                </span>
+            </div>
+
+            <div class="skills-grid">
+                @foreach ($this->available->take(60) as $plugin)
+                    <div class="plugin-card" wire:key="available-{{ $plugin->key() }}">
+                        <div class="flex items-start justify-between gap-3">
+                            <div class="flex items-center gap-2">
+                                <div class="text-[15px] font-semibold text-yak-slate">{{ $plugin->name }}</div>
+                                @if ($plugin->link())
+                                    <a href="{{ $plugin->link() }}" target="_blank" rel="noopener"
+                                        class="text-yak-blue hover:text-yak-orange" aria-label="Plugin source">
+                                        <flux:icon.arrow-top-right-on-square class="size-4" />
+                                    </a>
+                                @endif
+                            </div>
+                            @if ($plugin->category)
+                                <span class="badge badge-neutral">{{ $plugin->category }}</span>
+                            @endif
+                        </div>
+                        <p class="m-0 flex-1 line-clamp-3 text-[13.5px] leading-snug text-yak-blue">
+                            {{ $plugin->description }}
+                        </p>
+                        <div class="mt-1 flex items-center justify-between border-t border-dashed border-yak-tan/40 pt-[10px]">
+                            <span class="text-[11px] text-yak-blue opacity-85">{{ $plugin->marketplace }}</span>
+                            <flux:button size="xs" variant="filled"
+                                wire:click="install(@js($plugin->name), @js($plugin->marketplace))">
+                                Install
+                            </flux:button>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+
+            @if ($this->available->count() > 60)
+                <p class="mt-3 text-[12px] text-yak-blue">
+                    Showing 60 of {{ $this->available->count() }}. Use search to narrow results.
+                </p>
+            @endif
+        @endif
+
+        {{-- Marketplaces --}}
+        @if ($filter === 'all')
+            <div class="skills-section-title">
+                <span>Marketplaces</span>
+            </div>
+
+            <div class="rounded-xl border border-yak-tan/40 bg-white p-5">
+                @forelse ($this->marketplaces as $mp)
+                    <div @class([
+                        'flex items-center justify-between py-3',
+                        'border-t border-yak-tan/25' => ! $loop->first,
+                    ])>
+                        <div>
+                            <div class="text-[14px] font-semibold text-yak-slate">{{ $mp->name }}</div>
+                            <div class="mt-[2px] text-[12.5px] text-yak-blue">
+                                {{ $mp->source ?: '—' }}
+                                @if ($mp->lastUpdated)
+                                    · Updated {{ $mp->lastUpdated->diffForHumans() }}
+                                @endif
+                            </div>
+                        </div>
+                        <flux:button size="xs" variant="ghost" wire:click="removeMarketplace(@js($mp->name))"
+                            wire:confirm="Remove marketplace {{ $mp->name }}?">
+                            Remove
+                        </flux:button>
+                    </div>
+                @empty
+                    <p class="text-sm text-yak-blue">No marketplaces configured.</p>
+                @endforelse
+
+                <form wire:submit.prevent="addMarketplace" class="mt-4 flex items-center gap-2">
+                    <flux:input wire:model="newMarketplace" placeholder="github:owner/repo or git URL" class="flex-1" />
+                    <flux:button type="submit" variant="filled">Add</flux:button>
+                    <flux:button type="button" variant="ghost" wire:click="refreshMarketplaces">Refresh</flux:button>
+                </form>
+                @error('newMarketplace')
+                    <p class="mt-2 text-sm text-yak-danger">{{ $message }}</p>
+                @enderror
+            </div>
+        @endif
+
+        {{-- Install from URL modal --}}
+        <flux:modal wire:model.self="showInstallFromUrl" name="install-from-url">
+            <div class="space-y-5">
+                <div>
+                    <flux:heading size="lg">Install from URL or path</flux:heading>
+                    <flux:text class="mt-2">Accepts a git URL (e.g. <code>https://github.com/acme/plugin.git</code>) or an absolute path on the Yak server.</flux:text>
+                </div>
+
+                <form wire:submit.prevent="installFromUrl" class="space-y-3">
+                    <flux:input wire:model="installUrl" placeholder="https://github.com/owner/plugin.git" autofocus />
+                    @error('installUrl')
+                        <p class="text-sm text-yak-danger">{{ $message }}</p>
+                    @enderror
+
+                    <div class="flex justify-end gap-2">
+                        <flux:button type="button" variant="ghost" wire:click="$set('showInstallFromUrl', false)">Cancel</flux:button>
+                        <flux:button type="submit" variant="primary">Install</flux:button>
+                    </div>
+                </form>
+            </div>
+        </flux:modal>
+    </x-settings.layout>
+</section>

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -3,6 +3,7 @@
 use App\Livewire\Settings\Appearance;
 use App\Livewire\Settings\LinearConnection;
 use App\Livewire\Settings\Profile;
+use App\Livewire\Settings\Skills;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth'])->group(function () {
@@ -11,4 +12,5 @@ Route::middleware(['auth'])->group(function () {
     Route::livewire('settings/profile', Profile::class)->name('profile.edit');
     Route::livewire('settings/appearance', Appearance::class)->name('appearance.edit');
     Route::livewire('settings/linear', LinearConnection::class)->name('settings.linear');
+    Route::livewire('settings/skills', Skills::class)->name('settings.skills');
 });

--- a/tests/Feature/Livewire/Settings/SkillsTest.php
+++ b/tests/Feature/Livewire/Settings/SkillsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Livewire\Settings\Skills;
+use App\Models\User;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->create());
+    $this->tmp = sys_get_temp_dir() . '/yak-skills-livewire-' . uniqid();
+    File::makeDirectory($this->tmp, recursive: true);
+    File::makeDirectory($this->tmp . '/bundled', recursive: true);
+    config()->set('yak.plugins_dir', $this->tmp);
+    config()->set('yak.skills_dir', $this->tmp . '/bundled');
+});
+
+afterEach(function () {
+    File::deleteDirectory($this->tmp);
+});
+
+it('renders the page', function () {
+    Livewire::test(Skills::class)
+        ->assertOk()
+        ->assertSee('Install and manage Claude Code plugins');
+});
+
+it('dispatches install via the component', function () {
+    Process::fake(['*' => Process::result(output: 'ok', exitCode: 0)]);
+
+    Livewire::test(Skills::class)
+        ->call('install', 'code-review', 'claude-plugins-official');
+
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins install')
+        && str_contains($p->command, 'code-review@claude-plugins-official'));
+});
+
+it('validates the install URL', function () {
+    Livewire::test(Skills::class)
+        ->set('installUrl', '')
+        ->call('installFromUrl')
+        ->assertHasErrors(['installUrl']);
+});
+
+it('filters installed plugins by search', function () {
+    File::put($this->tmp . '/installed_plugins.json', json_encode([
+        'version' => 2,
+        'plugins' => [
+            'code-review@official' => [[
+                'scope' => 'user', 'installPath' => '/x', 'version' => '1', 'installedAt' => '2026-01-01T00:00:00Z',
+            ]],
+            'frontend-design@official' => [[
+                'scope' => 'user', 'installPath' => '/x', 'version' => '1', 'installedAt' => '2026-01-01T00:00:00Z',
+            ]],
+        ],
+    ]));
+
+    Livewire::test(Skills::class)
+        ->set('search', 'frontend')
+        ->assertSee('frontend-design')
+        ->assertDontSee('code-review');
+});
+
+it('toggles a plugin enabled/disabled', function () {
+    Process::fake(['*' => Process::result(output: '', exitCode: 0)]);
+
+    Livewire::test(Skills::class)
+        ->call('toggle', 'code-review@official', false);
+
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins disable')
+        && str_contains($p->command, 'code-review@official'));
+});
+
+it('adds a marketplace via the form', function () {
+    Process::fake(['*' => Process::result(output: 'ok', exitCode: 0)]);
+
+    Livewire::test(Skills::class)
+        ->set('newMarketplace', 'github:acme/plugins')
+        ->call('addMarketplace')
+        ->assertHasNoErrors();
+
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins marketplace add')
+        && str_contains($p->command, 'github:acme/plugins'));
+});

--- a/tests/Feature/Services/MarketplaceReaderTest.php
+++ b/tests/Feature/Services/MarketplaceReaderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Services\MarketplaceReader;
+use Illuminate\Support\Facades\File;
+
+beforeEach(function () {
+    $this->tmp = sys_get_temp_dir() . '/yak-marketplaces-' . uniqid();
+    File::makeDirectory($this->tmp . '/marketplaces/acme/.claude-plugin', recursive: true);
+    config()->set('yak.plugins_dir', $this->tmp);
+});
+
+afterEach(function () {
+    File::deleteDirectory($this->tmp);
+});
+
+it('reads plugins from a marketplace manifest, normalizing all source shapes', function () {
+    File::put($this->tmp . '/known_marketplaces.json', json_encode([
+        'acme' => [
+            'source' => ['source' => 'github', 'repo' => 'acme/plugins'],
+            'installLocation' => $this->tmp . '/marketplaces/acme',
+            'lastUpdated' => '2026-04-12T10:00:00Z',
+        ],
+    ]));
+
+    File::put($this->tmp . '/marketplaces/acme/.claude-plugin/marketplace.json', json_encode([
+        'name' => 'acme',
+        'owner' => ['name' => 'Acme Inc'],
+        'plugins' => [
+            [
+                'name' => 'inline-plugin',
+                'description' => 'Lives in the marketplace repo',
+                'source' => './plugins/inline',
+                'homepage' => 'https://acme.test/inline',
+                'category' => 'dev',
+            ],
+            [
+                'name' => 'url-plugin',
+                'description' => 'Separate repo',
+                'source' => ['source' => 'url', 'url' => 'https://github.com/acme/url-plugin.git', 'sha' => 'deadbeef'],
+            ],
+            [
+                'name' => 'subdir-plugin',
+                'description' => 'Subdir',
+                'source' => ['source' => 'git-subdir', 'url' => 'acme/toolkit', 'path' => 'plugins/sub', 'ref' => 'main', 'sha' => 'cafed00d'],
+                'homepage' => 'https://acme.test/subdir',
+            ],
+        ],
+    ]));
+
+    $plugins = app(MarketplaceReader::class)->listAll();
+
+    expect($plugins)->toHaveCount(3);
+
+    $inline = $plugins->firstWhere('name', 'inline-plugin');
+    expect($inline->marketplace)->toBe('acme')
+        ->and($inline->homepage)->toBe('https://acme.test/inline')
+        ->and($inline->sourceUrl)->toBeNull()
+        ->and($inline->category)->toBe('dev')
+        ->and($inline->author)->toBe('Acme Inc');
+
+    $url = $plugins->firstWhere('name', 'url-plugin');
+    expect($url->sourceUrl)->toBe('https://github.com/acme/url-plugin.git')
+        ->and($url->link())->toBe('https://github.com/acme/url-plugin.git');
+
+    $subdir = $plugins->firstWhere('name', 'subdir-plugin');
+    expect($subdir->sourceUrl)->toBe('https://github.com/acme/toolkit/tree/main/plugins/sub')
+        ->and($subdir->link())->toBe('https://acme.test/subdir');
+});
+
+it('returns empty collection when no marketplaces are known', function () {
+    expect(app(MarketplaceReader::class)->listAll())->toHaveCount(0);
+});
+
+it('skips marketplaces whose manifest is missing', function () {
+    File::put($this->tmp . '/known_marketplaces.json', json_encode([
+        'orphan' => ['installLocation' => $this->tmp . '/does-not-exist'],
+    ]));
+
+    expect(app(MarketplaceReader::class)->listAll())->toHaveCount(0);
+});

--- a/tests/Feature/Services/SkillManagerTest.php
+++ b/tests/Feature/Services/SkillManagerTest.php
@@ -65,3 +65,29 @@ it('marks plugins disabled when listed in config.json', function () {
 it('returns empty collection when installed_plugins.json is missing', function () {
     expect(app(SkillManager::class)->listInstalled())->toHaveCount(0);
 });
+
+it('lists bundled skills from the skills directory', function () {
+    $skillsDir = $this->tmp . '/bundled';
+    File::makeDirectory($skillsDir . '/agent-browser', recursive: true);
+    File::put($skillsDir . '/agent-browser/SKILL.md', <<<'MD'
+    ---
+    name: agent-browser
+    description: Browser automation CLI for AI agents.
+    ---
+
+    Body
+    MD);
+    File::makeDirectory($skillsDir . '/polish', recursive: true);
+    File::put($skillsDir . '/polish/SKILL.md', "---\nname: polish\ndescription: Visual polish rules.\n---\n");
+
+    $skills = app(SkillManager::class)->listBundledSkills();
+
+    expect($skills)->toHaveCount(2)
+        ->and($skills->pluck('name')->sort()->values()->all())->toBe(['agent-browser', 'polish'])
+        ->and($skills->firstWhere('name', 'agent-browser')->description)->toBe('Browser automation CLI for AI agents.');
+});
+
+it('returns empty when skills dir is missing', function () {
+    config()->set('yak.skills_dir', $this->tmp . '/no-such-dir');
+    expect(app(SkillManager::class)->listBundledSkills())->toHaveCount(0);
+});

--- a/tests/Feature/Services/SkillManagerTest.php
+++ b/tests/Feature/Services/SkillManagerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\DataTransferObjects\InstalledPlugin;
+use App\Services\SkillManager;
+use Illuminate\Support\Facades\File;
+
+beforeEach(function () {
+    $this->tmp = sys_get_temp_dir() . '/yak-skills-' . uniqid();
+    File::makeDirectory($this->tmp, recursive: true);
+    config()->set('yak.plugins_dir', $this->tmp);
+    config()->set('yak.skills_dir', $this->tmp . '/bundled');
+});
+
+afterEach(function () {
+    File::deleteDirectory($this->tmp);
+});
+
+it('lists installed plugins from installed_plugins.json', function () {
+    File::put($this->tmp . '/installed_plugins.json', json_encode([
+        'version' => 2,
+        'plugins' => [
+            'code-review@claude-plugins-official' => [[
+                'scope' => 'user',
+                'installPath' => '/home/yak/.claude/plugins/cache/claude-plugins-official/code-review/abc123',
+                'version' => 'abc123',
+                'installedAt' => '2026-03-01T12:00:00Z',
+                'lastUpdated' => '2026-04-10T12:00:00Z',
+                'gitCommitSha' => 'abc123def4567890',
+            ]],
+        ],
+    ]));
+
+    $plugins = app(SkillManager::class)->listInstalled();
+
+    expect($plugins)->toHaveCount(1);
+    expect($plugins->first())->toBeInstanceOf(InstalledPlugin::class)
+        ->and($plugins->first()->name)->toBe('code-review')
+        ->and($plugins->first()->marketplace)->toBe('claude-plugins-official')
+        ->and($plugins->first()->version)->toBe('abc123')
+        ->and($plugins->first()->gitCommitSha)->toBe('abc123def4567890')
+        ->and($plugins->first()->enabled)->toBeTrue();
+});
+
+it('marks plugins disabled when listed in config.json', function () {
+    File::put($this->tmp . '/installed_plugins.json', json_encode([
+        'version' => 2,
+        'plugins' => [
+            'code-review@official' => [[
+                'scope' => 'user',
+                'installPath' => '/x',
+                'version' => '1',
+                'installedAt' => '2026-03-01T12:00:00Z',
+            ]],
+        ],
+    ]));
+    File::put($this->tmp . '/config.json', json_encode([
+        'disabledPlugins' => ['code-review@official'],
+    ]));
+
+    $plugin = app(SkillManager::class)->listInstalled()->first();
+
+    expect($plugin->enabled)->toBeFalse();
+});
+
+it('returns empty collection when installed_plugins.json is missing', function () {
+    expect(app(SkillManager::class)->listInstalled())->toHaveCount(0);
+});

--- a/tests/Feature/Services/SkillManagerTest.php
+++ b/tests/Feature/Services/SkillManagerTest.php
@@ -1,8 +1,10 @@
 <?php
 
 use App\DataTransferObjects\InstalledPlugin;
+use App\Exceptions\ClaudeCliException;
 use App\Services\SkillManager;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
 
 beforeEach(function () {
     $this->tmp = sys_get_temp_dir() . '/yak-skills-' . uniqid();
@@ -90,4 +92,43 @@ it('lists bundled skills from the skills directory', function () {
 it('returns empty when skills dir is missing', function () {
     config()->set('yak.skills_dir', $this->tmp . '/no-such-dir');
     expect(app(SkillManager::class)->listBundledSkills())->toHaveCount(0);
+});
+
+it('lists marketplaces from known_marketplaces.json', function () {
+    File::put($this->tmp . '/known_marketplaces.json', json_encode([
+        'acme' => [
+            'source' => ['source' => 'github', 'repo' => 'acme/plugins'],
+            'installLocation' => $this->tmp . '/marketplaces/acme',
+            'lastUpdated' => '2026-04-12T10:00:00Z',
+        ],
+    ]));
+
+    $list = app(SkillManager::class)->listMarketplaces();
+
+    expect($list)->toHaveCount(1)
+        ->and($list->first()->name)->toBe('acme')
+        ->and($list->first()->source)->toBe('acme/plugins')
+        ->and($list->first()->lastUpdated?->toIso8601String())->toBe('2026-04-12T10:00:00+00:00');
+});
+
+it('adds, removes, and refreshes marketplaces via the CLI', function () {
+    Process::fake(['*' => Process::result(output: 'ok', exitCode: 0)]);
+
+    app(SkillManager::class)->addMarketplace('github:acme/plugins');
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins marketplace add')
+        && str_contains($p->command, 'github:acme/plugins'));
+
+    app(SkillManager::class)->removeMarketplace('acme');
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins marketplace remove')
+        && str_contains($p->command, 'acme'));
+
+    app(SkillManager::class)->refreshMarketplaces();
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins marketplace update'));
+});
+
+it('throws a ClaudeCliException when the CLI exits non-zero', function () {
+    Process::fake(['*' => Process::result(errorOutput: 'boom', exitCode: 1)]);
+
+    expect(fn () => app(SkillManager::class)->addMarketplace('bad'))
+        ->toThrow(ClaudeCliException::class, 'boom');
 });

--- a/tests/Feature/Services/SkillManagerTest.php
+++ b/tests/Feature/Services/SkillManagerTest.php
@@ -132,3 +132,49 @@ it('throws a ClaudeCliException when the CLI exits non-zero', function () {
     expect(fn () => app(SkillManager::class)->addMarketplace('bad'))
         ->toThrow(ClaudeCliException::class, 'boom');
 });
+
+it('installs a plugin scoped to a marketplace', function () {
+    Process::fake(['*' => Process::result(output: 'ok', exitCode: 0)]);
+    app(SkillManager::class)->install('code-review', 'claude-plugins-official');
+
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins install')
+        && str_contains($p->command, 'code-review@claude-plugins-official'));
+});
+
+it('installs a plugin without marketplace', function () {
+    Process::fake(['*' => Process::result(output: '', exitCode: 0)]);
+    app(SkillManager::class)->install('code-review');
+
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins install')
+        && str_contains($p->command, 'code-review')
+        && ! str_contains($p->command, 'code-review@'));
+});
+
+it('installs a plugin from a URL or path', function () {
+    Process::fake(['*' => Process::result(output: '', exitCode: 0)]);
+    app(SkillManager::class)->installFromUrl('https://github.com/acme/plugin.git');
+
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins install')
+        && str_contains($p->command, 'github.com/acme/plugin.git'));
+});
+
+it('uninstalls, enables, disables, and updates', function () {
+    Process::fake(['*' => Process::result(output: '', exitCode: 0)]);
+    $manager = app(SkillManager::class);
+
+    $manager->uninstall('code-review');
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins uninstall')
+        && str_contains($p->command, 'code-review'));
+
+    $manager->enable('code-review');
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins enable')
+        && str_contains($p->command, 'code-review'));
+
+    $manager->disable('code-review');
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins disable')
+        && str_contains($p->command, 'code-review'));
+
+    $manager->update('code-review');
+    Process::assertRan(fn ($p) => str_contains($p->command, 'plugins update')
+        && str_contains($p->command, 'code-review'));
+});

--- a/tests/Unit/ClaudeCliTest.php
+++ b/tests/Unit/ClaudeCliTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\ClaudeCli;
+use App\Exceptions\ClaudeCliException;
+use Illuminate\Support\Facades\Process;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('wraps claude commands as the yak user with HOME set', function () {
+    Process::fake([
+        '*' => Process::result(output: '', exitCode: 0),
+    ]);
+
+    app(ClaudeCli::class)->exec('plugins list');
+
+    Process::assertRan(function ($process) {
+        return str_contains($process->command, 'sudo runuser -u yak -- env HOME=/home/yak bash -c')
+            && str_contains($process->command, "'claude plugins list'");
+    });
+});
+
+it('applies the configured timeout', function () {
+    Process::fake(['*' => Process::result()]);
+
+    app(ClaudeCli::class)->exec('plugins list', timeout: 90);
+
+    Process::assertRan(function ($process) {
+        return $process->timeout === 90;
+    });
+});
+
+it('wraps Symfony timeout exceptions as ClaudeCliException', function () {
+    Process::fake([
+        '*' => function () {
+            throw new ProcessTimedOutException(
+                Symfony\Component\Process\Process::fromShellCommandline('true'),
+                ProcessTimedOutException::TYPE_GENERAL,
+            );
+        },
+    ]);
+
+    expect(fn () => app(ClaudeCli::class)->exec('plugins list'))
+        ->toThrow(ClaudeCliException::class);
+});
+
+it('includes extra env vars in the wrapped command', function () {
+    $wrapped = app(ClaudeCli::class)->buildWrappedCommand('echo hi', ['FOO' => 'bar baz']);
+    expect($wrapped)->toContain("HOME=/home/yak FOO='bar baz'")
+        ->and($wrapped)->toContain("bash -c 'echo hi'");
+});


### PR DESCRIPTION
## Summary

Adds a new **/settings/skills** page that lets any authenticated Yak user browse, install, uninstall, enable, disable, and update Claude Code plugins without SSH access. Design follows `docs/superpowers/specs/2026-04-14-skills-management-design.md` (gitignored).

Scope is deliberately narrow: plugin management only. MCP OAuth and blocklist management were pulled out during brainstorming (MCP deferred until Anthropic publishes a stable headless-auth story; blocklist is upstream-curated and YAGNI for a single Geocodio deployment).

## What's included

- **`App\ClaudeCli`** — shared wrapper centralizing the `sudo runuser -u yak -- env HOME=/home/yak bash -c '<claude …>'` pattern. `ClaudeCodeRunner::wrapCommand()` now delegates through it so the env contract lives in one place.
- **`App\Services\SkillManager`** — thin synchronous wrapper around `claude plugins *` covering list/install/installFromUrl/uninstall/enable/disable/update plus marketplace list/add/remove/refresh. Reads `installed_plugins.json` directly for the source-of-truth install state.
- **`App\Services\MarketplaceReader`** — reads `~/.claude/plugins/marketplaces/<name>/.claude-plugin/marketplace.json` (already synced locally by Claude Code) and normalizes the three `source` shapes (string path, `url` object, `git-subdir` object) into a uniform DTO with `homepage`/`sourceUrl` for linking back to each plugin's source.
- **`App\Livewire\Settings\Skills`** + blade — browse-first UI with search, filter pills (All / Installed / Bundled / Available), plugin cards in a responsive grid, marketplace management, and an "Install from URL" Flux modal. Yak visual language: cream bg, slate/orange accents, rounded cards, Outfit + Instrument Serif. Widens `x-settings.layout` via a new `:wide` prop so the grid has room to breathe.
- **Bundled skills** (installed via Ansible + `npx skills add`) are surfaced read-only so users have the full picture of what Claude Code is loading.
- Toggling a plugin flips an Enabled/Disabled badge with a custom `.yak-toggle` switch; changes take effect on the next task run (called out in an info callout at the top of the page).

## Test plan

- [x] `tests/Unit/ClaudeCliTest.php` — wrapper shape, timeout, env-var handling (4 tests)
- [x] `tests/Feature/Services/SkillManagerTest.php` — installed plugin parsing, disabled-plugin detection, bundled skills, marketplace list/add/remove/refresh, install/uninstall/enable/disable/update, timeout/exit-code error handling (12 tests)
- [x] `tests/Feature/Services/MarketplaceReaderTest.php` — normalization of all three `source` shapes, missing-manifest handling (3 tests)
- [x] `tests/Feature/Livewire/Settings/SkillsTest.php` — page render, install dispatch, URL validation, search filter, toggle, marketplace add (6 tests)
- [x] `vendor/bin/phpstan analyse --memory-limit=2G` → no errors
- [x] `vendor/bin/pint --dirty --format agent` clean
- [x] Full Pest suite: **761 passed, 15 skipped, 3 failed** — the 3 failures (`ClaudeCodeRunnerContractTest`) hit the live Claude API and were already failing on `main`; no new regressions introduced

## Manual verification (post-merge)

- Deploy to yak.geocod.io and visit `/settings/skills` as a signed-in user
- Install a plugin from `claude-plugins-official` and confirm it appears in the Installed section
- Uninstall the same plugin and confirm it returns to Available
- Add a second marketplace (e.g. a custom Geocodio repo) via the Marketplaces form and confirm its plugins show up in Available
- Refresh marketplaces and confirm `lastUpdated` timestamps move