### PR TITLE
feat: PR review mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 - **Receives tasks** from Slack, Linear, Sentry, and other channels via webhooks
 - **Executes AI-driven workflows** using Claude to fix bugs, set up repos, and research codebases
+- **Reviews pull requests** with line-level comments, `suggestion` blocks, and a feedback dashboard
 - **Integrates with CI** to verify changes pass before merging pull requests
 - **Tracks costs and progress** through a real-time Livewire dashboard
 
@@ -40,7 +41,7 @@ See the [Setup Guide](https://geocodio.github.io/yak/setup/) for provisioning a 
 | Slack    | Yes                   | Yes                          |
 | Linear   | Yes                   | Yes                          |
 | Sentry   | Yes                   | --                           |
-| GitHub   | --                    | Yes (PR comments)            |
+| GitHub   | Yes (PR review events)| Yes (PR reviews, comments)   |
 
 ## Design Philosophy
 
@@ -56,6 +57,7 @@ Full documentation is hosted at **[geocodio.github.io/yak](https://geocodio.gith
 - [Setup](https://geocodio.github.io/yak/setup/)
 - [Channels](https://geocodio.github.io/yak/channels/)
 - [Repositories](https://geocodio.github.io/yak/repositories/)
+- [PR Review](https://geocodio.github.io/yak/pr-review/)
 - [Architecture](https://geocodio.github.io/yak/architecture/)
 - [Prompting](https://geocodio.github.io/yak/prompting/)
 - [Troubleshooting](https://geocodio.github.io/yak/troubleshooting/)

--- a/app/Actions/ApplyPrReviewToOpenPulls.php
+++ b/app/Actions/ApplyPrReviewToOpenPulls.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Repository;
+use App\Services\GitHubAppService;
+
+class ApplyPrReviewToOpenPulls
+{
+    public function __invoke(Repository $repository): int
+    {
+        $installationId = (int) config('yak.channels.github.installation_id');
+        $yakBot = (string) config('yak.channels.github.app_bot_login');
+
+        $prs = app(GitHubAppService::class)->listOpenPullRequests($installationId, $repository->slug);
+
+        $enqueued = 0;
+
+        foreach ($prs as $pr) {
+            if ((bool) ($pr['draft'] ?? false)) {
+                continue;
+            }
+            if ((string) ($pr['user']['login'] ?? '') === $yakBot) {
+                continue;
+            }
+
+            $task = app(EnqueuePrReview::class)->dispatch($repository, $pr, 'full');
+
+            if ($task !== null) {
+                $enqueued++;
+            }
+        }
+
+        return $enqueued;
+    }
+}

--- a/app/Actions/EnqueuePrReview.php
+++ b/app/Actions/EnqueuePrReview.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\TaskMode;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\TaskJobResolver;
+
+class EnqueuePrReview
+{
+    /**
+     * @param  array<string, mixed>  $prPayload
+     */
+    public function __invoke(Repository $repository, array $prPayload, string $reviewScope, ?string $incrementalBaseSha = null): ?YakTask
+    {
+        $prUrl = (string) $prPayload['html_url'];
+        $headSha = (string) $prPayload['head']['sha'];
+
+        if ($this->isDuplicate($prUrl, $headSha)) {
+            return null;
+        }
+
+        $title = (string) ($prPayload['title'] ?? '');
+        $description = "Review PR #{$prPayload['number']}" . ($title !== '' ? ": {$title}" : '');
+
+        return YakTask::create([
+            'mode' => TaskMode::Review,
+            'source' => 'github',
+            'description' => $description,
+            'repo' => $repository->slug,
+            'external_id' => $prUrl,
+            'pr_url' => $prUrl,
+            'branch_name' => (string) $prPayload['head']['ref'],
+            'context' => json_encode([
+                'pr_number' => (int) $prPayload['number'],
+                'head_sha' => $headSha,
+                'base_sha' => (string) $prPayload['base']['sha'],
+                'author' => (string) $prPayload['user']['login'],
+                'title' => (string) ($prPayload['title'] ?? ''),
+                'body' => (string) ($prPayload['body'] ?? ''),
+                'review_scope' => $reviewScope,
+                'incremental_base_sha' => $incrementalBaseSha,
+            ]),
+            'status' => 'pending',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $prPayload
+     */
+    public function dispatch(Repository $repository, array $prPayload, string $reviewScope, ?string $incrementalBaseSha = null): ?YakTask
+    {
+        $task = $this($repository, $prPayload, $reviewScope, $incrementalBaseSha);
+
+        if ($task !== null) {
+            TaskJobResolver::dispatch($task);
+        }
+
+        return $task;
+    }
+
+    private function isDuplicate(string $prUrl, string $headSha): bool
+    {
+        $candidates = YakTask::query()
+            ->where('mode', TaskMode::Review)
+            ->where('external_id', $prUrl)
+            ->whereIn('status', ['pending', 'running'])
+            ->get(['context']);
+
+        foreach ($candidates as $task) {
+            $ctx = json_decode((string) $task->context, true);
+            if (is_array($ctx) && ($ctx['head_sha'] ?? null) === $headSha) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/DataTransferObjects/ParsedReview.php
+++ b/app/DataTransferObjects/ParsedReview.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+final readonly class ParsedReview
+{
+    /**
+     * @param  array<int, ReviewFinding>  $findings
+     */
+    public function __construct(
+        public string $summary,
+        public string $verdict,
+        public string $verdictDetail,
+        public array $findings,
+    ) {}
+}

--- a/app/DataTransferObjects/ReviewFinding.php
+++ b/app/DataTransferObjects/ReviewFinding.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+final readonly class ReviewFinding
+{
+    public function __construct(
+        public string $file,
+        public int $line,
+        public string $severity,
+        public string $category,
+        public string $body,
+        public ?int $suggestionLoc = null,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public static function fromArray(array $raw): self
+    {
+        foreach (['file', 'line', 'severity', 'category', 'body'] as $key) {
+            if (! array_key_exists($key, $raw)) {
+                throw new \RuntimeException("Finding missing required key: {$key}");
+            }
+        }
+
+        return new self(
+            file: (string) $raw['file'],
+            line: (int) $raw['line'],
+            severity: (string) $raw['severity'],
+            category: (string) $raw['category'],
+            body: (string) $raw['body'],
+            suggestionLoc: isset($raw['suggestion_loc']) ? (int) $raw['suggestion_loc'] : null,
+        );
+    }
+}

--- a/app/Enums/TaskMode.php
+++ b/app/Enums/TaskMode.php
@@ -7,4 +7,5 @@ enum TaskMode: string
     case Fix = 'fix';
     case Research = 'research';
     case Setup = 'setup';
+    case Review = 'review';
 }

--- a/app/Http/Controllers/Webhooks/GitHubWebhookController.php
+++ b/app/Http/Controllers/Webhooks/GitHubWebhookController.php
@@ -2,8 +2,11 @@
 
 namespace App\Http\Controllers\Webhooks;
 
+use App\Actions\EnqueuePrReview;
 use App\Http\Concerns\VerifiesWebhookSignature;
 use App\Http\Controllers\Controller;
+use App\Models\PrReview;
+use App\Models\Repository;
 use App\Models\YakTask;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -20,10 +23,25 @@ class GitHubWebhookController extends Controller
             'X-Hub-Signature-256',
         );
 
-        if ($request->header('X-GitHub-Event') !== 'pull_request' || $request->input('action') !== 'closed') {
-            return response()->json(['ok' => true, 'skipped' => 'not a pull_request.closed event']);
+        if ($request->header('X-GitHub-Event') !== 'pull_request') {
+            return response()->json(['ok' => true, 'skipped' => 'not a pull_request event']);
         }
 
+        $action = $request->input('action');
+
+        if ($action === 'closed') {
+            return $this->handleClosed($request);
+        }
+
+        if (in_array($action, ['opened', 'ready_for_review', 'reopened', 'synchronize'], true)) {
+            return $this->handleReviewTrigger($request, $action);
+        }
+
+        return response()->json(['ok' => true, 'skipped' => "unhandled action: {$action}"]);
+    }
+
+    private function handleClosed(Request $request): JsonResponse
+    {
         /** @var string $prUrl */
         $prUrl = $request->input('pull_request.html_url', '');
 
@@ -42,5 +60,53 @@ class GitHubWebhookController extends Controller
         }
 
         return response()->json(['ok' => true, 'updated' => true]);
+    }
+
+    private function handleReviewTrigger(Request $request, string $action): JsonResponse
+    {
+        $pr = (array) $request->input('pull_request', []);
+        $repoFullName = (string) $request->input('repository.full_name', '');
+
+        $repo = Repository::where('slug', $repoFullName)->first();
+
+        if ($repo === null || ! $repo->is_active) {
+            return response()->json(['ok' => true, 'skipped' => 'repo not registered or inactive']);
+        }
+
+        if (! $repo->pr_review_enabled) {
+            return response()->json(['ok' => true, 'skipped' => 'pr review disabled on repo']);
+        }
+
+        if ((bool) ($pr['draft'] ?? false)) {
+            return response()->json(['ok' => true, 'skipped' => 'draft PR']);
+        }
+
+        if ((string) ($pr['user']['login'] ?? '') === (string) config('yak.channels.github.app_bot_login')) {
+            return response()->json(['ok' => true, 'skipped' => 'yak-authored PR']);
+        }
+
+        $scope = $action === 'synchronize' ? 'incremental' : 'full';
+        $incrementalBase = null;
+
+        if ($scope === 'incremental') {
+            $prior = PrReview::where('pr_url', (string) $pr['html_url'])
+                ->whereNull('dismissed_at')
+                ->orderByDesc('submitted_at')
+                ->first();
+
+            if ($prior === null) {
+                $scope = 'full';
+            } else {
+                $incrementalBase = $prior->commit_sha_reviewed;
+            }
+        }
+
+        $task = app(EnqueuePrReview::class)->dispatch($repo, $pr, $scope, $incrementalBase);
+
+        if ($task === null) {
+            return response()->json(['ok' => true, 'skipped' => 'duplicate']);
+        }
+
+        return response()->json(['ok' => true, 'enqueued' => $task->id]);
     }
 }

--- a/app/Http/Controllers/Webhooks/GitHubWebhookController.php
+++ b/app/Http/Controllers/Webhooks/GitHubWebhookController.php
@@ -46,17 +46,28 @@ class GitHubWebhookController extends Controller
         $prUrl = $request->input('pull_request.html_url', '');
 
         $task = YakTask::where('pr_url', $prUrl)->first();
-
-        if (! $task) {
-            return response()->json(['ok' => true, 'skipped' => 'no task found for PR']);
-        }
-
         $merged = (bool) $request->input('pull_request.merged', false);
 
-        if ($merged) {
-            $task->update(['pr_merged_at' => $request->input('pull_request.merged_at', now())]);
-        } else {
-            $task->update(['pr_closed_at' => $request->input('pull_request.closed_at', now())]);
+        if ($task) {
+            if ($merged) {
+                $task->update(['pr_merged_at' => $request->input('pull_request.merged_at', now())]);
+            } else {
+                $task->update(['pr_closed_at' => $request->input('pull_request.closed_at', now())]);
+            }
+        }
+
+        $prReviews = PrReview::where('pr_url', $prUrl)->get();
+
+        foreach ($prReviews as $pr) {
+            $updates = ['pr_closed_at' => $request->input('pull_request.closed_at', now())];
+            if ($merged) {
+                $updates['pr_merged_at'] = $request->input('pull_request.merged_at', now());
+            }
+            $pr->update($updates);
+        }
+
+        if (! $task && $prReviews->isEmpty()) {
+            return response()->json(['ok' => true, 'skipped' => 'no task found for PR']);
         }
 
         return response()->json(['ok' => true, 'updated' => true]);

--- a/app/Jobs/PollPullRequestReactionsJob.php
+++ b/app/Jobs/PollPullRequestReactionsJob.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\PrReviewComment;
+use App\Models\PrReviewCommentReaction;
+use App\Services\GitHubAppService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class PollPullRequestReactionsJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $timeout = 600;
+
+    public function __construct()
+    {
+        $this->onQueue('yak-poll');
+    }
+
+    public function handle(GitHubAppService $github): void
+    {
+        $windowDays = (int) config('yak.pr_review.reaction_poll_window_days', 30);
+        $installationId = (int) config('yak.channels.github.installation_id');
+        $cutoff = now()->subDays($windowDays);
+
+        $query = PrReviewComment::query()
+            ->whereHas('review', function ($q) use ($cutoff): void {
+                $q->where(function ($qq) use ($cutoff): void {
+                    $qq->whereNull('pr_closed_at')
+                        ->orWhere('pr_closed_at', '>=', $cutoff);
+                });
+            });
+
+        $query->chunkById(100, function ($comments) use ($github, $installationId): void {
+            foreach ($comments as $comment) {
+                try {
+                    $this->pollOne($github, $installationId, $comment);
+                } catch (\Throwable $e) {
+                    Log::warning('Reaction poll failed for comment', [
+                        'comment_id' => $comment->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+        });
+    }
+
+    private function pollOne(GitHubAppService $github, int $installationId, PrReviewComment $comment): void
+    {
+        $review = $comment->review;
+        if ($review === null) {
+            return;
+        }
+
+        $reactions = $github->listCommentReactions($installationId, $review->repo, (int) $comment->github_comment_id);
+
+        $seenIds = [];
+
+        foreach ($reactions as $r) {
+            $content = (string) ($r['content'] ?? '');
+            if (! in_array($content, ['+1', '-1'], true)) {
+                continue;
+            }
+
+            $seenIds[] = (int) $r['id'];
+
+            PrReviewCommentReaction::updateOrCreate(
+                ['github_reaction_id' => (int) $r['id']],
+                [
+                    'pr_review_comment_id' => $comment->id,
+                    'github_user_login' => (string) ($r['user']['login'] ?? ''),
+                    'github_user_id' => (int) ($r['user']['id'] ?? 0),
+                    'content' => $content,
+                    'reacted_at' => (string) ($r['created_at'] ?? now()),
+                ],
+            );
+        }
+
+        PrReviewCommentReaction::where('pr_review_comment_id', $comment->id)
+            ->whereNotIn('github_reaction_id', $seenIds)
+            ->delete();
+
+        $up = PrReviewCommentReaction::where('pr_review_comment_id', $comment->id)->where('content', '+1')->count();
+        $down = PrReviewCommentReaction::where('pr_review_comment_id', $comment->id)->where('content', '-1')->count();
+
+        $comment->update([
+            'thumbs_up' => $up,
+            'thumbs_down' => $down,
+            'last_polled_at' => now(),
+        ]);
+    }
+}

--- a/app/Jobs/RunYakReviewJob.php
+++ b/app/Jobs/RunYakReviewJob.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\YakTask;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class RunYakReviewJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public YakTask $task)
+    {
+        $this->onQueue('yak-claude');
+    }
+
+    public function handle(): void
+    {
+        // Implemented in Task 1.11.
+    }
+}

--- a/app/Jobs/RunYakReviewJob.php
+++ b/app/Jobs/RunYakReviewJob.php
@@ -11,15 +11,18 @@ use App\Exceptions\ClaudeAuthException;
 use App\Jobs\Middleware\EnsureDailyBudget;
 use App\Jobs\Middleware\EnsureRepoReady;
 use App\Models\DailyCost;
+use App\Models\LinearOauthConnection;
 use App\Models\PrReview;
 use App\Models\PrReviewComment;
 use App\Models\Repository;
 use App\Models\YakTask;
 use App\Services\GitHubAppService;
 use App\Services\IncusSandboxManager;
+use App\Services\LinearIssueFetcher;
 use App\Services\ReviewOutputParser;
 use App\Services\TaskLogger;
 use App\Services\TaskMetricsAccumulator;
+use App\Support\LinearIdentifierExtractor;
 use App\Support\PathMatcher;
 use App\Support\TaskContext;
 use App\YakPromptBuilder;
@@ -266,8 +269,48 @@ class RunYakReviewJob implements ShouldQueue
             'changedFiles' => $changedFiles,
             'repoAgentInstructions' => (string) ($repository->agent_instructions ?? ''),
             'pathExcludes' => $pathExcludes,
-            'linearTicket' => null,
+            'linearTicket' => $this->tryFetchLinearTicket($metadata),
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     * @return array<string, string>|null
+     */
+    private function tryFetchLinearTicket(array $metadata): ?array
+    {
+        $haystack = ((string) ($metadata['body'] ?? '')) . "\n" . ((string) ($metadata['title'] ?? ''));
+        $identifier = LinearIdentifierExtractor::firstFrom($haystack);
+
+        if ($identifier === null) {
+            return null;
+        }
+
+        if (LinearOauthConnection::query()->exists() === false) {
+            return null;
+        }
+
+        try {
+            $issue = app(LinearIssueFetcher::class)->fetch($identifier);
+
+            if ($issue === null) {
+                return null;
+            }
+
+            return [
+                'identifier' => (string) $issue['identifier'],
+                'title' => (string) $issue['title'],
+                'description' => (string) $issue['description'],
+                'url' => (string) $issue['url'],
+            ];
+        } catch (\Throwable $e) {
+            Log::info('Linear fetch failed for review', [
+                'identifier' => $identifier,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
     }
 
     /**

--- a/app/Jobs/RunYakReviewJob.php
+++ b/app/Jobs/RunYakReviewJob.php
@@ -249,6 +249,7 @@ class RunYakReviewJob implements ShouldQueue
 
         $changedFiles = array_values(array_filter(array_map('trim', explode("\n", $changedList))));
 
+        /** @var array<int, string> $pathExcludes */
         $pathExcludes = $repository->pr_review_path_excludes
             ?? (array) config('yak.pr_review.default_path_excludes', []);
 

--- a/app/Jobs/RunYakReviewJob.php
+++ b/app/Jobs/RunYakReviewJob.php
@@ -310,6 +310,34 @@ class RunYakReviewJob implements ShouldQueue
             'submitted_at' => now(),
         ]);
 
+        if ((string) ($metadata['review_scope'] ?? 'full') === 'full') {
+            $priorReviews = PrReview::where('pr_url', $this->task->pr_url)
+                ->whereNull('dismissed_at')
+                ->where('id', '!=', $review->id)
+                ->get();
+
+            foreach ($priorReviews as $prior) {
+                if ($prior->github_review_id !== null) {
+                    try {
+                        app(GitHubAppService::class)->dismissPullRequestReview(
+                            $installationId,
+                            $repository->slug,
+                            (int) $metadata['pr_number'],
+                            (int) $prior->github_review_id,
+                            'Superseded by newer commits',
+                        );
+                    } catch (\Throwable $e) {
+                        Log::warning('Failed to dismiss prior review', [
+                            'prior_id' => $prior->id,
+                            'error' => $e->getMessage(),
+                        ]);
+                    }
+                }
+
+                $prior->update(['dismissed_at' => now()]);
+            }
+        }
+
         $nonConsider = array_values(array_filter(
             $findings,
             fn ($f): bool => $f->severity !== 'consider',

--- a/app/Jobs/RunYakReviewJob.php
+++ b/app/Jobs/RunYakReviewJob.php
@@ -2,21 +2,376 @@
 
 namespace App\Jobs;
 
+use App\Contracts\AgentRunner;
+use App\DataTransferObjects\AgentRunRequest;
+use App\DataTransferObjects\ParsedReview;
+use App\DataTransferObjects\ReviewFinding;
+use App\Enums\TaskStatus;
+use App\Exceptions\ClaudeAuthException;
+use App\Jobs\Middleware\EnsureDailyBudget;
+use App\Jobs\Middleware\EnsureRepoReady;
+use App\Models\DailyCost;
+use App\Models\PrReview;
+use App\Models\PrReviewComment;
+use App\Models\Repository;
 use App\Models\YakTask;
+use App\Services\GitHubAppService;
+use App\Services\IncusSandboxManager;
+use App\Services\ReviewOutputParser;
+use App\Services\TaskLogger;
+use App\Services\TaskMetricsAccumulator;
+use App\Support\PathMatcher;
+use App\Support\TaskContext;
+use App\YakPromptBuilder;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
 
 class RunYakReviewJob implements ShouldQueue
 {
     use Queueable;
+
+    public int $timeout = 600;
+
+    /** @var array<int, int> */
+    public array $backoff = [1, 5, 10];
 
     public function __construct(public YakTask $task)
     {
         $this->onQueue('yak-claude');
     }
 
-    public function handle(): void
+    /**
+     * @return array<int, object>
+     */
+    public function middleware(): array
     {
-        // Implemented in Task 1.11.
+        return [new EnsureRepoReady, new EnsureDailyBudget];
+    }
+
+    public function handle(AgentRunner $agent): void
+    {
+        TaskContext::set($this->task);
+
+        try {
+            $this->runTask($agent);
+        } finally {
+            TaskContext::clear();
+        }
+    }
+
+    private function runTask(AgentRunner $agent): void
+    {
+        $repository = Repository::where('slug', $this->task->repo)->first();
+
+        if ($repository === null || ! $repository->pr_review_enabled) {
+            $this->task->update([
+                'status' => TaskStatus::Failed,
+                'error_log' => 'Repository missing or PR review not enabled',
+                'completed_at' => now(),
+            ]);
+
+            return;
+        }
+
+        $sandbox = app(IncusSandboxManager::class);
+        $containerName = null;
+        $metadata = $this->metadata();
+
+        $this->task->update([
+            'status' => TaskStatus::Running,
+            'started_at' => now(),
+            'attempts' => $this->task->attempts + 1,
+        ]);
+
+        TaskLogger::info($this->task, 'Picked up review task', ['pr' => $this->task->pr_url]);
+
+        try {
+            $containerName = $sandbox->create($this->task, $repository);
+            TaskLogger::info($this->task, 'Sandbox created', ['container' => $containerName]);
+
+            $this->checkoutPrHead($sandbox, $containerName, $metadata);
+            $promptContext = $this->buildPromptContext($sandbox, $containerName, $repository, $metadata);
+
+            $prompt = YakPromptBuilder::taskPrompt($this->task, $promptContext);
+
+            $result = $agent->run(new AgentRunRequest(
+                prompt: $prompt,
+                systemPrompt: YakPromptBuilder::systemPrompt($this->task),
+                containerName: $containerName,
+                timeoutSeconds: $this->timeout - 30,
+                maxBudgetUsd: (float) config('yak.max_budget_per_task'),
+                maxTurns: (int) config('yak.max_turns'),
+                model: (string) config('yak.default_model'),
+                resumeSessionId: null,
+                mcpConfigPath: config('yak.mcp_config_path'),
+                task: $this->task,
+            ));
+
+            if ($result->isError) {
+                TaskMetricsAccumulator::applyFresh($this->task, $result);
+                $this->handleError($result->resultSummary ?: 'Agent returned an error');
+
+                return;
+            }
+
+            TaskMetricsAccumulator::applyFresh($this->task, $result);
+            DailyCost::accumulate($result->costUsd);
+
+            $parsed = app(ReviewOutputParser::class)->parse($result->resultSummary);
+
+            $parsed = $this->filterFindings($parsed, $promptContext['pathExcludes']);
+
+            $this->postReview($repository, $parsed, $metadata);
+
+            $this->task->update([
+                'status' => TaskStatus::Success,
+                'completed_at' => now(),
+                'result_summary' => "Reviewed PR #{$metadata['pr_number']} — " . count($parsed->findings) . ' findings',
+                'model_used' => config('yak.default_model'),
+            ]);
+
+            TaskLogger::info($this->task, 'Review posted', ['findings' => count($parsed->findings)]);
+        } catch (ClaudeAuthException $e) {
+            Log::error('RunYakReviewJob auth failure', ['task_id' => $this->task->id, 'error' => $e->getMessage()]);
+            $this->handleError($e->getMessage());
+        } catch (\Throwable $e) {
+            Log::error('RunYakReviewJob failed', ['task_id' => $this->task->id, 'error' => $e->getMessage()]);
+            $this->handleError($e->getMessage());
+        } finally {
+            if ($containerName !== null) {
+                $sandbox->destroy($containerName);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function metadata(): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode((string) $this->task->context, true) ?: [];
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    private function checkoutPrHead(IncusSandboxManager $sandbox, string $containerName, array $metadata): void
+    {
+        $workspace = (string) config('yak.sandbox.workspace_path', '/workspace');
+        $prNumber = (int) $metadata['pr_number'];
+        $headBranch = (string) $this->task->branch_name;
+
+        $installationId = (int) config('yak.channels.github.installation_id');
+        if ($installationId > 0) {
+            $token = app(GitHubAppService::class)->getInstallationToken($installationId);
+            $sandbox->run(
+                $containerName,
+                'git config --global credential.https://github.com.helper ' .
+                escapeshellarg("!f() { echo \"protocol=https\nhost=github.com\nusername=x-access-token\npassword={$token}\"; }; f"),
+                timeout: 10,
+            );
+        }
+
+        $sandbox->run(
+            $containerName,
+            "cd {$workspace} && git fetch origin pull/{$prNumber}/head:" . escapeshellarg($headBranch),
+            timeout: 60,
+        );
+        $sandbox->run(
+            $containerName,
+            "cd {$workspace} && git checkout " . escapeshellarg($headBranch),
+            timeout: 30,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     * @return array<string, mixed>
+     */
+    private function buildPromptContext(
+        IncusSandboxManager $sandbox,
+        string $containerName,
+        Repository $repository,
+        array $metadata,
+    ): array {
+        $workspace = (string) config('yak.sandbox.workspace_path', '/workspace');
+        $base = (string) $metadata['base_sha'];
+        $head = (string) $metadata['head_sha'];
+
+        $diffStat = $sandbox->run(
+            $containerName,
+            "cd {$workspace} && git diff --stat " . escapeshellarg($base) . '...' . escapeshellarg($head),
+            timeout: 30,
+        )->output();
+
+        $changedList = $sandbox->run(
+            $containerName,
+            "cd {$workspace} && git diff --name-only " . escapeshellarg($base) . '...' . escapeshellarg($head),
+            timeout: 30,
+        )->output();
+
+        $changedFiles = array_values(array_filter(array_map('trim', explode("\n", $changedList))));
+
+        $pathExcludes = $repository->pr_review_path_excludes
+            ?? (array) config('yak.pr_review.default_path_excludes', []);
+
+        $changedFiles = array_values(array_filter(
+            $changedFiles,
+            fn (string $f): bool => ! PathMatcher::matches($f, $pathExcludes),
+        ));
+
+        return [
+            'prNumber' => (int) $metadata['pr_number'],
+            'prTitle' => (string) $metadata['title'],
+            'prBody' => (string) $metadata['body'],
+            'prAuthor' => (string) $metadata['author'],
+            'baseBranch' => $repository->default_branch,
+            'headBranch' => (string) $this->task->branch_name,
+            'diffSummary' => trim($diffStat),
+            'reviewScope' => (string) ($metadata['review_scope'] ?? 'full'),
+            'changedFiles' => $changedFiles,
+            'repoAgentInstructions' => (string) ($repository->agent_instructions ?? ''),
+            'pathExcludes' => $pathExcludes,
+            'linearTicket' => null,
+        ];
+    }
+
+    /**
+     * @param  array<int, string>  $pathExcludes
+     */
+    private function filterFindings(ParsedReview $parsed, array $pathExcludes): ParsedReview
+    {
+        $allowed = array_values(array_filter(
+            $parsed->findings,
+            fn ($f): bool => ! PathMatcher::matches($f->file, $pathExcludes),
+        ));
+
+        return new ParsedReview(
+            summary: $parsed->summary,
+            verdict: $parsed->verdict,
+            verdictDetail: $parsed->verdictDetail,
+            findings: $allowed,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    private function postReview(Repository $repository, ParsedReview $parsed, array $metadata): void
+    {
+        $installationId = (int) config('yak.channels.github.installation_id');
+        $maxFindings = (int) config('yak.pr_review.max_findings_per_review', 20);
+
+        $findings = array_slice($parsed->findings, 0, $maxFindings);
+
+        $lineComments = [];
+        $nitpicks = [];
+
+        foreach ($findings as $f) {
+            if ($f->severity === 'consider') {
+                $nitpicks[] = $f;
+
+                continue;
+            }
+
+            $lineComments[] = [
+                'path' => $f->file,
+                'line' => $f->line,
+                'body' => "**[{$f->category} · " . strtoupper($f->severity) . "]**\n\n{$f->body}",
+            ];
+        }
+
+        $body = $this->renderReviewBody($parsed, $nitpicks);
+
+        $response = app(GitHubAppService::class)->createPullRequestReview(
+            $installationId,
+            $repository->slug,
+            (int) $metadata['pr_number'],
+            $body,
+            'COMMENT',
+            $lineComments,
+        );
+
+        $review = PrReview::create([
+            'yak_task_id' => $this->task->id,
+            'repo' => $repository->slug,
+            'pr_number' => (int) $metadata['pr_number'],
+            'pr_url' => $this->task->pr_url,
+            'github_review_id' => $response['id'] ?? null,
+            'commit_sha_reviewed' => (string) $metadata['head_sha'],
+            'review_scope' => (string) ($metadata['review_scope'] ?? 'full'),
+            'incremental_base_sha' => $metadata['incremental_base_sha'] ?? null,
+            'summary' => $parsed->summary,
+            'verdict' => $parsed->verdict,
+            'submitted_at' => now(),
+        ]);
+
+        $nonConsider = array_values(array_filter(
+            $findings,
+            fn ($f): bool => $f->severity !== 'consider',
+        ));
+
+        foreach ($response['comments'] ?? [] as $i => $returned) {
+            $finding = $lineComments[$i] ?? null;
+            if ($finding === null) {
+                continue;
+            }
+
+            $original = $nonConsider[$i] ?? null;
+            if ($original === null) {
+                continue;
+            }
+
+            PrReviewComment::create([
+                'pr_review_id' => $review->id,
+                'github_comment_id' => (int) $returned['id'],
+                'file_path' => $original->file,
+                'line_number' => $original->line,
+                'body' => $finding['body'],
+                'category' => $original->category,
+                'severity' => $original->severity,
+                'is_suggestion' => $original->suggestionLoc !== null,
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<int, ReviewFinding>  $nitpicks
+     */
+    private function renderReviewBody(ParsedReview $parsed, array $nitpicks): string
+    {
+        $parts = [];
+        $parts[] = "## Summary\n\n" . $parsed->summary;
+
+        if ($nitpicks !== []) {
+            $nitsBody = collect($nitpicks)
+                ->map(fn ($n) => "- **{$n->file}:{$n->line}** — _{$n->category}_: {$n->body}")
+                ->implode("\n");
+
+            $parts[] = "<details>\n<summary>Nitpicks (" . count($nitpicks) . ")</summary>\n\n" . $nitsBody . "\n</details>";
+        }
+
+        $parts[] = "## Verdict\n\n**{$parsed->verdict}** — {$parsed->verdictDetail}";
+
+        return implode("\n\n", $parts);
+    }
+
+    private function handleError(string $message): void
+    {
+        if ($this->task->fresh()?->status === TaskStatus::Cancelled) {
+            return;
+        }
+
+        $this->task->update([
+            'status' => TaskStatus::Failed,
+            'error_log' => $message,
+            'completed_at' => now(),
+        ]);
+
+        TaskLogger::error($this->task, 'Review failed', ['error' => $message]);
     }
 }

--- a/app/Jobs/RunYakReviewJob.php
+++ b/app/Jobs/RunYakReviewJob.php
@@ -196,21 +196,51 @@ class RunYakReviewJob implements ShouldQueue
         IncusSandboxManager $sandbox,
         string $containerName,
         Repository $repository,
-        array $metadata,
+        array &$metadata,
     ): array {
         $workspace = (string) config('yak.sandbox.workspace_path', '/workspace');
-        $base = (string) $metadata['base_sha'];
         $head = (string) $metadata['head_sha'];
+
+        $scope = (string) ($metadata['review_scope'] ?? 'full');
+        $incrementalBase = $metadata['incremental_base_sha'] ?? null;
+
+        $effectiveBase = $scope === 'incremental' && $incrementalBase !== null
+            ? (string) $incrementalBase
+            : (string) $metadata['base_sha'];
+
+        if ($scope === 'incremental' && $incrementalBase !== null) {
+            $fetchResult = $sandbox->run(
+                $containerName,
+                "cd {$workspace} && git fetch origin " . escapeshellarg((string) $incrementalBase),
+                timeout: 30,
+            );
+
+            if ($fetchResult->exitCode() !== 0) {
+                Log::warning('Incremental base SHA not fetchable, degrading to full', [
+                    'task_id' => $this->task->id,
+                    'base_sha' => $incrementalBase,
+                ]);
+
+                $scope = 'full';
+                $effectiveBase = (string) $metadata['base_sha'];
+                $metadata['review_scope'] = 'full';
+                $metadata['incremental_base_sha'] = null;
+
+                $this->task->update([
+                    'context' => json_encode($metadata),
+                ]);
+            }
+        }
 
         $diffStat = $sandbox->run(
             $containerName,
-            "cd {$workspace} && git diff --stat " . escapeshellarg($base) . '...' . escapeshellarg($head),
+            "cd {$workspace} && git diff --stat " . escapeshellarg($effectiveBase) . '...' . escapeshellarg($head),
             timeout: 30,
         )->output();
 
         $changedList = $sandbox->run(
             $containerName,
-            "cd {$workspace} && git diff --name-only " . escapeshellarg($base) . '...' . escapeshellarg($head),
+            "cd {$workspace} && git diff --name-only " . escapeshellarg($effectiveBase) . '...' . escapeshellarg($head),
             timeout: 30,
         )->output();
 
@@ -232,7 +262,7 @@ class RunYakReviewJob implements ShouldQueue
             'baseBranch' => $repository->default_branch,
             'headBranch' => (string) $this->task->branch_name,
             'diffSummary' => trim($diffStat),
-            'reviewScope' => (string) ($metadata['review_scope'] ?? 'full'),
+            'reviewScope' => $scope,
             'changedFiles' => $changedFiles,
             'repoAgentInstructions' => (string) ($repository->agent_instructions ?? ''),
             'pathExcludes' => $pathExcludes,

--- a/app/Livewire/PrReviewFeedback.php
+++ b/app/Livewire/PrReviewFeedback.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\PrReview;
+use App\Models\PrReviewComment;
+use App\Models\PrReviewCommentReaction;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use Illuminate\View\View;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+#[Title('PR Reviews')]
+class PrReviewFeedback extends Component
+{
+    use WithPagination;
+
+    public string $repo_filter = '';
+
+    public string $severity_filter = '';
+
+    public string $category_filter = '';
+
+    public string $scope_filter = '';
+
+    public string $reviewer_filter = '';
+
+    public bool $has_reactions_only = false;
+
+    public string $sort_by = 'submitted_at';
+
+    public string $sort_dir = 'desc';
+
+    public string $active_tab = 'all';
+
+    public function comments(): LengthAwarePaginator
+    {
+        $query = PrReviewComment::query()
+            ->with(['review', 'reactions'])
+            ->when($this->severity_filter !== '', fn ($q) => $q->where('severity', $this->severity_filter))
+            ->when($this->category_filter !== '', fn ($q) => $q->where('category', $this->category_filter))
+            ->when($this->repo_filter !== '', fn ($q) => $q->whereHas('review', fn ($r) => $r->where('repo', $this->repo_filter)))
+            ->when($this->scope_filter !== '', fn ($q) => $q->whereHas('review', fn ($r) => $r->where('review_scope', $this->scope_filter)))
+            ->when($this->reviewer_filter !== '', fn ($q) => $q->whereHas('reactions', fn ($r) => $r->where('github_user_login', $this->reviewer_filter)))
+            ->when($this->has_reactions_only, fn ($q) => $q->where(fn ($qq) => $qq->where('thumbs_up', '>', 0)->orWhere('thumbs_down', '>', 0)));
+
+        if ($this->sort_by === 'submitted_at') {
+            $query->leftJoin('pr_reviews', 'pr_review_comments.pr_review_id', '=', 'pr_reviews.id')
+                ->orderBy('pr_reviews.submitted_at', $this->sort_dir)
+                ->select('pr_review_comments.*');
+        } else {
+            $query->orderBy($this->sort_by, $this->sort_dir);
+        }
+
+        return $query->paginate(50);
+    }
+
+    /**
+     * @return array{reviews: int, suggestions: int, thumbs_up_rate: float, most_downvoted_category: ?string}
+     */
+    public function stats(): array
+    {
+        return [
+            'reviews' => PrReview::count(),
+            'suggestions' => PrReviewComment::where('is_suggestion', true)->count(),
+            'thumbs_up_rate' => $this->computeThumbsUpRate(),
+            'most_downvoted_category' => PrReviewComment::where('thumbs_down', '>', 0)
+                ->selectRaw('category, SUM(thumbs_down) as total')
+                ->groupBy('category')
+                ->orderByDesc('total')
+                ->value('category'),
+        ];
+    }
+
+    public function reviewerStats(): Collection
+    {
+        return PrReviewCommentReaction::query()
+            ->selectRaw('github_user_login, COUNT(*) as total, SUM(CASE WHEN content = \'+1\' THEN 1 ELSE 0 END) as up, SUM(CASE WHEN content = \'-1\' THEN 1 ELSE 0 END) as down')
+            ->groupBy('github_user_login')
+            ->get();
+    }
+
+    public function sortBy(string $column): void
+    {
+        if ($this->sort_by === $column) {
+            $this->sort_dir = $this->sort_dir === 'asc' ? 'desc' : 'asc';
+        } else {
+            $this->sort_by = $column;
+            $this->sort_dir = 'desc';
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.pr-review-feedback', [
+            'comments' => $this->comments(),
+            'stats' => $this->stats(),
+            'reviewerStats' => $this->reviewerStats(),
+        ]);
+    }
+
+    private function computeThumbsUpRate(): float
+    {
+        $total = PrReviewComment::where(fn ($q) => $q->where('thumbs_up', '>', 0)->orWhere('thumbs_down', '>', 0))->count();
+
+        if ($total === 0) {
+            return 0.0;
+        }
+
+        $positive = PrReviewComment::where('thumbs_up', '>', 0)->whereColumn('thumbs_up', '>=', 'thumbs_down')->count();
+
+        return round(($positive / $total) * 100, 1);
+    }
+}

--- a/app/Livewire/PrReviewFeedback.php
+++ b/app/Livewire/PrReviewFeedback.php
@@ -35,6 +35,9 @@ class PrReviewFeedback extends Component
 
     public string $active_tab = 'all';
 
+    /**
+     * @return LengthAwarePaginator<int, PrReviewComment>
+     */
     public function comments(): LengthAwarePaginator
     {
         $query = PrReviewComment::query()
@@ -74,6 +77,9 @@ class PrReviewFeedback extends Component
         ];
     }
 
+    /**
+     * @return Collection<int, PrReviewCommentReaction>
+     */
     public function reviewerStats(): Collection
     {
         return PrReviewCommentReaction::query()

--- a/app/Livewire/PrReviewFeedback.php
+++ b/app/Livewire/PrReviewFeedback.php
@@ -82,6 +82,24 @@ class PrReviewFeedback extends Component
             ->get();
     }
 
+    public function showIntro(): bool
+    {
+        $user = auth()->user();
+
+        return $user !== null && $user->has_seen_pr_review_intro_at === null;
+    }
+
+    public function dismissIntro(): void
+    {
+        $user = auth()->user();
+
+        if ($user === null) {
+            return;
+        }
+
+        $user->forceFill(['has_seen_pr_review_intro_at' => now()])->save();
+    }
+
     public function sortBy(string $column): void
     {
         if ($this->sort_by === $column) {

--- a/app/Livewire/PrReviewForPr.php
+++ b/app/Livewire/PrReviewForPr.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Actions\EnqueuePrReview;
+use App\Enums\TaskMode;
+use App\Models\PrReview;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\GitHubAppService;
+use Flux\Flux;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\View\View;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+#[Title('PR Review')]
+class PrReviewForPr extends Component
+{
+    public string $repoSlug = '';
+
+    public int $prNumber = 0;
+
+    public function mount(string $repoSlug, int $prNumber): void
+    {
+        $this->repoSlug = $repoSlug;
+        $this->prNumber = $prNumber;
+    }
+
+    /**
+     * @return Collection<int, PrReview>
+     */
+    #[Computed]
+    public function reviews(): Collection
+    {
+        return PrReview::query()
+            ->where('repo', $this->repoSlug)
+            ->where('pr_number', $this->prNumber)
+            ->with(['task', 'comments'])
+            ->orderByDesc('submitted_at')
+            ->get();
+    }
+
+    public function rerunReview(): void
+    {
+        $prUrl = "https://github.com/{$this->repoSlug}/pull/{$this->prNumber}";
+
+        $existing = YakTask::query()
+            ->where('mode', TaskMode::Review)
+            ->where('external_id', $prUrl)
+            ->whereIn('status', ['pending', 'running'])
+            ->exists();
+
+        if ($existing) {
+            Flux::toast('A review is already queued for this PR.', variant: 'warning');
+
+            return;
+        }
+
+        $installationId = (int) config('yak.channels.github.installation_id');
+        $prPayload = app(GitHubAppService::class)->getPullRequest($installationId, $this->repoSlug, $this->prNumber);
+
+        if (! isset($prPayload['head']['sha'])) {
+            Flux::toast('Failed to fetch PR from GitHub.', variant: 'danger');
+
+            return;
+        }
+
+        $repo = Repository::where('slug', $this->repoSlug)->firstOrFail();
+
+        app(EnqueuePrReview::class)->dispatch($repo, $prPayload, 'full');
+
+        Flux::toast('Re-running review for this PR.');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.pr-review-for-pr', [
+            'reviews' => $this->reviews(),
+        ]);
+    }
+}

--- a/app/Livewire/Repos/RepoForm.php
+++ b/app/Livewire/Repos/RepoForm.php
@@ -47,6 +47,13 @@ class RepoForm extends Component
 
     public bool $apply_to_open_prs = true;
 
+    /** @var array<int, string> */
+    public array $path_excludes = [];
+
+    public string $path_exclude_input = '';
+
+    public bool $using_defaults = true;
+
     // GitHub repo picker (create mode only)
     public string $github_search = '';
 
@@ -79,6 +86,14 @@ class RepoForm extends Component
             $this->ci_system = $repository->ci_system;
             $this->sentry_project = $repository->sentry_project ?? '';
             $this->pr_review_enabled = (bool) $repository->pr_review_enabled;
+
+            if ($repository->pr_review_path_excludes !== null) {
+                $this->path_excludes = array_values($repository->pr_review_path_excludes);
+                $this->using_defaults = false;
+            } else {
+                $this->path_excludes = [];
+                $this->using_defaults = true;
+            }
         } else {
             $this->loadGitHubRepos();
         }
@@ -317,6 +332,7 @@ class RepoForm extends Component
             'ci_system' => $this->ci_system,
             'sentry_project' => $this->sentry_project ?: null,
             'pr_review_enabled' => $this->pr_review_enabled,
+            'pr_review_path_excludes' => $this->using_defaults ? null : $this->path_excludes,
         ];
 
         $wasEnabled = (bool) ($this->repository?->pr_review_enabled ?? false);
@@ -335,6 +351,38 @@ class RepoForm extends Component
         }
 
         $this->redirectRoute('repos.edit', $this->repository, navigate: true);
+    }
+
+    public function addPathExclude(): void
+    {
+        $pattern = trim($this->path_exclude_input);
+
+        if ($pattern === '' || in_array($pattern, $this->path_excludes, true)) {
+            return;
+        }
+
+        if (! preg_match('#^[A-Za-z0-9_./*?\-]+$#', $pattern)) {
+            $this->addError('path_exclude_input', 'Invalid glob pattern.');
+
+            return;
+        }
+
+        $this->path_excludes[] = $pattern;
+        $this->path_exclude_input = '';
+        $this->using_defaults = false;
+    }
+
+    public function removePathExclude(int $index): void
+    {
+        unset($this->path_excludes[$index]);
+        $this->path_excludes = array_values($this->path_excludes);
+        $this->using_defaults = false;
+    }
+
+    public function resetPathExcludes(): void
+    {
+        $this->path_excludes = [];
+        $this->using_defaults = true;
     }
 
     public function reviewAllOpenPrs(): void

--- a/app/Livewire/Repos/RepoForm.php
+++ b/app/Livewire/Repos/RepoForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Repos;
 
+use App\Actions\ApplyPrReviewToOpenPulls;
 use App\Enums\TaskMode;
 use App\Jobs\SetupYakJob;
 use App\Models\Repository;
@@ -42,6 +43,10 @@ class RepoForm extends Component
 
     public string $sentry_project = '';
 
+    public bool $pr_review_enabled = false;
+
+    public bool $apply_to_open_prs = true;
+
     // GitHub repo picker (create mode only)
     public string $github_search = '';
 
@@ -73,6 +78,7 @@ class RepoForm extends Component
             $this->is_default = $repository->is_default;
             $this->ci_system = $repository->ci_system;
             $this->sentry_project = $repository->sentry_project ?? '';
+            $this->pr_review_enabled = (bool) $repository->pr_review_enabled;
         } else {
             $this->loadGitHubRepos();
         }
@@ -263,6 +269,8 @@ class RepoForm extends Component
             'is_default' => ['boolean'],
             'ci_system' => ['required', 'string', Rule::in(['github_actions', 'drone', 'none'])],
             'sentry_project' => ['nullable', 'string', 'max:255'],
+            'pr_review_enabled' => ['boolean'],
+            'apply_to_open_prs' => ['boolean'],
         ];
 
         if ($this->repository) {
@@ -308,7 +316,10 @@ class RepoForm extends Component
             'is_default' => $this->is_default,
             'ci_system' => $this->ci_system,
             'sentry_project' => $this->sentry_project ?: null,
+            'pr_review_enabled' => $this->pr_review_enabled,
         ];
+
+        $wasEnabled = (bool) ($this->repository?->pr_review_enabled ?? false);
 
         if ($this->repository) {
             $this->repository->update($data);
@@ -319,7 +330,22 @@ class RepoForm extends Component
             Flux::toast('Repository created. Setup task dispatched.');
         }
 
+        if ($this->pr_review_enabled && ! $wasEnabled && $this->apply_to_open_prs) {
+            app(ApplyPrReviewToOpenPulls::class)($this->repository);
+        }
+
         $this->redirectRoute('repos.edit', $this->repository, navigate: true);
+    }
+
+    public function reviewAllOpenPrs(): void
+    {
+        if (! $this->repository) {
+            return;
+        }
+
+        $count = app(ApplyPrReviewToOpenPulls::class)($this->repository);
+
+        Flux::toast("Enqueued review for {$count} open PRs.");
     }
 
     public function rerunSetup(): void

--- a/app/Livewire/Repos/RepoForm.php
+++ b/app/Livewire/Repos/RepoForm.php
@@ -335,7 +335,7 @@ class RepoForm extends Component
             'pr_review_path_excludes' => $this->using_defaults ? null : $this->path_excludes,
         ];
 
-        $wasEnabled = (bool) ($this->repository?->pr_review_enabled ?? false);
+        $wasEnabled = (bool) ($this->repository->pr_review_enabled ?? false);
 
         if ($this->repository) {
             $this->repository->update($data);

--- a/app/Livewire/Repos/RepoList.php
+++ b/app/Livewire/Repos/RepoList.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Repos;
 
+use App\Models\PrReview;
 use App\Models\Repository;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Computed;
@@ -17,7 +18,15 @@ class RepoList extends Component
     #[Computed]
     public function repositories(): Collection
     {
-        return Repository::query()
+        $cutoff = now()->subDays(30);
+
+        $reviewCounts = PrReview::query()
+            ->where('submitted_at', '>=', $cutoff)
+            ->selectRaw('repo, COUNT(*) as count')
+            ->groupBy('repo')
+            ->pluck('count', 'repo');
+
+        $repos = Repository::query()
             ->withCount([
                 'tasks',
                 'tasks as tasks_recent_count' => function ($query) {
@@ -28,6 +37,12 @@ class RepoList extends Component
             ->orderByDesc('is_default')
             ->orderBy('name')
             ->get();
+
+        foreach ($repos as $repo) {
+            $repo->pr_reviews_30d_count = (int) ($reviewCounts[$repo->slug] ?? 0);
+        }
+
+        return $repos;
     }
 
     public static function setupBadgeClasses(string $status): string

--- a/app/Livewire/Tasks/TaskDetail.php
+++ b/app/Livewire/Tasks/TaskDetail.php
@@ -13,6 +13,7 @@ use App\Jobs\SendNotificationJob;
 use App\Jobs\SetupYakJob;
 use App\Models\AiUsage;
 use App\Models\Artifact;
+use App\Models\PrReview;
 use App\Models\TaskLog;
 use App\Models\YakTask;
 use App\Services\IncusSandboxManager;
@@ -22,6 +23,7 @@ use Flux\Flux;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
+use League\CommonMark\CommonMarkConverter;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
 use Livewire\Component;
@@ -224,6 +226,42 @@ class TaskDetail extends Component
     public function toggleDebug(): void
     {
         $this->showDebug = ! $this->showDebug;
+    }
+
+    #[Computed]
+    public function prReview(): ?PrReview
+    {
+        if ($this->task->mode !== TaskMode::Review) {
+            return null;
+        }
+
+        return PrReview::where('yak_task_id', $this->task->id)
+            ->with('comments')
+            ->first();
+    }
+
+    #[Computed]
+    public function renderedReviewBody(): string
+    {
+        $review = $this->prReview;
+        if ($review === null) {
+            return '';
+        }
+
+        $parts = [];
+        $parts[] = "## Summary\n\n" . ($review->summary ?? '');
+
+        $nitpicks = $review->comments->where('severity', 'consider');
+        if ($nitpicks->isNotEmpty()) {
+            $body = $nitpicks->map(fn ($c) => "- **{$c->file_path}:{$c->line_number}** — _{$c->category}_: {$c->body}")->implode("\n");
+            $parts[] = "### Nitpicks ({$nitpicks->count()})\n\n" . $body;
+        }
+
+        $parts[] = "## Verdict\n\n**" . ($review->verdict ?? '') . '**';
+
+        $md = implode("\n\n", $parts);
+
+        return (new CommonMarkConverter)->convert($md)->getContent();
     }
 
     #[Computed]

--- a/app/Livewire/Tasks/TaskDetail.php
+++ b/app/Livewire/Tasks/TaskDetail.php
@@ -33,6 +33,8 @@ use Livewire\Component;
 
 /**
  * @property-read Collection<int, TaskLog> $logs
+ * @property-read ?PrReview $prReview
+ * @property-read string $renderedReviewBody
  */
 #[Title('Task Detail')]
 class TaskDetail extends Component

--- a/app/Livewire/Tasks/TaskDetail.php
+++ b/app/Livewire/Tasks/TaskDetail.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Tasks;
 
+use App\Actions\EnqueuePrReview;
 use App\Drivers\LinearNotificationDriver;
 use App\Enums\NotificationType;
 use App\Enums\TaskMode;
@@ -14,8 +15,10 @@ use App\Jobs\SetupYakJob;
 use App\Models\AiUsage;
 use App\Models\Artifact;
 use App\Models\PrReview;
+use App\Models\Repository;
 use App\Models\TaskLog;
 use App\Models\YakTask;
+use App\Services\GitHubAppService;
 use App\Services\IncusSandboxManager;
 use App\Services\TaskLogger;
 use App\Support\TaskSourceUrl;
@@ -226,6 +229,50 @@ class TaskDetail extends Component
     public function toggleDebug(): void
     {
         $this->showDebug = ! $this->showDebug;
+    }
+
+    public function rerunReview(): void
+    {
+        if ($this->task->mode !== TaskMode::Review) {
+            return;
+        }
+
+        $existing = YakTask::query()
+            ->where('mode', TaskMode::Review)
+            ->where('external_id', $this->task->pr_url)
+            ->whereIn('status', ['pending', 'running'])
+            ->exists();
+
+        if ($existing) {
+            Flux::toast('A review is already queued for this PR.', variant: 'warning');
+
+            return;
+        }
+
+        $installationId = (int) config('yak.channels.github.installation_id');
+        $context = json_decode((string) $this->task->context, true) ?: [];
+        $prNumber = $context['pr_number'] ?? null;
+
+        if ($prNumber === null) {
+            Flux::toast('Cannot determine PR number.', variant: 'danger');
+
+            return;
+        }
+
+        $prPayload = app(GitHubAppService::class)
+            ->getPullRequest($installationId, $this->task->repo, (int) $prNumber);
+
+        if (! isset($prPayload['head']['sha'])) {
+            Flux::toast('Failed to fetch PR from GitHub.', variant: 'danger');
+
+            return;
+        }
+
+        $repo = Repository::where('slug', $this->task->repo)->firstOrFail();
+
+        app(EnqueuePrReview::class)->dispatch($repo, $prPayload, 'full');
+
+        Flux::toast('Re-running review for this PR.');
     }
 
     #[Computed]

--- a/app/Livewire/Tasks/TaskList.php
+++ b/app/Livewire/Tasks/TaskList.php
@@ -55,6 +55,7 @@ class TaskList extends Component
     {
         return match ($tab) {
             'setup' => YakTask::query()->where('mode', TaskMode::Setup),
+            'reviews' => YakTask::query()->where('mode', TaskMode::Review),
             default => YakTask::query()->whereIn('mode', [TaskMode::Fix, TaskMode::Research]),
         };
     }
@@ -69,6 +70,12 @@ class TaskList extends Component
     public function setupCount(): int
     {
         return $this->scopedQuery('setup')->count();
+    }
+
+    #[Computed]
+    public function reviewsCount(): int
+    {
+        return $this->scopedQuery('reviews')->count();
     }
 
     public function updatedTab(): void

--- a/app/Models/PrReview.php
+++ b/app/Models/PrReview.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\PrReviewFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PrReview extends Model
+{
+    /** @use HasFactory<PrReviewFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'submitted_at' => 'datetime',
+            'dismissed_at' => 'datetime',
+            'pr_closed_at' => 'datetime',
+            'pr_merged_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<YakTask, $this>
+     */
+    public function task(): BelongsTo
+    {
+        return $this->belongsTo(YakTask::class, 'yak_task_id');
+    }
+
+    /**
+     * @return HasMany<PrReviewComment, $this>
+     */
+    public function comments(): HasMany
+    {
+        return $this->hasMany(PrReviewComment::class);
+    }
+}

--- a/app/Models/PrReviewComment.php
+++ b/app/Models/PrReviewComment.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\PrReviewCommentFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PrReviewComment extends Model
+{
+    /** @use HasFactory<PrReviewCommentFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_suggestion' => 'boolean',
+            'last_polled_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<PrReview, $this>
+     */
+    public function review(): BelongsTo
+    {
+        return $this->belongsTo(PrReview::class, 'pr_review_id');
+    }
+
+    /**
+     * @return HasMany<PrReviewCommentReaction, $this>
+     */
+    public function reactions(): HasMany
+    {
+        return $this->hasMany(PrReviewCommentReaction::class);
+    }
+}

--- a/app/Models/PrReviewCommentReaction.php
+++ b/app/Models/PrReviewCommentReaction.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\PrReviewCommentReactionFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PrReviewCommentReaction extends Model
+{
+    /** @use HasFactory<PrReviewCommentReactionFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'reacted_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<PrReviewComment, $this>
+     */
+    public function comment(): BelongsTo
+    {
+        return $this->belongsTo(PrReviewComment::class, 'pr_review_comment_id');
+    }
+}

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -8,6 +8,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * @property array<int, string>|null $pr_review_path_excludes
+ * @property int $pr_reviews_30d_count
+ */
 class Repository extends Model
 {
     /** @use HasFactory<RepositoryFactory> */

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -21,6 +21,7 @@ class Repository extends Model
         'is_active' => true,
         'setup_status' => 'pending',
         'default_branch' => 'main',
+        'pr_review_enabled' => false,
     ];
 
     /**
@@ -32,6 +33,8 @@ class Repository extends Model
             'is_default' => 'boolean',
             'is_active' => 'boolean',
             'sandbox_base_version' => 'integer',
+            'pr_review_enabled' => 'boolean',
+            'pr_review_path_excludes' => 'array',
         ];
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -28,6 +28,7 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'has_seen_task_detail_intro_at' => 'datetime',
             'has_seen_setup_card_at' => 'datetime',
+            'has_seen_pr_review_intro_at' => 'datetime',
             'password' => 'hashed',
         ];
     }

--- a/app/Prompts/PromptDefinitions.php
+++ b/app/Prompts/PromptDefinitions.php
@@ -95,6 +95,18 @@ class PromptDefinitions
                 'type' => 'task',
                 'variables' => ['chosenOption'],
             ],
+            'tasks-review' => [
+                'view' => 'prompts.tasks.review',
+                'label' => 'PR Review',
+                'category' => 'high_touch',
+                'type' => 'task',
+                'variables' => [
+                    'prNumber', 'prTitle', 'prBody', 'prAuthor',
+                    'baseBranch', 'headBranch', 'diffSummary',
+                    'reviewScope', 'changedFiles',
+                    'repoAgentInstructions', 'pathExcludes', 'linearTicket',
+                ],
+            ],
             'channels-sentry' => [
                 'view' => 'prompts.channels.sentry',
                 'label' => 'Channel: Sentry',

--- a/app/Prompts/PromptFixtures.php
+++ b/app/Prompts/PromptFixtures.php
@@ -174,6 +174,30 @@ class PromptFixtures
                     ],
                 ],
             ],
+            'tasks-review' => [
+                [
+                    'label' => 'Typical PR',
+                    'data' => [
+                        'prNumber' => 42,
+                        'prTitle' => 'Add retry-on-timeout to the geocode client',
+                        'prBody' => "Fixes GEO-1234.\n\nThe geocode client was bailing after the first 5xx. Add exponential backoff retry up to 3 attempts.",
+                        'prAuthor' => 'mathiasgeocodio',
+                        'baseBranch' => 'main',
+                        'headBranch' => 'geo-1234-retry-timeout',
+                        'diffSummary' => " app/Services/GeocodeClient.php | 18 +++++++++++++++---\n tests/Unit/GeocodeClientTest.php | 24 ++++++++++++++++++++++\n 2 files changed, 39 insertions(+), 3 deletions(-)",
+                        'reviewScope' => 'full',
+                        'changedFiles' => ['app/Services/GeocodeClient.php', 'tests/Unit/GeocodeClientTest.php'],
+                        'repoAgentInstructions' => 'Use Laravel 13 conventions. Pest for tests.',
+                        'pathExcludes' => ['vendor/**', 'node_modules/**'],
+                        'linearTicket' => [
+                            'identifier' => 'GEO-1234',
+                            'title' => 'Add retry on timeout',
+                            'description' => 'Users are seeing geocode requests fail silently on transient 502s.',
+                            'url' => 'https://linear.app/geocodio/issue/GEO-1234',
+                        ],
+                    ],
+                ],
+            ],
             'channels-sentry' => [
                 [
                     'label' => 'Static content',

--- a/app/Services/GitHubAppService.php
+++ b/app/Services/GitHubAppService.php
@@ -338,6 +338,22 @@ class GitHubAppService
         return $results;
     }
 
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function listCommentReactions(int $installationId, string $repoSlug, int $commentId): array
+    {
+        $token = $this->getInstallationToken($installationId);
+
+        $response = Http::withToken($token)
+            ->withHeaders(['Accept' => 'application/vnd.github+json'])
+            ->get("https://api.github.com/repos/{$repoSlug}/pulls/comments/{$commentId}/reactions");
+
+        $json = $response->json();
+
+        return is_array($json) ? $json : [];
+    }
+
     public function dismissPullRequestReview(
         int $installationId,
         string $repoSlug,

--- a/app/Services/GitHubAppService.php
+++ b/app/Services/GitHubAppService.php
@@ -277,6 +277,32 @@ class GitHubAppService
         return "{$header}.{$payload}.{$this->base64UrlEncode($signature)}";
     }
 
+    /**
+     * @param  array<int, array{path: string, line: int, body: string}>  $comments
+     * @return array<string, mixed>
+     */
+    public function createPullRequestReview(
+        int $installationId,
+        string $repoSlug,
+        int $prNumber,
+        string $body,
+        string $event,
+        array $comments,
+    ): array {
+        $token = $this->getInstallationToken($installationId);
+
+        $response = Http::withToken($token)
+            ->withHeaders(['Accept' => 'application/vnd.github+json'])
+            ->post("https://api.github.com/repos/{$repoSlug}/pulls/{$prNumber}/reviews", [
+                'body' => $body,
+                'event' => $event,
+                'comments' => $comments,
+            ]);
+
+        /** @var array<string, mixed> */
+        return $response->json();
+    }
+
     private function requestInstallationToken(int $installationId): string
     {
         $jwt = $this->generateJwt();

--- a/app/Services/GitHubAppService.php
+++ b/app/Services/GitHubAppService.php
@@ -303,6 +303,41 @@ class GitHubAppService
         return $response->json();
     }
 
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function listOpenPullRequests(int $installationId, string $repoSlug): array
+    {
+        $token = $this->getInstallationToken($installationId);
+        $results = [];
+        $page = 1;
+
+        while (true) {
+            $response = Http::withToken($token)
+                ->withHeaders(['Accept' => 'application/vnd.github+json'])
+                ->get("https://api.github.com/repos/{$repoSlug}/pulls", [
+                    'state' => 'open',
+                    'per_page' => 100,
+                    'page' => $page,
+                ]);
+
+            $batch = $response->json();
+            if (! is_array($batch) || $batch === []) {
+                break;
+            }
+
+            $results = array_merge($results, $batch);
+
+            if (count($batch) < 100) {
+                break;
+            }
+
+            $page++;
+        }
+
+        return $results;
+    }
+
     public function dismissPullRequestReview(
         int $installationId,
         string $repoSlug,

--- a/app/Services/GitHubAppService.php
+++ b/app/Services/GitHubAppService.php
@@ -303,6 +303,23 @@ class GitHubAppService
         return $response->json();
     }
 
+    public function dismissPullRequestReview(
+        int $installationId,
+        string $repoSlug,
+        int $prNumber,
+        int $reviewId,
+        string $message,
+    ): void {
+        $token = $this->getInstallationToken($installationId);
+
+        Http::withToken($token)
+            ->withHeaders(['Accept' => 'application/vnd.github+json'])
+            ->put("https://api.github.com/repos/{$repoSlug}/pulls/{$prNumber}/reviews/{$reviewId}/dismissals", [
+                'message' => $message,
+                'event' => 'DISMISS',
+            ]);
+    }
+
     private function requestInstallationToken(int $installationId): string
     {
         $jwt = $this->generateJwt();

--- a/app/Services/GitHubAppService.php
+++ b/app/Services/GitHubAppService.php
@@ -339,6 +339,22 @@ class GitHubAppService
     }
 
     /**
+     * @return array<string, mixed>
+     */
+    public function getPullRequest(int $installationId, string $repoSlug, int $prNumber): array
+    {
+        $token = $this->getInstallationToken($installationId);
+
+        $response = Http::withToken($token)
+            ->withHeaders(['Accept' => 'application/vnd.github+json'])
+            ->get("https://api.github.com/repos/{$repoSlug}/pulls/{$prNumber}");
+
+        $json = $response->json();
+
+        return is_array($json) ? $json : [];
+    }
+
+    /**
      * @return array<int, array<string, mixed>>
      */
     public function listCommentReactions(int $installationId, string $repoSlug, int $commentId): array

--- a/app/Services/LinearIssueFetcher.php
+++ b/app/Services/LinearIssueFetcher.php
@@ -72,6 +72,53 @@ class LinearIssueFetcher
         return $names;
     }
 
+    /**
+     * Fetch issue metadata for review context (title, description, url).
+     * Returns null when Linear is unavailable or the issue isn't found.
+     *
+     * @return array{identifier: string, title: string, description: string, url: string}|null
+     */
+    public function fetch(string $identifier): ?array
+    {
+        $accessToken = $this->resolveAccessToken();
+        if ($accessToken === null || $identifier === '') {
+            return null;
+        }
+
+        try {
+            $response = Http::withToken($accessToken)
+                ->timeout(self::TIMEOUT_SECONDS)
+                ->post(self::GRAPHQL_ENDPOINT, [
+                    'query' => 'query($id: String!) { issue(id: $id) { identifier title description url } }',
+                    'variables' => ['id' => $identifier],
+                ]);
+        } catch (\Throwable $e) {
+            Log::channel('yak')->warning('LinearIssueFetcher: fetch failed', [
+                'identifier' => $identifier,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        if (! $response->successful()) {
+            return null;
+        }
+
+        /** @var array<string, mixed>|null $issue */
+        $issue = $response->json('data.issue');
+        if (! is_array($issue)) {
+            return null;
+        }
+
+        return [
+            'identifier' => (string) ($issue['identifier'] ?? $identifier),
+            'title' => (string) ($issue['title'] ?? ''),
+            'description' => (string) ($issue['description'] ?? ''),
+            'url' => (string) ($issue['url'] ?? ''),
+        ];
+    }
+
     public function hasLabel(string $identifier, string $labelName): bool
     {
         $names = $this->labelNames($identifier);

--- a/app/Services/ReviewOutputParser.php
+++ b/app/Services/ReviewOutputParser.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services;
+
+use App\DataTransferObjects\ParsedReview;
+use App\DataTransferObjects\ReviewFinding;
+
+class ReviewOutputParser
+{
+    public function parse(string $agentOutput): ParsedReview
+    {
+        $json = $this->extractJsonBlock($agentOutput);
+
+        if ($json === null) {
+            throw new \RuntimeException('Agent did not emit a JSON code block.');
+        }
+
+        /** @var array<string, mixed>|null $decoded */
+        $decoded = json_decode($json, true);
+
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('Agent JSON block did not decode to an object.');
+        }
+
+        foreach (['summary', 'verdict', 'verdict_detail', 'findings'] as $required) {
+            if (! array_key_exists($required, $decoded)) {
+                throw new \RuntimeException("Review output missing required key: {$required}");
+            }
+        }
+
+        if (! is_array($decoded['findings'])) {
+            throw new \RuntimeException('`findings` must be an array.');
+        }
+
+        $findings = array_map(
+            fn (array $raw): ReviewFinding => ReviewFinding::fromArray($raw),
+            $decoded['findings'],
+        );
+
+        return new ParsedReview(
+            summary: (string) $decoded['summary'],
+            verdict: (string) $decoded['verdict'],
+            verdictDetail: (string) $decoded['verdict_detail'],
+            findings: $findings,
+        );
+    }
+
+    private function extractJsonBlock(string $output): ?string
+    {
+        if (preg_match_all('/```json\s*(.*?)```/s', $output, $matches) === 0) {
+            return null;
+        }
+
+        $blocks = $matches[1];
+
+        return trim(end($blocks)) ?: null;
+    }
+}

--- a/app/Services/ReviewOutputParser.php
+++ b/app/Services/ReviewOutputParser.php
@@ -52,7 +52,12 @@ class ReviewOutputParser
         }
 
         $blocks = $matches[1];
+        $last = end($blocks);
 
-        return trim(end($blocks)) ?: null;
+        if ($last === false) {
+            return null;
+        }
+
+        return trim($last) ?: null;
     }
 }

--- a/app/Services/TaskJobResolver.php
+++ b/app/Services/TaskJobResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\TaskMode;
+use App\Jobs\RunYakJob;
+use App\Jobs\RunYakReviewJob;
+use App\Models\YakTask;
+
+class TaskJobResolver
+{
+    /**
+     * @return class-string
+     */
+    public static function jobClass(YakTask $task): string
+    {
+        return match ($task->mode) {
+            TaskMode::Review => RunYakReviewJob::class,
+            default => RunYakJob::class,
+        };
+    }
+
+    public static function dispatch(YakTask $task): void
+    {
+        $class = self::jobClass($task);
+        $class::dispatch($task);
+    }
+}

--- a/app/Support/LinearIdentifierExtractor.php
+++ b/app/Support/LinearIdentifierExtractor.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Support;
+
+class LinearIdentifierExtractor
+{
+    public static function firstFrom(?string $text): ?string
+    {
+        if ($text === null || $text === '') {
+            return null;
+        }
+
+        if (preg_match('/\b([A-Z]{2,6}-\d+)\b/', $text, $m) === 1) {
+            return $m[1];
+        }
+
+        return null;
+    }
+}

--- a/app/Support/PathMatcher.php
+++ b/app/Support/PathMatcher.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Matches a file path against a list of fnmatch-style glob patterns.
+ *
+ * Rules:
+ * - Patterns use `*`, `**`, and `?` as in gitignore-style globs.
+ * - Matching is anchored to the full path for patterns containing `/`.
+ * - Patterns without `/` (e.g. `*.min.js`) match any segment of the path.
+ * - Returns true if any pattern matches. Empty pattern list → false.
+ */
+class PathMatcher
+{
+    /**
+     * @param  array<int, string>  $patterns
+     */
+    public static function matches(string $path, array $patterns): bool
+    {
+        foreach ($patterns as $pattern) {
+            if (self::singleMatch($path, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function singleMatch(string $path, string $pattern): bool
+    {
+        $regex = self::globToRegex($pattern);
+
+        if (str_contains($pattern, '/')) {
+            return preg_match($regex, $path) === 1;
+        }
+
+        $basename = basename($path);
+
+        return preg_match($regex, $basename) === 1 || preg_match($regex, $path) === 1;
+    }
+
+    private static function globToRegex(string $pattern): string
+    {
+        $regex = '';
+        $length = strlen($pattern);
+
+        for ($i = 0; $i < $length; $i++) {
+            $c = $pattern[$i];
+
+            if ($c === '*' && ($pattern[$i + 1] ?? '') === '*') {
+                $regex .= '.*';
+                $i++;
+            } elseif ($c === '*') {
+                $regex .= '[^/]*';
+            } elseif ($c === '?') {
+                $regex .= '[^/]';
+            } elseif (in_array($c, ['.', '+', '(', ')', '[', ']', '^', '$', '|', '\\'], true)) {
+                $regex .= '\\' . $c;
+            } else {
+                $regex .= $c;
+            }
+        }
+
+        return '#^' . $regex . '$#';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "laravel/framework": "^13.0",
         "laravel/socialite": "^5.26",
         "laravel/tinker": "^3.0",
+        "league/commonmark": "*",
         "livewire/flux": "^2.13.1",
         "livewire/livewire": "^4.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f39cc7c256b1efd0399e316b4a63c081",
+    "content-hash": "d6b4dc5439ee2517f67a5320b036f838",
     "packages": [
         {
             "name": "artisan-build/fat-enums",

--- a/config/yak.php
+++ b/config/yak.php
@@ -184,8 +184,26 @@ return [
                 : env('YAK_GITHUB_PRIVATE_KEY', ''),
             'installation_id' => (int) env('YAK_GITHUB_INSTALLATION_ID'),
             'webhook_secret' => env('YAK_GITHUB_WEBHOOK_SECRET'),
+            'app_bot_login' => env('GITHUB_APP_BOT_LOGIN', 'yak-bot[bot]'),
         ],
 
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | PR Review Configuration
+    |--------------------------------------------------------------------------
+    */
+
+    'pr_review' => [
+        'reaction_poll_window_days' => (int) env('YAK_PR_REVIEW_POLL_DAYS', 30),
+        'max_findings_per_review' => (int) env('YAK_PR_REVIEW_MAX_FINDINGS', 20),
+        'enabled_globally' => (bool) env('YAK_PR_REVIEW_ENABLED_GLOBALLY', true),
+        'default_path_excludes' => [
+            'vendor/**', 'node_modules/**', 'public/build/**', 'public/hot',
+            'storage/**', '*.lock', '*.min.js', '*.min.css',
+            'database/migrations/**', '.idea/**', '.vscode/**',
+        ],
     ],
 
 ];

--- a/database/factories/PrReviewCommentFactory.php
+++ b/database/factories/PrReviewCommentFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PrReview;
+use App\Models\PrReviewComment;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PrReviewComment>
+ */
+class PrReviewCommentFactory extends Factory
+{
+    protected $model = PrReviewComment::class;
+
+    public function definition(): array
+    {
+        return [
+            'pr_review_id' => PrReview::factory(),
+            'github_comment_id' => fake()->unique()->numberBetween(1_000_000, 999_999_999),
+            'file_path' => 'app/Services/Example.php',
+            'line_number' => fake()->numberBetween(1, 500),
+            'body' => fake()->sentence(),
+            'category' => fake()->randomElement(['Simplicity', 'Test Quality', 'Performance']),
+            'severity' => fake()->randomElement(['must_fix', 'should_fix', 'consider']),
+            'is_suggestion' => false,
+            'thumbs_up' => 0,
+            'thumbs_down' => 0,
+        ];
+    }
+}

--- a/database/factories/PrReviewCommentReactionFactory.php
+++ b/database/factories/PrReviewCommentReactionFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PrReviewComment;
+use App\Models\PrReviewCommentReaction;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PrReviewCommentReaction>
+ */
+class PrReviewCommentReactionFactory extends Factory
+{
+    protected $model = PrReviewCommentReaction::class;
+
+    public function definition(): array
+    {
+        return [
+            'pr_review_comment_id' => PrReviewComment::factory(),
+            'github_reaction_id' => fake()->unique()->numberBetween(1_000_000, 999_999_999),
+            'github_user_login' => fake()->userName(),
+            'github_user_id' => fake()->numberBetween(1, 1_000_000),
+            'content' => fake()->randomElement(['+1', '-1']),
+            'reacted_at' => now(),
+        ];
+    }
+}

--- a/database/factories/PrReviewFactory.php
+++ b/database/factories/PrReviewFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PrReview;
+use App\Models\YakTask;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PrReview>
+ */
+class PrReviewFactory extends Factory
+{
+    protected $model = PrReview::class;
+
+    public function definition(): array
+    {
+        return [
+            'yak_task_id' => YakTask::factory(),
+            'repo' => 'geocodio/api',
+            'pr_number' => fake()->numberBetween(1, 9999),
+            'pr_url' => fn (array $a) => "https://github.com/{$a['repo']}/pull/{$a['pr_number']}",
+            'github_review_id' => fake()->numberBetween(1000000, 9999999),
+            'commit_sha_reviewed' => fake()->sha1(),
+            'review_scope' => 'full',
+            'summary' => fake()->sentence(),
+            'verdict' => 'Approve with suggestions',
+            'submitted_at' => now(),
+        ];
+    }
+
+    public function incremental(): self
+    {
+        return $this->state(fn () => [
+            'review_scope' => 'incremental',
+            'incremental_base_sha' => fake()->sha1(),
+        ]);
+    }
+
+    public function dismissed(): self
+    {
+        return $this->state(fn () => ['dismissed_at' => now()]);
+    }
+}

--- a/database/migrations/2026_04_17_100000_add_pr_review_columns_to_repositories_table.php
+++ b/database/migrations/2026_04_17_100000_add_pr_review_columns_to_repositories_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('repositories', function (Blueprint $table): void {
+            $table->boolean('pr_review_enabled')->default(false)->after('is_active');
+            $table->json('pr_review_path_excludes')->nullable()->after('pr_review_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('repositories', function (Blueprint $table): void {
+            $table->dropColumn(['pr_review_enabled', 'pr_review_path_excludes']);
+        });
+    }
+};

--- a/database/migrations/2026_04_17_100001_create_pr_reviews_table.php
+++ b/database/migrations/2026_04_17_100001_create_pr_reviews_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pr_reviews', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('yak_task_id')->constrained('tasks')->cascadeOnDelete();
+            $table->string('repo');
+            $table->unsignedInteger('pr_number');
+            $table->string('pr_url');
+            $table->unsignedBigInteger('github_review_id')->nullable();
+            $table->string('commit_sha_reviewed', 64);
+            $table->enum('review_scope', ['full', 'incremental']);
+            $table->string('incremental_base_sha', 64)->nullable();
+            $table->text('summary')->nullable();
+            $table->text('verdict')->nullable();
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamp('dismissed_at')->nullable();
+            $table->timestamp('pr_closed_at')->nullable();
+            $table->timestamp('pr_merged_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['repo', 'pr_number']);
+            $table->index(['pr_url', 'dismissed_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pr_reviews');
+    }
+};

--- a/database/migrations/2026_04_17_100002_create_pr_review_comments_table.php
+++ b/database/migrations/2026_04_17_100002_create_pr_review_comments_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pr_review_comments', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('pr_review_id')->constrained('pr_reviews')->cascadeOnDelete();
+            $table->unsignedBigInteger('github_comment_id')->unique();
+            $table->string('file_path');
+            $table->unsignedInteger('line_number');
+            $table->text('body');
+            $table->string('category');
+            $table->enum('severity', ['must_fix', 'should_fix', 'consider']);
+            $table->boolean('is_suggestion')->default(false);
+            $table->unsignedInteger('thumbs_up')->default(0);
+            $table->unsignedInteger('thumbs_down')->default(0);
+            $table->timestamp('last_polled_at')->nullable();
+            $table->timestamps();
+
+            $table->index('category');
+            $table->index('severity');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pr_review_comments');
+    }
+};

--- a/database/migrations/2026_04_17_100003_create_pr_review_comment_reactions_table.php
+++ b/database/migrations/2026_04_17_100003_create_pr_review_comment_reactions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pr_review_comment_reactions', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('pr_review_comment_id')->constrained('pr_review_comments')->cascadeOnDelete();
+            $table->unsignedBigInteger('github_reaction_id')->unique();
+            $table->string('github_user_login');
+            $table->unsignedBigInteger('github_user_id');
+            $table->string('content', 16);
+            $table->timestamp('reacted_at');
+            $table->timestamps();
+
+            $table->index(['github_user_login']);
+            $table->index(['content']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pr_review_comment_reactions');
+    }
+};

--- a/database/migrations/2026_04_17_100004_add_has_seen_pr_review_intro_at_to_users_table.php
+++ b/database/migrations/2026_04_17_100004_add_has_seen_pr_review_intro_at_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->timestamp('has_seen_pr_review_intro_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('has_seen_pr_review_intro_at');
+        });
+    }
+};

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ User-facing documentation for running and operating Yak. Source of truth lives h
 - **[Setup](setup.md)** — provisioning a fresh server with Ansible, vault configuration, verification
 - **[Channels](channels.md)** — configuring Slack, Linear, Sentry, GitHub, Drone, and the manual CLI
 - **[Repositories](repositories.md)** — adding repos, the setup task, CLAUDE.md guidance, multi-repo routing
+- **[PR Review](pr-review.md)** — enabling Yak to review pull requests, path filters, dashboard, reactions
 
 ## Reference
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,6 +256,8 @@ With Incus sandbox isolation, Claude Code tasks run **concurrently** (4 workers 
 - **`RetryYakJob`** — resumes the original Claude session with CI failure output and runs a second attempt on the existing branch. **Yak** force-pushes the result.
 - **`ResearchYakJob`** — for research mode tasks. Read-only; no branch, no CI. Claude generates a standalone HTML findings page saved to `.yak-artifacts/research.html`.
 - **`SetupYakJob`** — the one-time dev environment setup task for a new repo. See [Repositories → The Setup Task](repositories.md#the-setup-task).
+- **`RunYakReviewJob`** — the PR review path. Runs Claude in the sandbox with a read-only prompt scoped to a PR's diff, then posts the parsed findings as a GitHub review via the installation token. See [PR Review](pr-review.md).
+- **`PollPullRequestReactionsJob`** — scheduled hourly. Polls GitHub for 👍/👎 reactions on Yak-authored review comments within a configurable window and denormalizes counts onto `pr_review_comments`.
 
 ### Middleware
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -54,9 +54,11 @@ If you already have a GitHub App and want to reuse it, fill in `github_app_id`, 
 The GitHub App subscribes to:
 
 - `check_suite.completed` — CI result processing
-- `pull_request.closed` — merge/close tracking
+- `pull_request.closed` — merge/close tracking (also denormalizes onto `pr_reviews`)
+- `pull_request.opened` / `ready_for_review` / `reopened` — triggers a full PR review when `pr_review_enabled` is on
+- `pull_request.synchronize` — triggers an incremental PR review
 
-Webhook URL: `https://{your-domain}/webhooks/ci/github`
+Webhook URL: `https://{your-domain}/webhooks/ci/github` for CI; `https://{your-domain}/webhooks/github` for PR review events.
 
 ### Usage
 

--- a/docs/pr-review.md
+++ b/docs/pr-review.md
@@ -1,0 +1,81 @@
+# PR Review
+
+Yak can review pull requests on every enabled repository. When a PR is opened, updated, or marked ready for review, Yak dispatches a `review` task that runs the same Claude Code pipeline used for fixes and research — this time with read-only access and a rubric tuned for code review. The output is posted back to GitHub as a line-level review, complete with `suggestion` blocks where they fit.
+
+## Enabling It
+
+Go to the repo's settings page (`/repos/{id}/edit`) and flip the **PR Review** toggle. When you flip it on, a second switch appears — **Review all currently open PRs on save** — which, when kept on, enqueues a retroactive review for every eligible open PR the moment you save.
+
+After that:
+
+- Opening a new PR triggers a full review.
+- Marking a draft PR ready-for-review triggers a full review.
+- Reopening a closed PR triggers a full review.
+- Pushing new commits to an already-reviewed PR (`synchronize`) triggers an **incremental** review — only the commits since Yak's last review are considered. Force-pushes fall back to a full review automatically.
+
+PRs authored by the Yak app bot itself are skipped to avoid recursive reviews.
+
+## Path Filters
+
+Yak ships with sensible defaults for what to exclude from review — `vendor/**`, `node_modules/**`, lockfiles, minified assets, etc. The full default list is in `config/yak.php` under `pr_review.default_path_excludes`.
+
+If the defaults are wrong for a repo, the repo settings page has a **PR review path filters** section. You can add glob patterns (e.g. `custom/generated/**`), remove specific patterns, or reset back to the global defaults. The patterns support `*`, `**`, and `?` just like `.gitignore`.
+
+When path filters are active, Yak filters the changed file list before building the prompt AND filters findings Claude produces — so a model that still hallucinated a finding in `vendor/` gets silently dropped.
+
+## Interpreting Reviews
+
+Each review comment has three pieces of metadata:
+
+| Field | Values | Meaning |
+|---|---|---|
+| Category | Simplicity, Test Quality, Performance, ... | What kind of issue this is |
+| Severity | `must_fix`, `should_fix`, `consider` | How important |
+| Suggestion | yes/no | Whether the comment contains a 1–10 line code suggestion block |
+
+`consider` findings are bundled into a single collapsed "Nitpicks" block at the bottom of the review body — they don't create line-level comments. `should_fix` and `must_fix` are inline.
+
+Every review ends with a **verdict**: `Approve`, `Approve with suggestions`, or `Request changes`. The verdict is advisory — Yak does not use GitHub's Request Changes feature.
+
+## Linear Ticket Context
+
+If a PR body or title references a Linear ticket identifier (e.g. `GEO-1234`), and the Yak instance has an active Linear OAuth connection, Yak fetches the ticket's title and description and injects them into the review prompt. A new rubric category, **Ticket Alignment**, becomes available; Claude flags cases where the PR drifts from what the ticket actually asked for.
+
+No Linear connection? No identifier in the PR text? The review just skips this context silently.
+
+## Sandbox Tests
+
+The review runs inside the repo's normal Incus sandbox, so Claude can execute tests and type checkers against the changed files. The prompt explicitly encourages:
+
+- Running test suites when a subset is identifiable from `CLAUDE.md`
+- Running type checkers (`phpstan`, `tsc`) and linters (`pint`, `eslint`, `biome`) on changed files
+- Promoting genuine failures to `must_fix` findings
+
+Style-only issues that auto-formatters catch are suppressed — the prompt forbids them.
+
+## Tuning The Prompt
+
+The review prompt lives at `resources/views/prompts/tasks/review.blade.php` and is editable from `/prompts` under the slug `tasks-review`. Per-repo `agent_instructions` (set on the repo settings page) are appended to the prompt automatically.
+
+## Dashboard
+
+The **PR Reviews** tab (top-level nav) shows every finding Yak has posted, filterable by severity, category, repo, scope, and reviewer. Reactions (👍 / 👎) posted on GitHub are polled hourly and rolled up — you can see which categories trend helpful vs. noisy at a glance.
+
+- `/pr-reviews` — main table
+- `/pr-reviews/for/{repoSlug}/{prNumber}` — all Yak reviews for a specific PR, with a **Re-run review** button
+
+TaskDetail (`/tasks/{id}`) for a `review` task shows three additional panels: review output metadata, a rendered Markdown preview, and the full findings table.
+
+## Limitations
+
+- Yak does not post **approvals** — the verdict is advisory. GitHub's branch protection still requires a human reviewer if configured that way.
+- Review accuracy scales with the prompt; expect some noise on `consider` findings. Use the 👎 reaction to signal false positives — the dashboard surfaces patterns.
+- The `max_findings_per_review` cap (default 20) keeps reviews focused. Tune via `config/yak.php` if needed.
+- Incremental reviews only compute the diff between Yak's last reviewed SHA and the current head. Re-reviews of the full PR can always be triggered from TaskDetail.
+
+## Troubleshooting
+
+- **Review never posted** — Check the TaskDetail page for the failed review task. The sandbox might have failed to check out the PR head, or the JSON output from Claude might be malformed. Both failure modes are logged in the activity log.
+- **Review posted but comments missing** — Path filters may be too aggressive. Check `config/yak.php` `pr_review.default_path_excludes` or the per-repo overrides.
+- **Reactions not showing up** — The polling job runs hourly. Force a manual poll with `php artisan schedule:run` or wait for the next cycle.
+- **Linear ticket context not included** — Confirm a `LinearOauthConnection` exists and the ticket identifier follows the `[A-Z]{2,6}-\d+` pattern.

--- a/docs/prompting.md
+++ b/docs/prompting.md
@@ -267,6 +267,14 @@ Do NOT make code changes or commits.
    findings page.
 ```
 
+### PR Review
+
+Slug: `tasks-review`. Dispatched by the GitHub webhook when a PR is opened, made ready for review, reopened, or synchronized on a repo with `pr_review_enabled = true`.
+
+The template is read-only: it explicitly forbids commits or file modifications. It receives the PR title, body, author, head/base branches, scope (`full` or `incremental`), filtered list of changed files, an optional Linear ticket description (when the body mentions an identifier like `GEO-1234`), and the repo's path-exclude globs. Output is a strict JSON block with `summary`, `verdict`, `verdict_detail`, and `findings[]` — each finding carries a file, line, severity (`must_fix` / `should_fix` / `consider`), category, body, and an optional `suggestion_loc` when the body contains a `suggestion` block.
+
+See [pr-review.md](pr-review.md) for the operational guide.
+
 ### Slack Fix (with ambiguity check)
 
 ```

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -156,6 +156,12 @@ Same form pre-filled with current values. Also includes:
 - **Deactivate** toggle — soft-disables the repo (historical tasks remain; new tasks will not route here)
 - **Delete** (danger zone) — only available if the repo has zero tasks. If the repo has any task history, you must deactivate instead.
 
+## PR Review Toggle
+
+Each repo has a **PR Review** toggle on its edit page. When enabled, Yak reviews every open, non-draft PR on the repo — posting line-level comments with category + severity + (sometimes) `suggestion` blocks. See the [PR Review guide](pr-review.md) for the full flow.
+
+Path filters let you narrow what Yak reviews. The defaults (in `config/yak.php`) exclude `vendor/**`, `node_modules/**`, lockfiles, and minified assets; per-repo overrides are a chip list on the same edit page.
+
 ## Repo Refresh
 
 Yak automatically runs `git fetch origin {default_branch}` every 30 minutes via the scheduled `yak:refresh-repos` command. This keeps each repo's default branch tip up to date so that new tasks start from the latest code without a manual pull.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,6 +19,24 @@ docker exec yak php artisan queue:monitor yak-claude,default
 
 If the health check is green and logs are clean, the problem is usually in the external service (Slack app, Linear webhook, GitHub App installation) rather than Yak itself.
 
+## PR Review Not Posting
+
+Symptoms: a PR opened on a repo with `pr_review_enabled = true` but no Yak review comment appears.
+
+### Checklist
+
+1. **GitHub webhook reaching Yak?** Check webhook delivery in GitHub App settings. `pull_request.opened` and `pull_request.synchronize` must be subscribed.
+2. **Repo active and enabled?** Go to `/repos/{id}/edit` and confirm **Active** and **PR Review** are both on.
+3. **PR a draft, or authored by yak-bot?** Both are intentionally skipped. Convert the draft to ready-for-review to trigger.
+4. **Task dispatched but failed?** Look in `/tasks?tab=reviews` for a failed row. Common failure modes:
+   - Sandbox checkout failure — the PR's head wasn't fetchable (force-pushed, branch deleted). Inspect the task activity log.
+   - Claude output didn't contain a valid JSON block — usually means Claude failed the review instead of producing findings. The raw output lives in the task's `result_summary`.
+5. **Path filters too aggressive?** If the PR only touches excluded paths, the review is filtered out. Check `pr_review_path_excludes` on the repo.
+
+### Resolution
+
+Manual re-run from the TaskDetail page's **Re-run review** button. If the same task keeps failing, lower the prompt's `max_findings_per_review` or check the `tasks-review` prompt at `/prompts` for custom edits.
+
 ## Task Stuck In `running`
 
 Symptoms: a task's status on the dashboard is `running` and hasn't moved for several minutes beyond the expected Claude Code duration (typically 2–10 minutes).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,10 +1,172 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskMode\:\:Research will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Http/Controllers/Webhooks/LinearWebhookController.php
+
+		-
+			message: '#^Cannot cast array\<mixed\>\|string to string\.$#'
+			identifier: cast.string
+			count: 1
+			path: app/Http/Controllers/Webhooks/SlackInteractiveWebhookController.php
+
+		-
+			message: '#^Result of \|\| is always true\.$#'
+			identifier: booleanOr.alwaysTrue
+			count: 1
+			path: app/Http/Controllers/Webhooks/SlackInteractiveWebhookController.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and App\\Enums\\TaskStatus\:\:AwaitingClarification will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: app/Http/Controllers/Webhooks/SlackInteractiveWebhookController.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: app/Http/Controllers/Webhooks/SlackInteractiveWebhookController.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskMode\:\:Research will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Http/Controllers/Webhooks/SlackWebhookController.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments string, array\{App\\Enums\\TaskStatus\:\:Success, App\\Enums\\TaskStatus\:\:Failed, App\\Enums\\TaskStatus\:\:Expired, App\\Enums\\TaskStatus\:\:Cancelled\} and true will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: app/Jobs/ClarificationReplyJob.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: app/Jobs/ClarificationReplyJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskStatus\:\:Failed will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/ClarificationReplyJob.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments string, array\{App\\Enums\\TaskStatus\:\:Success, App\\Enums\\TaskStatus\:\:Failed, App\\Enums\\TaskStatus\:\:Expired, App\\Enums\\TaskStatus\:\:Cancelled\} and true will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: app/Jobs/ResearchYakJob.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: app/Jobs/ResearchYakJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskStatus\:\:Failed will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/ResearchYakJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string\|null and App\\Enums\\TaskStatus\:\:Cancelled will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/ResearchYakJob.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments string, array\{App\\Enums\\TaskStatus\:\:Success, App\\Enums\\TaskStatus\:\:Failed, App\\Enums\\TaskStatus\:\:Expired, App\\Enums\\TaskStatus\:\:Cancelled\} and true will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: app/Jobs/RetryYakJob.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: app/Jobs/RetryYakJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskStatus\:\:Failed will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/RetryYakJob.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments string, array\{App\\Enums\\TaskStatus\:\:Success, App\\Enums\\TaskStatus\:\:Failed, App\\Enums\\TaskStatus\:\:Expired, App\\Enums\\TaskStatus\:\:Cancelled\} and true will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: app/Jobs/RunYakJob.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: app/Jobs/RunYakJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskStatus\:\:Failed will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/RunYakJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string\|null and App\\Enums\\TaskStatus\:\:Cancelled will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/RunYakJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string\|null and App\\Enums\\TaskStatus\:\:Cancelled will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/RunYakReviewJob.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments string, array\{App\\Enums\\TaskStatus\:\:Success, App\\Enums\\TaskStatus\:\:Failed, App\\Enums\\TaskStatus\:\:Expired, App\\Enums\\TaskStatus\:\:Cancelled\} and true will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: app/Jobs/SetupYakJob.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: app/Jobs/SetupYakJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskStatus\:\:Failed will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/SetupYakJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string\|null and App\\Enums\\TaskStatus\:\:Cancelled will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/SetupYakJob.php
+
+		-
 			message: '#^Method App\\Livewire\\Actions\\Logout\:\:__invoke\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: app/Livewire/Actions/Logout.php
+
+		-
+			message: '#^Method App\\Livewire\\Channels\\ChannelList\:\:channels\(\) should return list\<array\{slug\: string, name\: string, icon\: string, role\: string, description\: string, vault_keys\: list\<string\>, docs_url\: string, enabled\: bool, \.\.\.\}\> but returns non\-empty\-array\<0\|1\|2\|3\|4, array\{slug\: ''drone''\|''github''\|''linear''\|''sentry''\|''slack'', name\: ''Drone CI''\|''GitHub''\|''Linear''\|''Sentry''\|''Slack'', icon\: ''bolt''\|''chat\-bubble\-left''\|''code\-bracket''\|''cog\-6\-tooth''\|''shield\-exclamation'', role\: ''CI results''\|''Input \(@yak…''\|''Input \(alert rules\)''\|''Input \(issue…''\|''Output \(pull…'', description\: ''Polled for CI…''\|''Required\. Yak opens…''\|''Sentry alerts…''\|''Users mention @yak…''\|''Yak installs as a…'', vault_keys\: array\{''drone_url'', ''drone_token''\}\|array\{''github_app_id'', ''github_installation…'', ''github_webhook…''\}\|array\{''linear_oauth_client…'', ''linear_oauth_client…'', ''linear_webhook…''\}\|array\{''sentry_auth_token'', ''sentry_webhook…'', ''sentry_org_slug''\}\|array\{''slack_bot_token'', ''slack_signing_secret'', ''slack_workspace_url''\}, docs_url\: string, enabled\: bool, \.\.\.\}\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Livewire/Channels/ChannelList.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between ''drone''\|''github''\|''linear''\|''sentry''\|''slack'' and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: app/Livewire/Channels/ChannelList.php
 
 		-
 			message: '#^Cannot call method delete\(\) on App\\Models\\User\|null\.$#'
@@ -73,6 +235,12 @@ parameters:
 			path: app/Livewire/Settings/Profile.php
 
 		-
+			message: '#^Call to an undefined method App\\Models\\User\:\:twoFactorQrCodeSvg\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Livewire/Settings/Security.php
+
+		-
 			message: '#^Cannot access property \$two_factor_confirmed_at on App\\Models\\User\|null\.$#'
 			identifier: property.nonObject
 			count: 1
@@ -109,12 +277,6 @@ parameters:
 			path: app/Livewire/Settings/Security.php
 
 		-
-			message: '#^Call to an undefined method App\\Models\\User\:\:twoFactorQrCodeSvg\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Livewire/Settings/Security.php
-
-		-
 			message: '#^Cannot access property \$two_factor_recovery_codes on App\\Models\\User\|null\.$#'
 			identifier: property.nonObject
 			count: 2
@@ -131,3 +293,81 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: app/Livewire/Settings/TwoFactor/RecoveryCodes.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 2
+			path: app/Livewire/Tasks/TaskDetail.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and App\\Enums\\TaskMode\:\:Review will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 2
+			path: app/Livewire/Tasks/TaskDetail.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and App\\Enums\\TaskStatus\:\:AwaitingClarification will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: app/Livewire/Tasks/TaskDetail.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskMode\:\:Fix will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Livewire/Tasks/TaskDetail.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskStatus\:\:Success will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Livewire/Tasks/TaskDetail.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 3
+			path: app/Livewire/Tasks/TaskDetail.php
+
+		-
+			message: '#^Call to function is_array\(\) with array\{name\?\: string\} will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: app/Services/LinearIssueFetcher.php
+
+		-
+			message: '#^Binary operation "\^" between string\|false and string\|false results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: app/Services/PerceptualHash.php
+
+		-
+			message: '#^Parameter \#1 \$num of function dechex expects int, float\|int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Services/PerceptualHash.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\TaskMode\:\:Review is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Services/TaskJobResolver.php
+
+		-
+			message: '#^Cannot access property \$value on string\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Support/SlackBlockFormatter.php
+
+		-
+			message: '#^Method App\\Support\\SlackBlockFormatter\:\:contextChips\(\) never returns null so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: app/Support/SlackBlockFormatter.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between list\{0\: non\-falsy\-string, 1\?\: non\-falsy\-string, 2\?\: non\-falsy\-string\} and array\{\} will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Support/SlackBlockFormatter.php

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -40,6 +40,12 @@
                             <flux:icon.code-bracket class="size-5" />
                             {{ __('Repositories') }}
                         </a>
+                        <a href="{{ route('pr-reviews') }}"
+                           class="flex items-center gap-3 px-3 py-2.5 text-sm rounded-btn transition-colors {{ request()->routeIs('pr-reviews') ? 'bg-yak-orange/10 text-yak-orange border-l-2 border-yak-orange font-medium' : 'text-yak-slate hover:bg-yak-cream' }}"
+                           wire:navigate @click="mobileNavOpen = false">
+                            <flux:icon.chat-bubble-left-ellipsis class="size-5" />
+                            {{ __('PR Reviews') }}
+                        </a>
                         <a href="{{ route('channels') }}"
                            class="flex items-center gap-3 px-3 py-2.5 text-sm rounded-btn transition-colors {{ request()->routeIs('channels') ? 'bg-yak-orange/10 text-yak-orange border-l-2 border-yak-orange font-medium' : 'text-yak-slate hover:bg-yak-cream' }}"
                            wire:navigate @click="mobileNavOpen = false">

--- a/resources/views/livewire/pr-review-feedback.blade.php
+++ b/resources/views/livewire/pr-review-feedback.blade.php
@@ -1,6 +1,26 @@
 <div>
     <h1 class="text-2xl font-semibold text-yak-slate mb-5">PR Reviews</h1>
 
+    @if ($this->showIntro())
+        <div class="mb-5 flex items-start gap-4 rounded-[20px] border border-yak-tan/40 bg-yak-cream-dark/60 p-4">
+            <div class="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-yak-orange/15 text-yak-orange">
+                <flux:icon.sparkles variant="mini" class="size-4" />
+            </div>
+            <div class="flex-1 text-sm text-yak-slate">
+                <div class="font-medium text-yak-orange mb-1">Yak now reviews your pull requests.</div>
+                Turn on <em>PR Review</em> on a repository, then open a PR — Yak posts a line-level review with suggestion blocks. Reactions (👍/👎) are tracked here so you can see which kinds of feedback the team finds useful.
+            </div>
+            <button
+                wire:click="dismissIntro"
+                type="button"
+                class="text-yak-slate/60 hover:text-yak-slate transition-colors"
+                aria-label="Dismiss"
+            >
+                <flux:icon.x-mark class="size-5" />
+            </button>
+        </div>
+    @endif
+
     @if ($stats['reviews'] === 0)
         <div class="rounded-[20px] border border-yak-tan/40 bg-yak-cream-dark/40 p-8 text-center">
             <flux:icon.chat-bubble-left-ellipsis class="mx-auto size-10 text-yak-slate/60" />

--- a/resources/views/livewire/pr-review-feedback.blade.php
+++ b/resources/views/livewire/pr-review-feedback.blade.php
@@ -1,0 +1,140 @@
+<div>
+    <h1 class="text-2xl font-semibold text-yak-slate mb-5">PR Reviews</h1>
+
+    @if ($stats['reviews'] === 0)
+        <div class="rounded-[20px] border border-yak-tan/40 bg-yak-cream-dark/40 p-8 text-center">
+            <flux:icon.chat-bubble-left-ellipsis class="mx-auto size-10 text-yak-slate/60" />
+            <p class="mt-3 text-yak-slate">No Yak reviews yet. Enable PR review on a repository to get started.</p>
+            <flux:button :href="route('repos')" variant="outline" class="mt-4">
+                Manage repositories
+            </flux:button>
+        </div>
+    @else
+        {{-- Stats strip --}}
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-5 mb-8">
+            <div class="bg-white/75 backdrop-blur-[40px] backdrop-saturate-[1.4] border border-white/60 rounded-[28px] shadow-yak p-6 text-center">
+                <div class="text-3xl font-semibold text-yak-slate">{{ $stats['reviews'] }}</div>
+                <div class="text-sm text-yak-slate/70 mt-1">Reviews</div>
+            </div>
+            <div class="bg-white/75 backdrop-blur-[40px] backdrop-saturate-[1.4] border border-white/60 rounded-[28px] shadow-yak p-6 text-center">
+                <div class="text-3xl font-semibold text-yak-slate">{{ $stats['suggestions'] }}</div>
+                <div class="text-sm text-yak-slate/70 mt-1">Suggestions</div>
+            </div>
+            <div class="bg-white/75 backdrop-blur-[40px] backdrop-saturate-[1.4] border border-white/60 rounded-[28px] shadow-yak p-6 text-center">
+                <div class="text-3xl font-semibold text-yak-slate">{{ $stats['thumbs_up_rate'] }}%</div>
+                <div class="text-sm text-yak-slate/70 mt-1">👍 rate</div>
+            </div>
+            <div class="bg-white/75 backdrop-blur-[40px] backdrop-saturate-[1.4] border border-white/60 rounded-[28px] shadow-yak p-6 text-center">
+                <div class="text-sm font-semibold text-yak-slate">{{ $stats['most_downvoted_category'] ?? '—' }}</div>
+                <div class="text-sm text-yak-slate/70 mt-1">Most 👎 category</div>
+            </div>
+        </div>
+
+        {{-- Filters --}}
+        <div class="flex flex-wrap gap-2 mb-6">
+            <flux:select wire:model.live="severity_filter" class="min-w-40">
+                <flux:select.option value="">All severities</flux:select.option>
+                <flux:select.option value="must_fix">Must fix</flux:select.option>
+                <flux:select.option value="should_fix">Should fix</flux:select.option>
+                <flux:select.option value="consider">Consider</flux:select.option>
+            </flux:select>
+            <flux:select wire:model.live="scope_filter" class="min-w-40">
+                <flux:select.option value="">All scopes</flux:select.option>
+                <flux:select.option value="full">Full</flux:select.option>
+                <flux:select.option value="incremental">Incremental</flux:select.option>
+            </flux:select>
+            <flux:input wire:model.live.debounce.500ms="repo_filter" placeholder="Repo (e.g. geocodio/api)" />
+            <flux:input wire:model.live.debounce.500ms="category_filter" placeholder="Category" />
+            <flux:input wire:model.live.debounce.500ms="reviewer_filter" placeholder="Reviewer login" />
+            <div class="flex items-center gap-2">
+                <flux:switch wire:model.live="has_reactions_only" />
+                <span class="text-sm text-yak-slate">With reactions only</span>
+            </div>
+        </div>
+
+        {{-- Tabs --}}
+        <div class="flex gap-2 mb-4">
+            <button
+                wire:click="$set('active_tab', 'all')"
+                class="px-4 py-2 rounded-[14px] text-sm font-medium transition-colors {{ $active_tab === 'all' ? 'bg-yak-orange text-white' : 'text-yak-blue hover:bg-yak-cream-dark' }}"
+            >
+                All comments
+            </button>
+            <button
+                wire:click="$set('active_tab', 'by_reviewer')"
+                class="px-4 py-2 rounded-[14px] text-sm font-medium transition-colors {{ $active_tab === 'by_reviewer' ? 'bg-yak-orange text-white' : 'text-yak-blue hover:bg-yak-cream-dark' }}"
+            >
+                By reviewer
+            </button>
+        </div>
+
+        @if ($active_tab === 'all')
+            <div class="bg-white/75 backdrop-blur-[40px] backdrop-saturate-[1.4] border border-white/60 rounded-[28px] shadow-yak overflow-hidden">
+                <table class="w-full text-sm">
+                    <thead class="bg-yak-cream-dark/60">
+                        <tr>
+                            <th class="px-4 py-3 text-left font-medium text-yak-slate">PR</th>
+                            <th class="px-4 py-3 text-left font-medium text-yak-slate">File</th>
+                            <th class="px-4 py-3 text-left font-medium text-yak-slate">Severity</th>
+                            <th class="px-4 py-3 text-left font-medium text-yak-slate">Category</th>
+                            <th class="px-4 py-3 text-left font-medium text-yak-slate">Reactions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($comments as $c)
+                            <tr class="border-t border-yak-tan/20 hover:bg-yak-cream-dark/30">
+                                <td class="px-4 py-3">
+                                    <a href="{{ $c->review->pr_url ?? '#' }}" target="_blank" class="text-yak-orange hover:underline">
+                                        {{ $c->review->repo }}#{{ $c->review->pr_number ?? '?' }}
+                                    </a>
+                                </td>
+                                <td class="px-4 py-3 font-mono text-xs text-yak-slate/80">{{ $c->file_path }}:{{ $c->line_number }}</td>
+                                <td class="px-4 py-3">
+                                    <flux:badge size="sm" :variant="$c->severity === 'must_fix' ? 'danger' : ($c->severity === 'should_fix' ? 'warning' : 'outline')">
+                                        {{ $c->severity }}
+                                    </flux:badge>
+                                </td>
+                                <td class="px-4 py-3 text-yak-slate">{{ $c->category }}</td>
+                                <td class="px-4 py-3 text-yak-slate">
+                                    @if ($c->thumbs_up > 0) <span class="mr-2">👍 {{ $c->thumbs_up }}</span> @endif
+                                    @if ($c->thumbs_down > 0) <span>👎 {{ $c->thumbs_down }}</span> @endif
+                                </td>
+                            </tr>
+                        @empty
+                            <tr><td colspan="5" class="px-4 py-8 text-center text-yak-slate/60">No matching comments.</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+
+                <div class="p-4 border-t border-yak-tan/20">
+                    {{ $comments->links() }}
+                </div>
+            </div>
+        @else
+            <div class="bg-white/75 backdrop-blur-[40px] backdrop-saturate-[1.4] border border-white/60 rounded-[28px] shadow-yak overflow-hidden">
+                <table class="w-full text-sm">
+                    <thead class="bg-yak-cream-dark/60">
+                        <tr>
+                            <th class="px-4 py-3 text-left font-medium text-yak-slate">Reviewer</th>
+                            <th class="px-4 py-3 text-left font-medium text-yak-slate">Reactions</th>
+                            <th class="px-4 py-3 text-left font-medium text-yak-slate">👍</th>
+                            <th class="px-4 py-3 text-left font-medium text-yak-slate">👎</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($reviewerStats as $r)
+                            <tr class="border-t border-yak-tan/20">
+                                <td class="px-4 py-3">{{ $r->github_user_login }}</td>
+                                <td class="px-4 py-3">{{ $r->total }}</td>
+                                <td class="px-4 py-3">{{ $r->up }}</td>
+                                <td class="px-4 py-3">{{ $r->down }}</td>
+                            </tr>
+                        @empty
+                            <tr><td colspan="4" class="px-4 py-8 text-center text-yak-slate/60">No reactions yet.</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        @endif
+    @endif
+</div>

--- a/resources/views/livewire/pr-review-for-pr.blade.php
+++ b/resources/views/livewire/pr-review-for-pr.blade.php
@@ -1,0 +1,55 @@
+<div>
+    <h1 class="text-2xl font-semibold text-yak-slate mb-2">{{ $repoSlug }}#{{ $prNumber }}</h1>
+    <p class="text-yak-slate/70 mb-5">
+        <a href="https://github.com/{{ $repoSlug }}/pull/{{ $prNumber }}" target="_blank" class="text-yak-orange hover:underline">
+            View on GitHub
+        </a>
+    </p>
+
+    <div class="mb-5">
+        <flux:button wire:click="rerunReview" variant="outline">
+            Re-run review
+        </flux:button>
+    </div>
+
+    @if($reviews->isEmpty())
+        <div class="rounded-[20px] border border-yak-tan/40 bg-yak-cream-dark/40 p-8 text-center">
+            <p class="text-yak-slate">No reviews yet for this PR.</p>
+        </div>
+    @else
+        <div class="space-y-4">
+            @foreach($reviews as $review)
+                <div class="bg-white/75 backdrop-blur-[40px] backdrop-saturate-[1.4] border border-white/60 rounded-[28px] shadow-yak p-6">
+                    <div class="flex items-center justify-between mb-3">
+                        <div class="flex items-center gap-3">
+                            <flux:badge size="sm" :variant="$review->review_scope === 'full' ? 'outline' : 'primary'">
+                                {{ $review->review_scope }}
+                            </flux:badge>
+                            @if($review->dismissed_at)
+                                <flux:badge size="sm" variant="ghost">Dismissed</flux:badge>
+                            @endif
+                            <span class="text-sm text-yak-slate/70">
+                                {{ $review->submitted_at?->diffForHumans() }}
+                            </span>
+                        </div>
+                        @if($review->task)
+                            <a href="{{ route('tasks.show', $review->task) }}" class="text-sm text-yak-orange hover:underline">
+                                View task →
+                            </a>
+                        @endif
+                    </div>
+                    <div class="text-sm text-yak-slate">
+                        <strong>{{ $review->verdict }}</strong>
+                        — {{ $review->comments->count() }} finding{{ $review->comments->count() === 1 ? '' : 's' }}
+                    </div>
+                    @if($review->summary)
+                        <p class="text-sm text-yak-slate/80 mt-2">{{ $review->summary }}</p>
+                    @endif
+                    <div class="text-xs font-mono text-yak-slate/60 mt-2">
+                        sha: {{ $review->commit_sha_reviewed }}
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/repos/repo-form.blade.php
+++ b/resources/views/livewire/repos/repo-form.blade.php
@@ -169,6 +169,25 @@
                         <flux:switch wire:model="is_active" label="Active" description="Enabled" />
                     </div>
                 @endif
+                <div>
+                    <flux:switch
+                        wire:model.live="pr_review_enabled"
+                        label="PR Review"
+                        description="Have Yak review every open, non-draft pull request on this repo."
+                    />
+                </div>
+                @if($pr_review_enabled && ! ($repository?->pr_review_enabled ?? false))
+                    <div class="rounded-lg border border-yak-tan/40 bg-yak-cream-dark/40 p-3">
+                        <flux:switch wire:model="apply_to_open_prs" label="Review all currently open PRs on save" />
+                    </div>
+                @endif
+                @if($this->isEditing && $pr_review_enabled && ($repository?->pr_review_enabled ?? false))
+                    <div>
+                        <flux:button wire:click="reviewAllOpenPrs" variant="outline" size="sm">
+                            Re-review all open PRs
+                        </flux:button>
+                    </div>
+                @endif
             </div>
         </div>
 

--- a/resources/views/livewire/repos/repo-form.blade.php
+++ b/resources/views/livewire/repos/repo-form.blade.php
@@ -188,6 +188,41 @@
                         </flux:button>
                     </div>
                 @endif
+                @if($pr_review_enabled)
+                    <div class="space-y-2">
+                        <flux:label>PR review path filters</flux:label>
+
+                        @if($using_defaults)
+                            <flux:description>Using global defaults.</flux:description>
+                            <div class="flex flex-wrap gap-1">
+                                @foreach(config('yak.pr_review.default_path_excludes') as $p)
+                                    <flux:badge variant="outline" size="sm">{{ $p }}</flux:badge>
+                                @endforeach
+                            </div>
+                        @else
+                            <div class="flex flex-wrap gap-1">
+                                @foreach($path_excludes as $i => $p)
+                                    <flux:badge size="sm">
+                                        {{ $p }}
+                                        <button wire:click="removePathExclude({{ $i }})" type="button" class="ml-1">×</button>
+                                    </flux:badge>
+                                @endforeach
+                            </div>
+                        @endif
+
+                        <div class="flex items-center gap-2">
+                            <flux:input wire:model="path_exclude_input" placeholder="vendor/**" size="sm" />
+                            <flux:button wire:click="addPathExclude" variant="outline" size="sm">
+                                Add pattern
+                            </flux:button>
+                            @unless($using_defaults)
+                                <flux:button wire:click="resetPathExcludes" variant="ghost" size="sm">
+                                    Reset to defaults
+                                </flux:button>
+                            @endunless
+                        </div>
+                    </div>
+                @endif
             </div>
         </div>
 

--- a/resources/views/livewire/repos/repo-list.blade.php
+++ b/resources/views/livewire/repos/repo-list.blade.php
@@ -19,6 +19,7 @@
                     <th class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400">Default</th>
                     <th class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400">Tasks (Total)</th>
                     <th class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400">Tasks (7d)</th>
+                    <th class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400">PR Review</th>
                 </tr>
             </thead>
             <tbody class="divide-y divide-zinc-200 dark:divide-zinc-700">
@@ -62,10 +63,22 @@
                         </td>
                         <td class="px-3 py-2 tabular-nums text-zinc-700 sm:px-5 dark:text-zinc-300 {{ $repo->tasks_count === 0 ? 'text-zinc-400!' : '' }}">{{ $repo->tasks_count }}</td>
                         <td class="px-3 py-2 tabular-nums text-zinc-700 sm:px-5 dark:text-zinc-300 {{ $repo->tasks_recent_count === 0 ? 'text-zinc-400!' : '' }}">{{ $repo->tasks_recent_count }}</td>
+                        <td class="px-3 py-2 sm:px-5">
+                            @if($repo->pr_review_enabled)
+                                <div class="flex flex-col gap-0.5">
+                                    <span class="inline-block rounded-lg px-2.5 py-1 text-xs font-medium bg-[rgba(122,140,94,0.12)] text-[#7a8c5e] w-fit">On</span>
+                                    @if($repo->pr_reviews_30d_count > 0)
+                                        <span class="text-xs text-zinc-500">{{ $repo->pr_reviews_30d_count }} in 30d</span>
+                                    @endif
+                                </div>
+                            @else
+                                <span class="text-zinc-400">—</span>
+                            @endif
+                        </td>
                     </tr>
                 @empty
                     <tr>
-                        <td colspan="9" class="px-3 py-16 text-center text-zinc-500 sm:px-5 dark:text-zinc-400">
+                        <td colspan="10" class="px-3 py-16 text-center text-zinc-500 sm:px-5 dark:text-zinc-400">
                             <div class="flex flex-col items-center gap-3">
                                 <p class="text-sm">No repositories yet. Add one so Yak can clone and work on it.</p>
                                 <x-doc-link anchor="repositories.adding" class="text-sm">Adding a repository</x-doc-link>

--- a/resources/views/livewire/tasks/task-detail.blade.php
+++ b/resources/views/livewire/tasks/task-detail.blade.php
@@ -245,7 +245,7 @@
 
     {{-- Review-specific panels --}}
     @if($task->mode === \App\Enums\TaskMode::Review && $this->prReview)
-        @php($review = $this->prReview)
+        @php $review = $this->prReview; @endphp
         <div class="mb-5 rounded-[28px] border border-[rgba(200,184,154,0.4)] bg-white p-4 sm:p-7 shadow-[0_4px_6px_rgba(61,79,95,0.03),0_12px_24px_rgba(61,79,95,0.06)]">
             <h2 class="mb-4 text-lg font-medium text-yak-slate">Review output</h2>
             <dl class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
@@ -276,6 +276,11 @@
                     </div>
                 @endif
             </dl>
+            <div class="mt-4">
+                <flux:button wire:click="rerunReview" variant="outline" size="sm">
+                    Re-run review
+                </flux:button>
+            </div>
         </div>
 
         <div class="mb-5 rounded-[28px] border border-[rgba(200,184,154,0.4)] bg-white p-4 sm:p-7 shadow-[0_4px_6px_rgba(61,79,95,0.03),0_12px_24px_rgba(61,79,95,0.06)]">

--- a/resources/views/livewire/tasks/task-detail.blade.php
+++ b/resources/views/livewire/tasks/task-detail.blade.php
@@ -243,6 +243,79 @@
         </div>
     @endif
 
+    {{-- Review-specific panels --}}
+    @if($task->mode === \App\Enums\TaskMode::Review && $this->prReview)
+        @php($review = $this->prReview)
+        <div class="mb-5 rounded-[28px] border border-[rgba(200,184,154,0.4)] bg-white p-4 sm:p-7 shadow-[0_4px_6px_rgba(61,79,95,0.03),0_12px_24px_rgba(61,79,95,0.06)]">
+            <h2 class="mb-4 text-lg font-medium text-yak-slate">Review output</h2>
+            <dl class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+                <div>
+                    <dt class="text-yak-slate/70">PR</dt>
+                    <dd>
+                        <a href="{{ $review->pr_url }}" target="_blank" class="font-medium text-yak-orange hover:text-yak-orange-warm">
+                            {{ $review->repo }}#{{ $review->pr_number }}
+                        </a>
+                    </dd>
+                </div>
+                <div>
+                    <dt class="text-yak-slate/70">Verdict</dt>
+                    <dd class="text-yak-slate">{{ $review->verdict ?? '—' }}</dd>
+                </div>
+                <div>
+                    <dt class="text-yak-slate/70">Scope</dt>
+                    <dd><flux:badge size="sm" :variant="$review->review_scope === 'full' ? 'outline' : 'primary'">{{ $review->review_scope }}</flux:badge></dd>
+                </div>
+                <div>
+                    <dt class="text-yak-slate/70">Findings</dt>
+                    <dd class="text-yak-slate">{{ $review->comments->count() }}</dd>
+                </div>
+                @if($review->dismissed_at)
+                    <div>
+                        <dt class="text-yak-slate/70">Dismissed</dt>
+                        <dd class="text-yak-slate">{{ $review->dismissed_at->diffForHumans() }}</dd>
+                    </div>
+                @endif
+            </dl>
+        </div>
+
+        <div class="mb-5 rounded-[28px] border border-[rgba(200,184,154,0.4)] bg-white p-4 sm:p-7 shadow-[0_4px_6px_rgba(61,79,95,0.03),0_12px_24px_rgba(61,79,95,0.06)]">
+            <h2 class="mb-4 text-lg font-medium text-yak-slate">Review preview</h2>
+            <div class="prose prose-sm prose-yak max-w-none text-yak-slate prose-headings:text-yak-slate prose-a:text-yak-orange prose-strong:text-yak-slate">
+                {!! $this->renderedReviewBody !!}
+            </div>
+        </div>
+
+        @if($review->comments->isNotEmpty())
+            <div class="mb-5 rounded-[28px] border border-[rgba(200,184,154,0.4)] bg-white p-4 sm:p-7 shadow-[0_4px_6px_rgba(61,79,95,0.03),0_12px_24px_rgba(61,79,95,0.06)]">
+                <h2 class="mb-4 text-lg font-medium text-yak-slate">Findings</h2>
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-yak-tan/30 text-left">
+                            <th class="py-2 font-medium text-yak-slate">File</th>
+                            <th class="py-2 font-medium text-yak-slate">Severity</th>
+                            <th class="py-2 font-medium text-yak-slate">Category</th>
+                            <th class="py-2 font-medium text-yak-slate">👍/👎</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($review->comments as $c)
+                            <tr class="border-b border-yak-tan/20">
+                                <td class="py-2 font-mono text-xs">{{ $c->file_path }}:{{ $c->line_number }}</td>
+                                <td class="py-2">
+                                    <flux:badge size="sm" :variant="$c->severity === 'must_fix' ? 'danger' : ($c->severity === 'should_fix' ? 'warning' : 'outline')">
+                                        {{ $c->severity }}
+                                    </flux:badge>
+                                </td>
+                                <td class="py-2 text-yak-slate">{{ $c->category }}</td>
+                                <td class="py-2 text-yak-slate">{{ $c->thumbs_up }} / {{ $c->thumbs_down }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
+    @endif
+
     {{-- Section 6: Screenshots --}}
     @if($this->screenshots->isNotEmpty() || $this->videos->isNotEmpty())
         <div class="mb-5 rounded-[28px] border border-[rgba(200,184,154,0.4)] bg-white p-4 sm:p-7 shadow-[0_4px_6px_rgba(61,79,95,0.03),0_12px_24px_rgba(61,79,95,0.06)]">

--- a/resources/views/livewire/tasks/task-list.blade.php
+++ b/resources/views/livewire/tasks/task-list.blade.php
@@ -66,6 +66,15 @@
         </button>
         <button
             type="button"
+            wire:click="$set('tab', 'reviews')"
+            class="-mb-px inline-flex items-center gap-2 border-b-2 px-4 py-2.5 text-sm font-medium transition-colors {{ $tab === 'reviews' ? 'border-yak-orange text-yak-orange' : 'border-transparent text-yak-blue hover:text-yak-slate' }}"
+            data-testid="tab-reviews"
+        >
+            <span>PR Reviews</span>
+            <span class="rounded-full px-2 py-0.5 text-xs {{ $tab === 'reviews' ? 'bg-yak-orange/15 text-yak-orange' : 'bg-yak-cream-dark text-yak-blue' }}">{{ $this->reviewsCount }}</span>
+        </button>
+        <button
+            type="button"
             wire:click="$set('tab', 'setup')"
             class="-mb-px inline-flex items-center gap-2 border-b-2 px-4 py-2.5 text-sm font-medium transition-colors {{ $tab === 'setup' ? 'border-yak-orange text-yak-orange' : 'border-transparent text-yak-blue hover:text-yak-slate' }}"
             data-testid="tab-setup"

--- a/resources/views/prompts/tasks/review.blade.php
+++ b/resources/views/prompts/tasks/review.blade.php
@@ -1,0 +1,91 @@
+Review pull request #{{ $prNumber }} in this sandbox.
+
+**Title:** {{ $prTitle }}
+**Author:** {{ $prAuthor }}
+**Base:** {{ $baseBranch }} → **Head:** {{ $headBranch }}
+**Scope:** {{ $reviewScope }} review
+
+@if ($reviewScope === 'incremental')
+This is an **incremental review**. Only review files and changes in the range since the previous Yak review. Do NOT re-review code outside this range.
+@endif
+
+**Changed files (already filtered through path excludes):**
+```
+@foreach ($changedFiles as $f)
+- {{ $f }}
+@endforeach
+```
+
+**Diff summary:**
+```
+{{ $diffSummary }}
+```
+
+@if (! empty($repoAgentInstructions))
+**Repository-specific instructions:**
+{!! $repoAgentInstructions !!}
+@endif
+
+@if ($linearTicket !== null)
+**Linear ticket ({{ $linearTicket['identifier'] }}):**
+Title: {{ $linearTicket['title'] }}
+{{ $linearTicket['description'] }}
+
+Evaluate whether this PR accomplishes what this ticket describes. Flag drift, out-of-scope changes, or unaddressed requirements as a `should_fix` finding in the **Ticket Alignment** category.
+@endif
+
+**PR description:**
+{!! $prBody !!}
+
+---
+
+## What to do
+
+1. Read the changed files. For the incremental case, focus on changes in the diff range only.
+2. If the repository has a test suite and you can identify how to run a subset (check `CLAUDE.md` and the instructions above), run tests relevant to the changed files. Include failures as `must_fix` findings.
+3. If the repository has type checkers (`phpstan`, `tsc`) or linters (`pint`, `eslint`, `biome`), run them against changed files. Include genuine issues — skip style nits that auto-formatters will catch.
+4. Evaluate findings against the rubric below.
+5. Emit the JSON output block specified at the end.
+
+## Rubric categories
+
+- Simplicity, Test Quality, Code Duplication & Reuse, Clean Code, Code Expressiveness, Boy Scout Rule, Technology & Dependencies, Documentation, Performance & Infrastructure, Laravel Conventions, Commit Hygiene
+- **Ticket Alignment** (only when a Linear ticket is attached)
+
+## Severity buckets
+
+- **must_fix** — blocks merge; real bug, test failure, obvious security issue
+- **should_fix** — meaningful improvement but not a blocker
+- **consider** — nits and suggestions; will be bundled into a collapsed "Nitpicks" block
+
+## Rules
+
+- Do NOT commit, push, or modify any files. This is read-only analysis.
+- Maximum 20 findings total. Cull ruthlessly.
+- Skip any file matching `pathExcludes`: @json($pathExcludes)
+- Use ` ```suggestion ` blocks only when the change is 1–10 lines AND inside the relevant diff hunk. Populate `suggestion_loc` with the line count.
+- Do not flag formatting-only issues that Pint / Prettier / Biome will auto-fix.
+
+## Output
+
+Emit exactly one JSON code fence at the end of your reply, with this shape:
+
+```json
+{
+  "summary": "One- or two-paragraph walkthrough of what the PR does. Sized to complexity.",
+  "verdict": "Approve" | "Approve with suggestions" | "Request changes",
+  "verdict_detail": "One-line justification.",
+  "findings": [
+    {
+      "file": "app/Services/Foo.php",
+      "line": 87,
+      "severity": "should_fix",
+      "category": "Simplicity",
+      "body": "Comment text. May contain a fenced suggestion block.",
+      "suggestion_loc": 3
+    }
+  ]
+}
+```
+
+If a finding is not a suggestion, omit `suggestion_loc`.

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1199,7 +1199,7 @@
                 <span><span class="dot d-linear"></span>Linear</span>
                 <span><span class="dot d-sentry"></span>Sentry</span>
                 <span><span class="dot d-github"></span>GitHub</span>
-                <span style="color: color-mix(in srgb, var(--yak-slate) 55%, transparent); font-style: italic;">+ flaky tests, research mode</span>
+                <span style="color: color-mix(in srgb, var(--yak-slate) 55%, transparent); font-style: italic;">+ flaky tests, research mode, PR reviews</span>
             </div>
         </div>
     </div>
@@ -1427,6 +1427,48 @@
                     <li>Bigger investigations produce a self-contained HTML findings page with file references, charts, risks, and an effort estimate.</li>
                     <li>Explicit overrides still work: a <span class="mono" style="color: var(--yak-orange); font-size: 14.5px;">research</span> label on Linear or a <span class="mono" style="color: var(--yak-orange); font-size: 14.5px;">research:</span> prefix in Slack skips the classifier.</li>
                 </ul>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section>
+    <div class="container">
+        <div class="pull-row">
+            <div>
+                <span class="eyebrow">Reviews PRs, too</span>
+                <h3 style="margin-top:14px;">Every open PR gets a <em>rubric-driven</em> review — with <em>suggestion</em> blocks.</h3>
+                <p>
+                    Flip a switch on a repo and Yak reviews every non-draft PR.
+                    Findings land as GitHub line-level comments with category
+                    and severity labels; one-to-ten-line fixes come through as
+                    native <span class="mono" style="color: var(--yak-orange); font-size: 14.5px;">suggestion</span> blocks you can commit with a click.
+                </p>
+                <ul class="bullets">
+                    <li>Incremental on <span class="mono" style="color: var(--yak-orange); font-size: 14.5px;">synchronize</span>: only new commits get re-reviewed. Force-pushes safely fall back to a full review.</li>
+                    <li>Runs in the same sandbox as fixes, so it can actually run the tests and linters for the files the PR touches.</li>
+                    <li>Reaction counts (👍 / 👎) are tracked — the dashboard shows which kinds of feedback your team finds useful.</li>
+                </ul>
+            </div>
+
+            <div class="autopickup">
+                <h4>Yak · <span class="mono" style="color: var(--yak-orange);">geocodio/api #412</span></h4>
+                <p style="margin: 14px 0 10px; font-family: var(--font-mono); font-size: 12.5px; color: color-mix(in srgb, var(--yak-slate) 70%, transparent);">
+                    app/Services/GeocodeClient.php:87
+                </p>
+                <p style="margin: 0 0 14px;">
+                    <span class="mono" style="padding: 2px 6px; border-radius: 4px; background: color-mix(in srgb, var(--yak-orange) 18%, transparent); color: var(--yak-orange); font-size: 11.5px;">Performance</span>
+                    <span class="mono" style="padding: 2px 6px; border-radius: 4px; background: color-mix(in srgb, var(--yak-slate) 18%, transparent); color: var(--yak-slate); font-size: 11.5px; margin-left: 6px;">should_fix</span>
+                </p>
+                <p style="margin: 0 0 10px;">
+                    Retry loop re-creates the <span class="mono" style="font-size:12.5px; color: var(--yak-orange);">Http::withHeaders</span> call on each attempt, losing connection reuse.
+                </p>
+                <pre style="margin: 0; padding: 10px 12px; background: color-mix(in srgb, var(--yak-slate) 6%, transparent); border-radius: 8px; font-family: var(--font-mono); font-size: 12px; color: var(--yak-slate); overflow: auto;">```suggestion
+$client = Http::withHeaders($headers);
+foreach (range(1, 3) as $attempt) {
+    $response = $client->get($url);
+}
+```</pre>
             </div>
         </div>
     </div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Jobs\PollPullRequestReactionsJob;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
@@ -20,3 +21,4 @@ Schedule::command('yak:timeout-ci')->everyFifteenMinutes();
 Schedule::command('yak:healthcheck')->everyFifteenMinutes();
 Schedule::command('yak:scan-ci')->everyTwoHours();
 Schedule::command('yak:poll-drone-ci')->everyMinute()->withoutOverlapping();
+Schedule::job(PollPullRequestReactionsJob::class)->hourly()->name('poll-pr-reactions');

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Livewire\CostDashboard;
 use App\Livewire\Health;
 use App\Livewire\PromptEditor;
 use App\Livewire\PrReviewFeedback;
+use App\Livewire\PrReviewForPr;
 use App\Livewire\Repos\RepoForm;
 use App\Livewire\Repos\RepoList;
 use App\Livewire\Skills;
@@ -43,6 +44,10 @@ Route::middleware(['auth'])->group(function () {
     Route::livewire('prompts', PromptEditor::class)->name('prompts');
     Route::livewire('skills', Skills::class)->name('skills');
     Route::livewire('pr-reviews', PrReviewFeedback::class)->name('pr-reviews');
+    Route::livewire('pr-reviews/for/{repoSlug}/{prNumber}', PrReviewForPr::class)
+        ->name('pr-reviews.for-pr')
+        ->where('repoSlug', '.+')
+        ->where('prNumber', '[0-9]+');
 
     Route::get('auth/linear', [LinearOAuthController::class, 'redirect'])->name('auth.linear.redirect');
     Route::get('auth/linear/callback', [LinearOAuthController::class, 'callback'])->name('auth.linear.callback');

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Livewire\Channels\ChannelList;
 use App\Livewire\CostDashboard;
 use App\Livewire\Health;
 use App\Livewire\PromptEditor;
+use App\Livewire\PrReviewFeedback;
 use App\Livewire\Repos\RepoForm;
 use App\Livewire\Repos\RepoList;
 use App\Livewire\Skills;
@@ -41,6 +42,7 @@ Route::middleware(['auth'])->group(function () {
     Route::livewire('channels', ChannelList::class)->name('channels');
     Route::livewire('prompts', PromptEditor::class)->name('prompts');
     Route::livewire('skills', Skills::class)->name('skills');
+    Route::livewire('pr-reviews', PrReviewFeedback::class)->name('pr-reviews');
 
     Route::get('auth/linear', [LinearOAuthController::class, 'redirect'])->name('auth.linear.redirect');
     Route::get('auth/linear/callback', [LinearOAuthController::class, 'callback'])->name('auth.linear.callback');

--- a/tests/Feature/Actions/ApplyPrReviewToOpenPullsTest.php
+++ b/tests/Feature/Actions/ApplyPrReviewToOpenPullsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Actions\ApplyPrReviewToOpenPulls;
+use App\Enums\TaskMode;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\GitHubAppService;
+use Illuminate\Support\Facades\Bus;
+
+beforeEach(function () {
+    config()->set('yak.channels.github.installation_id', 12345);
+    config()->set('yak.channels.github.app_bot_login', 'yak-bot[bot]');
+});
+
+it('enqueues review tasks for each open non-draft non-Yak PR', function () {
+    Bus::fake();
+
+    $repo = Repository::factory()->create([
+        'slug' => 'geocodio/api',
+        'pr_review_enabled' => true,
+        'is_active' => true,
+    ]);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('listOpenPullRequests')->andReturn([
+        ['number' => 1, 'html_url' => 'u1', 'title' => '', 'body' => '', 'draft' => false, 'user' => ['login' => 'maria'], 'head' => ['ref' => 'h1', 'sha' => 's1'], 'base' => ['ref' => 'main', 'sha' => 'b1']],
+        ['number' => 2, 'html_url' => 'u2', 'title' => '', 'body' => '', 'draft' => true, 'user' => ['login' => 'maria'], 'head' => ['ref' => 'h2', 'sha' => 's2'], 'base' => ['ref' => 'main', 'sha' => 'b2']],
+        ['number' => 3, 'html_url' => 'u3', 'title' => '', 'body' => '', 'draft' => false, 'user' => ['login' => 'yak-bot[bot]'], 'head' => ['ref' => 'h3', 'sha' => 's3'], 'base' => ['ref' => 'main', 'sha' => 'b3']],
+    ]);
+    app()->instance(GitHubAppService::class, $github);
+
+    app(ApplyPrReviewToOpenPulls::class)($repo);
+
+    expect(YakTask::where('mode', TaskMode::Review)->count())->toBe(1);
+});

--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -118,3 +118,21 @@ test('github channel has required credential fields', function () {
     expect($github)->toHaveKeys(['driver', 'app_id', 'private_key', 'webhook_secret'])
         ->and($github['driver'])->toBe('github');
 });
+
+/*
+|--------------------------------------------------------------------------
+| PR Review Configuration
+|--------------------------------------------------------------------------
+*/
+
+it('has pr_review config defaults', function () {
+    expect(config('yak.pr_review.reaction_poll_window_days'))->toBe(30)
+        ->and(config('yak.pr_review.max_findings_per_review'))->toBe(20)
+        ->and(config('yak.pr_review.enabled_globally'))->toBeTrue()
+        ->and(config('yak.pr_review.default_path_excludes'))->toBeArray()
+        ->and(config('yak.pr_review.default_path_excludes'))->toContain('vendor/**');
+});
+
+it('has github app_bot_login config key', function () {
+    expect(config('yak.channels.github.app_bot_login'))->not->toBeNull();
+});

--- a/tests/Feature/CostDashboardTest.php
+++ b/tests/Feature/CostDashboardTest.php
@@ -141,7 +141,7 @@ test('source filter narrows results', function () {
 
 test('guests cannot access cost dashboard', function () {
     auth()->logout();
-    $this->get('/costs')->assertRedirect('/auth/google');
+    $this->get('/costs')->assertRedirect('/login');
 });
 
 test('success rate is calculated correctly', function () {

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -6,7 +6,7 @@ test('guests see the login page at the homepage', function () {
     $response = $this->get(route('home'));
 
     $response->assertOk();
-    $response->assertSee('Continue with Google');
+    $response->assertSee('Sign in');
 });
 
 test('authenticated users are redirected from homepage to tasks', function () {

--- a/tests/Feature/GitHubPrReviewWebhookTest.php
+++ b/tests/Feature/GitHubPrReviewWebhookTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\TaskMode;
+use App\Models\PrReview;
 use App\Models\Repository;
 use App\Models\YakTask;
 use Illuminate\Support\Facades\Bus;
@@ -126,6 +127,122 @@ it('skips when the repo has pr_review_enabled = false', function () {
     ])->assertOk();
 
     expect(YakTask::count())->toBe(0);
+});
+
+it('triggers on ready_for_review', function () {
+    Bus::fake();
+    Repository::factory()->create(['slug' => 'geocodio/api', 'is_active' => true, 'pr_review_enabled' => true]);
+
+    $payload = [
+        'action' => 'ready_for_review',
+        'pull_request' => [
+            'html_url' => 'https://github.com/geocodio/api/pull/10',
+            'draft' => false, 'user' => ['login' => 'm'],
+            'head' => ['ref' => 'x', 'sha' => 'a'], 'base' => ['ref' => 'main', 'sha' => 'b'],
+            'number' => 10, 'title' => '', 'body' => '',
+        ],
+        'repository' => ['full_name' => 'geocodio/api'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signGhPayload($body),
+    ])->assertOk();
+
+    $task = YakTask::where('mode', TaskMode::Review)->first();
+    expect(json_decode($task->context, true)['review_scope'])->toBe('full');
+});
+
+it('triggers full review on reopened', function () {
+    Bus::fake();
+    Repository::factory()->create(['slug' => 'geocodio/api', 'is_active' => true, 'pr_review_enabled' => true]);
+
+    $payload = [
+        'action' => 'reopened',
+        'pull_request' => [
+            'html_url' => 'https://github.com/geocodio/api/pull/11',
+            'draft' => false, 'user' => ['login' => 'm'],
+            'head' => ['ref' => 'x', 'sha' => 'a'], 'base' => ['ref' => 'main', 'sha' => 'b'],
+            'number' => 11, 'title' => '', 'body' => '',
+        ],
+        'repository' => ['full_name' => 'geocodio/api'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signGhPayload($body),
+    ])->assertOk();
+
+    $task = YakTask::where('mode', TaskMode::Review)->first();
+    expect(json_decode($task->context, true)['review_scope'])->toBe('full');
+});
+
+it('triggers incremental review on synchronize when prior exists', function () {
+    Bus::fake();
+    $repo = Repository::factory()->create(['slug' => 'geocodio/api', 'is_active' => true, 'pr_review_enabled' => true]);
+
+    $priorTask = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => $repo->slug,
+        'pr_url' => 'https://github.com/geocodio/api/pull/20',
+    ]);
+
+    PrReview::factory()->create([
+        'yak_task_id' => $priorTask->id,
+        'pr_url' => 'https://github.com/geocodio/api/pull/20',
+        'commit_sha_reviewed' => 'old-sha',
+    ]);
+
+    $payload = [
+        'action' => 'synchronize',
+        'pull_request' => [
+            'html_url' => 'https://github.com/geocodio/api/pull/20',
+            'draft' => false, 'user' => ['login' => 'm'],
+            'head' => ['ref' => 'x', 'sha' => 'new-sha'], 'base' => ['ref' => 'main', 'sha' => 'b'],
+            'number' => 20, 'title' => '', 'body' => '',
+        ],
+        'repository' => ['full_name' => 'geocodio/api'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signGhPayload($body),
+    ])->assertOk();
+
+    $task = YakTask::where('mode', TaskMode::Review)->latest()->first();
+    $ctx = json_decode($task->context, true);
+    expect($ctx['review_scope'])->toBe('incremental')
+        ->and($ctx['incremental_base_sha'])->toBe('old-sha');
+});
+
+it('falls back to full on synchronize when no prior review exists', function () {
+    Bus::fake();
+    Repository::factory()->create(['slug' => 'geocodio/api', 'is_active' => true, 'pr_review_enabled' => true]);
+
+    $payload = [
+        'action' => 'synchronize',
+        'pull_request' => [
+            'html_url' => 'https://github.com/geocodio/api/pull/21',
+            'draft' => false, 'user' => ['login' => 'm'],
+            'head' => ['ref' => 'x', 'sha' => 'new-sha'], 'base' => ['ref' => 'main', 'sha' => 'b'],
+            'number' => 21, 'title' => '', 'body' => '',
+        ],
+        'repository' => ['full_name' => 'geocodio/api'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signGhPayload($body),
+    ])->assertOk();
+
+    $task = YakTask::where('mode', TaskMode::Review)->first();
+    $ctx = json_decode($task->context, true);
+    expect($ctx['review_scope'])->toBe('full')
+        ->and($ctx['incremental_base_sha'])->toBeNull();
 });
 
 it('dedups same PR + head SHA', function () {

--- a/tests/Feature/GitHubPrReviewWebhookTest.php
+++ b/tests/Feature/GitHubPrReviewWebhookTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use App\Enums\TaskMode;
+use App\Models\Repository;
+use App\Models\YakTask;
+use Illuminate\Support\Facades\Bus;
+
+beforeEach(function () {
+    config()->set('yak.channels.github.webhook_secret', 'secret');
+    config()->set('yak.channels.github.app_bot_login', 'yak-bot[bot]');
+});
+
+function signGhPayload(string $payload): string
+{
+    return 'sha256=' . hash_hmac('sha256', $payload, 'secret');
+}
+
+it('enqueues a full review task for pull_request.opened on a non-draft PR', function () {
+    Bus::fake();
+
+    Repository::factory()->create([
+        'slug' => 'geocodio/api',
+        'is_active' => true,
+        'pr_review_enabled' => true,
+        'git_url' => 'https://github.com/geocodio/api.git',
+    ]);
+
+    $payload = [
+        'action' => 'opened',
+        'pull_request' => [
+            'html_url' => 'https://github.com/geocodio/api/pull/1',
+            'number' => 1,
+            'title' => 'T',
+            'body' => 'B',
+            'draft' => false,
+            'user' => ['login' => 'mathias'],
+            'head' => ['ref' => 'feat/x', 'sha' => 'aaa'],
+            'base' => ['ref' => 'main', 'sha' => 'bbb'],
+        ],
+        'repository' => ['full_name' => 'geocodio/api'],
+    ];
+    $body = json_encode($payload);
+
+    $response = $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signGhPayload($body),
+    ]);
+
+    $response->assertOk();
+
+    expect(YakTask::where('mode', TaskMode::Review)->count())->toBe(1);
+});
+
+it('skips draft PRs', function () {
+    Bus::fake();
+
+    Repository::factory()->create(['slug' => 'geocodio/api', 'is_active' => true, 'pr_review_enabled' => true]);
+
+    $payload = [
+        'action' => 'opened',
+        'pull_request' => [
+            'html_url' => 'https://github.com/geocodio/api/pull/2',
+            'draft' => true,
+            'user' => ['login' => 'mathias'],
+            'head' => ['ref' => 'x', 'sha' => 'a'], 'base' => ['ref' => 'main', 'sha' => 'b'],
+            'number' => 2, 'title' => '', 'body' => '',
+        ],
+        'repository' => ['full_name' => 'geocodio/api'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signGhPayload($body),
+    ])->assertOk();
+
+    expect(YakTask::count())->toBe(0);
+});
+
+it('skips Yak-authored PRs', function () {
+    Bus::fake();
+
+    Repository::factory()->create(['slug' => 'geocodio/api', 'is_active' => true, 'pr_review_enabled' => true]);
+
+    $payload = [
+        'action' => 'opened',
+        'pull_request' => [
+            'html_url' => 'https://github.com/geocodio/api/pull/3',
+            'draft' => false,
+            'user' => ['login' => 'yak-bot[bot]'],
+            'head' => ['ref' => 'x', 'sha' => 'a'], 'base' => ['ref' => 'main', 'sha' => 'b'],
+            'number' => 3, 'title' => '', 'body' => '',
+        ],
+        'repository' => ['full_name' => 'geocodio/api'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signGhPayload($body),
+    ])->assertOk();
+
+    expect(YakTask::count())->toBe(0);
+});
+
+it('skips when the repo has pr_review_enabled = false', function () {
+    Bus::fake();
+
+    Repository::factory()->create(['slug' => 'geocodio/api', 'is_active' => true, 'pr_review_enabled' => false]);
+
+    $payload = [
+        'action' => 'opened',
+        'pull_request' => [
+            'html_url' => 'https://github.com/geocodio/api/pull/4',
+            'draft' => false, 'user' => ['login' => 'mathias'],
+            'head' => ['ref' => 'x', 'sha' => 'a'], 'base' => ['ref' => 'main', 'sha' => 'b'],
+            'number' => 4, 'title' => '', 'body' => '',
+        ],
+        'repository' => ['full_name' => 'geocodio/api'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signGhPayload($body),
+    ])->assertOk();
+
+    expect(YakTask::count())->toBe(0);
+});
+
+it('dedups same PR + head SHA', function () {
+    Bus::fake();
+
+    $repo = Repository::factory()->create(['slug' => 'geocodio/api', 'is_active' => true, 'pr_review_enabled' => true]);
+
+    YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => $repo->slug,
+        'external_id' => 'https://github.com/geocodio/api/pull/5',
+        'pr_url' => 'https://github.com/geocodio/api/pull/5',
+        'status' => 'pending',
+        'context' => json_encode(['head_sha' => 'same-sha']),
+    ]);
+
+    $payload = [
+        'action' => 'opened',
+        'pull_request' => [
+            'html_url' => 'https://github.com/geocodio/api/pull/5',
+            'draft' => false, 'user' => ['login' => 'mathias'],
+            'head' => ['ref' => 'x', 'sha' => 'same-sha'],
+            'base' => ['ref' => 'main', 'sha' => 'b'],
+            'number' => 5, 'title' => '', 'body' => '',
+        ],
+        'repository' => ['full_name' => 'geocodio/api'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signGhPayload($body),
+    ])->assertOk();
+
+    expect(YakTask::where('mode', TaskMode::Review)->count())->toBe(1);
+});

--- a/tests/Feature/Jobs/PollPullRequestReactionsJobTest.php
+++ b/tests/Feature/Jobs/PollPullRequestReactionsJobTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Jobs\PollPullRequestReactionsJob;
+use App\Models\PrReview;
+use App\Models\PrReviewComment;
+use App\Models\PrReviewCommentReaction;
+use App\Services\GitHubAppService;
+
+beforeEach(function () {
+    config()->set('yak.channels.github.installation_id', 12345);
+    config()->set('yak.pr_review.reaction_poll_window_days', 30);
+});
+
+it('creates new reactions and updates denormalized counts', function () {
+    $review = PrReview::factory()->create(['repo' => 'geocodio/api']);
+    $comment = PrReviewComment::factory()->create([
+        'pr_review_id' => $review->id,
+        'github_comment_id' => 555,
+        'thumbs_up' => 0,
+        'thumbs_down' => 0,
+    ]);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('listCommentReactions')
+        ->with(12345, 'geocodio/api', 555)
+        ->andReturn([
+            ['id' => 1, 'user' => ['login' => 'maria', 'id' => 1], 'content' => '+1', 'created_at' => '2026-04-17T00:00:00Z'],
+            ['id' => 2, 'user' => ['login' => 'bob', 'id' => 2], 'content' => '+1', 'created_at' => '2026-04-17T00:00:00Z'],
+            ['id' => 3, 'user' => ['login' => 'eve', 'id' => 3], 'content' => '-1', 'created_at' => '2026-04-17T00:00:00Z'],
+        ]);
+    app()->instance(GitHubAppService::class, $github);
+
+    (new PollPullRequestReactionsJob)->handle($github);
+
+    $comment->refresh();
+    expect($comment->thumbs_up)->toBe(2)
+        ->and($comment->thumbs_down)->toBe(1)
+        ->and($comment->last_polled_at)->not->toBeNull()
+        ->and(PrReviewCommentReaction::count())->toBe(3);
+});
+
+it('deletes reactions that no longer exist on GitHub', function () {
+    $review = PrReview::factory()->create(['repo' => 'geocodio/api']);
+    $comment = PrReviewComment::factory()->create([
+        'pr_review_id' => $review->id,
+        'github_comment_id' => 777,
+    ]);
+
+    // Existing reaction we'll delete
+    PrReviewCommentReaction::create([
+        'pr_review_comment_id' => $comment->id,
+        'github_reaction_id' => 99,
+        'github_user_login' => 'stale',
+        'github_user_id' => 100,
+        'content' => '+1',
+        'reacted_at' => now(),
+    ]);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('listCommentReactions')->andReturn([]); // GitHub says no reactions
+    app()->instance(GitHubAppService::class, $github);
+
+    (new PollPullRequestReactionsJob)->handle($github);
+
+    expect(PrReviewCommentReaction::count())->toBe(0)
+        ->and($comment->fresh()->thumbs_up)->toBe(0);
+});
+
+it('skips non-thumb reactions', function () {
+    $review = PrReview::factory()->create(['repo' => 'geocodio/api']);
+    $comment = PrReviewComment::factory()->create([
+        'pr_review_id' => $review->id,
+        'github_comment_id' => 888,
+    ]);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('listCommentReactions')->andReturn([
+        ['id' => 1, 'user' => ['login' => 'm', 'id' => 1], 'content' => 'laugh', 'created_at' => '2026-04-17T00:00:00Z'],
+        ['id' => 2, 'user' => ['login' => 'b', 'id' => 2], 'content' => '+1', 'created_at' => '2026-04-17T00:00:00Z'],
+    ]);
+    app()->instance(GitHubAppService::class, $github);
+
+    (new PollPullRequestReactionsJob)->handle($github);
+
+    expect(PrReviewCommentReaction::count())->toBe(1);
+});
+
+it('excludes comments from PRs closed outside the window', function () {
+    $oldReview = PrReview::factory()->create([
+        'repo' => 'geocodio/api',
+        'pr_closed_at' => now()->subDays(45),
+    ]);
+    PrReviewComment::factory()->create(['pr_review_id' => $oldReview->id, 'github_comment_id' => 1000]);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldNotReceive('listCommentReactions');
+    app()->instance(GitHubAppService::class, $github);
+
+    (new PollPullRequestReactionsJob)->handle($github);
+});

--- a/tests/Feature/Jobs/RunYakReviewJobDismissTest.php
+++ b/tests/Feature/Jobs/RunYakReviewJobDismissTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Contracts\AgentRunner;
+use App\DataTransferObjects\AgentRunResult;
+use App\Enums\TaskMode;
+use App\Jobs\RunYakReviewJob;
+use App\Models\PrReview;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\GitHubAppService;
+use App\Services\IncusSandboxManager;
+use Illuminate\Support\Facades\Process;
+
+beforeEach(function () {
+    config()->set('yak.channels.github.installation_id', 12345);
+    config()->set('yak.sandbox.workspace_path', '/workspace');
+});
+
+function setUpReviewJobMocks(string $scope = 'full'): YakTask
+{
+    $repo = Repository::factory()->create([
+        'slug' => 'geocodio/api',
+        'pr_review_enabled' => true,
+        'default_branch' => 'main',
+        'ci_system' => 'none',
+        'is_active' => true,
+    ]);
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => $repo->slug,
+        'pr_url' => 'https://github.com/geocodio/api/pull/99',
+        'external_id' => 'https://github.com/geocodio/api/pull/99',
+        'branch_name' => 'feat/x',
+        'context' => json_encode([
+            'pr_number' => 99,
+            'head_sha' => 'new-head',
+            'base_sha' => 'base',
+            'author' => 'mathias',
+            'title' => 't',
+            'body' => 'b',
+            'review_scope' => $scope,
+            'incremental_base_sha' => $scope === 'incremental' ? 'old-head' : null,
+        ]),
+    ]);
+
+    $sandbox = mock(IncusSandboxManager::class);
+    $sandbox->shouldReceive('create')->andReturn('yak-task-' . $task->id);
+    $sandbox->shouldReceive('run')->andReturn(
+        Process::result(output: "app/Foo.php\n", exitCode: 0),
+    );
+    $sandbox->shouldReceive('destroy');
+    app()->instance(IncusSandboxManager::class, $sandbox);
+
+    $agent = mock(AgentRunner::class);
+    $agent->shouldReceive('run')->andReturn(new AgentRunResult(
+        sessionId: 's-1',
+        resultSummary: "```json\n{\"summary\":\"ok\",\"verdict\":\"Approve\",\"verdict_detail\":\"ok\",\"findings\":[]}\n```",
+        costUsd: 0.01,
+        numTurns: 1,
+        durationMs: 100,
+        isError: false,
+        clarificationNeeded: false,
+        clarificationOptions: [],
+        rawOutput: '',
+    ));
+    app()->instance(AgentRunner::class, $agent);
+
+    return $task;
+}
+
+it('dismisses prior non-dismissed reviews on a full-scope run', function () {
+    $task = setUpReviewJobMocks('full');
+
+    $priorTask = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => 'geocodio/api',
+        'pr_url' => $task->pr_url,
+    ]);
+
+    $prior = PrReview::factory()->create([
+        'yak_task_id' => $priorTask->id,
+        'repo' => 'geocodio/api',
+        'pr_number' => 99,
+        'pr_url' => $task->pr_url,
+        'github_review_id' => 1234,
+        'commit_sha_reviewed' => 'old-head',
+    ]);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('getInstallationToken')->andReturn('tok');
+    $github->shouldReceive('createPullRequestReview')->andReturn([
+        'id' => 5678,
+        'comments' => [],
+    ]);
+    $github->shouldReceive('dismissPullRequestReview')
+        ->once()
+        ->with(12345, 'geocodio/api', 99, 1234, 'Superseded by newer commits');
+    app()->instance(GitHubAppService::class, $github);
+
+    (new RunYakReviewJob($task))->handle(app(AgentRunner::class));
+
+    expect($prior->fresh()->dismissed_at)->not->toBeNull();
+});
+
+it('does NOT dismiss prior reviews on an incremental-scope run', function () {
+    $task = setUpReviewJobMocks('incremental');
+
+    $priorTask = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => 'geocodio/api',
+        'pr_url' => $task->pr_url,
+    ]);
+
+    $prior = PrReview::factory()->create([
+        'yak_task_id' => $priorTask->id,
+        'repo' => 'geocodio/api',
+        'pr_number' => 99,
+        'pr_url' => $task->pr_url,
+        'github_review_id' => 1234,
+        'commit_sha_reviewed' => 'old-head',
+    ]);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('getInstallationToken')->andReturn('tok');
+    $github->shouldReceive('createPullRequestReview')->andReturn([
+        'id' => 5678,
+        'comments' => [],
+    ]);
+    $github->shouldNotReceive('dismissPullRequestReview');
+    app()->instance(GitHubAppService::class, $github);
+
+    (new RunYakReviewJob($task))->handle(app(AgentRunner::class));
+
+    expect($prior->fresh()->dismissed_at)->toBeNull();
+});

--- a/tests/Feature/Jobs/RunYakReviewJobIncrementalTest.php
+++ b/tests/Feature/Jobs/RunYakReviewJobIncrementalTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Contracts\AgentRunner;
+use App\DataTransferObjects\AgentRunResult;
+use App\Enums\TaskMode;
+use App\Jobs\RunYakReviewJob;
+use App\Models\PrReview;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\GitHubAppService;
+use App\Services\IncusSandboxManager;
+use Illuminate\Support\Facades\Process;
+
+beforeEach(function () {
+    config()->set('yak.channels.github.installation_id', 12345);
+    config()->set('yak.sandbox.workspace_path', '/workspace');
+});
+
+it('computes diff against incremental_base_sha in incremental scope', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'geocodio/api',
+        'pr_review_enabled' => true,
+        'default_branch' => 'main',
+        'is_active' => true,
+    ]);
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => $repo->slug,
+        'pr_url' => 'https://github.com/geocodio/api/pull/50',
+        'external_id' => 'https://github.com/geocodio/api/pull/50',
+        'branch_name' => 'feat/x',
+        'context' => json_encode([
+            'pr_number' => 50,
+            'head_sha' => 'new-head',
+            'base_sha' => 'pr-base',
+            'author' => 'mathias',
+            'title' => 't',
+            'body' => 'b',
+            'review_scope' => 'incremental',
+            'incremental_base_sha' => 'old-head',
+        ]),
+    ]);
+
+    $capturedCommands = [];
+    $sandbox = mock(IncusSandboxManager::class);
+    $sandbox->shouldReceive('create')->andReturn('container');
+    $sandbox->shouldReceive('run')->andReturnUsing(function ($name, $cmd) use (&$capturedCommands) {
+        $capturedCommands[] = $cmd;
+
+        return Process::result(output: "app/Foo.php\n", exitCode: 0);
+    });
+    $sandbox->shouldReceive('destroy');
+    app()->instance(IncusSandboxManager::class, $sandbox);
+
+    $agent = mock(AgentRunner::class);
+    $agent->shouldReceive('run')->andReturn(new AgentRunResult(
+        sessionId: 's',
+        resultSummary: "```json\n{\"summary\":\"ok\",\"verdict\":\"Approve\",\"verdict_detail\":\"ok\",\"findings\":[]}\n```",
+        costUsd: 0.01, numTurns: 1, durationMs: 100,
+        isError: false, clarificationNeeded: false, clarificationOptions: [], rawOutput: '',
+    ));
+    app()->instance(AgentRunner::class, $agent);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('getInstallationToken')->andReturn('tok');
+    $github->shouldReceive('createPullRequestReview')->andReturn(['id' => 5, 'comments' => []]);
+    app()->instance(GitHubAppService::class, $github);
+
+    (new RunYakReviewJob($task))->handle(app(AgentRunner::class));
+
+    $diffCommands = array_filter($capturedCommands, fn ($c) => str_contains($c, 'git diff'));
+    $commandsText = implode("\n", $diffCommands);
+
+    expect($commandsText)->toContain("'old-head'")
+        ->and($commandsText)->not->toContain("'pr-base'");
+});
+
+it('falls back to full review when incremental base fetch fails', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'geocodio/api',
+        'pr_review_enabled' => true,
+        'default_branch' => 'main',
+        'is_active' => true,
+    ]);
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => $repo->slug,
+        'pr_url' => 'https://github.com/geocodio/api/pull/51',
+        'external_id' => 'https://github.com/geocodio/api/pull/51',
+        'branch_name' => 'feat/x',
+        'context' => json_encode([
+            'pr_number' => 51,
+            'head_sha' => 'new-head',
+            'base_sha' => 'pr-base',
+            'author' => 'mathias',
+            'title' => 't',
+            'body' => 'b',
+            'review_scope' => 'incremental',
+            'incremental_base_sha' => 'missing-sha',
+        ]),
+    ]);
+
+    $sandbox = mock(IncusSandboxManager::class);
+    $sandbox->shouldReceive('create')->andReturn('container');
+    $sandbox->shouldReceive('run')->andReturnUsing(function ($name, $cmd) {
+        if (str_contains($cmd, 'git fetch origin ') && str_contains($cmd, 'missing-sha')) {
+            return Process::result(output: '', errorOutput: 'fatal: no such ref', exitCode: 1);
+        }
+
+        return Process::result(output: "app/Foo.php\n", exitCode: 0);
+    });
+    $sandbox->shouldReceive('destroy');
+    app()->instance(IncusSandboxManager::class, $sandbox);
+
+    $agent = mock(AgentRunner::class);
+    $agent->shouldReceive('run')->andReturn(new AgentRunResult(
+        sessionId: 's',
+        resultSummary: "```json\n{\"summary\":\"ok\",\"verdict\":\"Approve\",\"verdict_detail\":\"ok\",\"findings\":[]}\n```",
+        costUsd: 0.01, numTurns: 1, durationMs: 100,
+        isError: false, clarificationNeeded: false, clarificationOptions: [], rawOutput: '',
+    ));
+    app()->instance(AgentRunner::class, $agent);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('getInstallationToken')->andReturn('tok');
+    $github->shouldReceive('createPullRequestReview')->andReturn(['id' => 5, 'comments' => []]);
+    app()->instance(GitHubAppService::class, $github);
+
+    (new RunYakReviewJob($task))->handle(app(AgentRunner::class));
+
+    $review = PrReview::where('yak_task_id', $task->id)->first();
+    expect($review->review_scope)->toBe('full')
+        ->and($review->incremental_base_sha)->toBeNull();
+});

--- a/tests/Feature/Jobs/RunYakReviewJobTest.php
+++ b/tests/Feature/Jobs/RunYakReviewJobTest.php
@@ -11,6 +11,7 @@ use App\Models\Repository;
 use App\Models\YakTask;
 use App\Services\GitHubAppService;
 use App\Services\IncusSandboxManager;
+use App\Services\LinearIssueFetcher;
 use Illuminate\Support\Facades\Process;
 
 beforeEach(function () {
@@ -84,4 +85,105 @@ it('runs a full-scope review end to end', function () {
     expect($task->status)->toBe(TaskStatus::Success)
         ->and(PrReview::where('yak_task_id', $task->id)->exists())->toBeTrue()
         ->and(PrReviewComment::count())->toBe(1);
+});
+
+it('does not fetch Linear ticket when no identifier is present', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'geocodio/api',
+        'pr_review_enabled' => true,
+        'default_branch' => 'main',
+        'is_active' => true,
+    ]);
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => $repo->slug,
+        'pr_url' => 'https://github.com/geocodio/api/pull/60',
+        'external_id' => 'https://github.com/geocodio/api/pull/60',
+        'branch_name' => 'feat/x',
+        'context' => json_encode([
+            'pr_number' => 60,
+            'head_sha' => 'h', 'base_sha' => 'b',
+            'author' => 'm', 'title' => 'plain title', 'body' => 'no ticket here',
+            'review_scope' => 'full', 'incremental_base_sha' => null,
+        ]),
+    ]);
+
+    $sandbox = mock(IncusSandboxManager::class);
+    $sandbox->shouldReceive('create')->andReturn('c');
+    $sandbox->shouldReceive('run')->andReturn(Process::result(output: '', exitCode: 0));
+    $sandbox->shouldReceive('destroy');
+    app()->instance(IncusSandboxManager::class, $sandbox);
+
+    $fetcher = mock(LinearIssueFetcher::class);
+    $fetcher->shouldNotReceive('fetch');
+    app()->instance(LinearIssueFetcher::class, $fetcher);
+
+    $agent = mock(AgentRunner::class);
+    $agent->shouldReceive('run')->andReturn(new AgentRunResult(
+        sessionId: 's', resultSummary: "```json\n{\"summary\":\"\",\"verdict\":\"Approve\",\"verdict_detail\":\"\",\"findings\":[]}\n```",
+        costUsd: 0, numTurns: 1, durationMs: 1, isError: false,
+        clarificationNeeded: false, clarificationOptions: [], rawOutput: '',
+    ));
+    app()->instance(AgentRunner::class, $agent);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('getInstallationToken')->andReturn('t');
+    $github->shouldReceive('createPullRequestReview')->andReturn(['id' => 1, 'comments' => []]);
+    app()->instance(GitHubAppService::class, $github);
+
+    (new RunYakReviewJob($task))->handle(app(AgentRunner::class));
+
+    expect(PrReview::where('yak_task_id', $task->id)->exists())->toBeTrue();
+});
+
+it('skips Linear fetch when no LinearOauthConnection exists', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'geocodio/api',
+        'pr_review_enabled' => true,
+        'default_branch' => 'main',
+        'is_active' => true,
+    ]);
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => $repo->slug,
+        'pr_url' => 'https://github.com/geocodio/api/pull/61',
+        'external_id' => 'https://github.com/geocodio/api/pull/61',
+        'branch_name' => 'feat/x',
+        'context' => json_encode([
+            'pr_number' => 61,
+            'head_sha' => 'h', 'base_sha' => 'b',
+            'author' => 'm', 'title' => 't', 'body' => 'Fixes GEO-99',
+            'review_scope' => 'full', 'incremental_base_sha' => null,
+        ]),
+    ]);
+
+    // No LinearOauthConnection exists, so fetcher should never be called.
+    $sandbox = mock(IncusSandboxManager::class);
+    $sandbox->shouldReceive('create')->andReturn('c');
+    $sandbox->shouldReceive('run')->andReturn(Process::result(output: '', exitCode: 0));
+    $sandbox->shouldReceive('destroy');
+    app()->instance(IncusSandboxManager::class, $sandbox);
+
+    $fetcher = mock(LinearIssueFetcher::class);
+    $fetcher->shouldNotReceive('fetch');
+    app()->instance(LinearIssueFetcher::class, $fetcher);
+
+    $agent = mock(AgentRunner::class);
+    $agent->shouldReceive('run')->andReturn(new AgentRunResult(
+        sessionId: 's', resultSummary: "```json\n{\"summary\":\"\",\"verdict\":\"Approve\",\"verdict_detail\":\"\",\"findings\":[]}\n```",
+        costUsd: 0, numTurns: 1, durationMs: 1, isError: false,
+        clarificationNeeded: false, clarificationOptions: [], rawOutput: '',
+    ));
+    app()->instance(AgentRunner::class, $agent);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('getInstallationToken')->andReturn('t');
+    $github->shouldReceive('createPullRequestReview')->andReturn(['id' => 1, 'comments' => []]);
+    app()->instance(GitHubAppService::class, $github);
+
+    (new RunYakReviewJob($task))->handle(app(AgentRunner::class));
+
+    expect(PrReview::where('yak_task_id', $task->id)->exists())->toBeTrue();
 });

--- a/tests/Feature/Jobs/RunYakReviewJobTest.php
+++ b/tests/Feature/Jobs/RunYakReviewJobTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Contracts\AgentRunner;
+use App\DataTransferObjects\AgentRunResult;
+use App\Enums\TaskMode;
+use App\Enums\TaskStatus;
+use App\Jobs\RunYakReviewJob;
+use App\Models\PrReview;
+use App\Models\PrReviewComment;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\GitHubAppService;
+use App\Services\IncusSandboxManager;
+use Illuminate\Support\Facades\Process;
+
+beforeEach(function () {
+    config()->set('yak.channels.github.installation_id', 12345);
+    config()->set('yak.sandbox.workspace_path', '/workspace');
+});
+
+it('runs a full-scope review end to end', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'geocodio/api',
+        'pr_review_enabled' => true,
+        'default_branch' => 'main',
+        'ci_system' => 'none',
+        'is_active' => true,
+    ]);
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => $repo->slug,
+        'pr_url' => 'https://github.com/geocodio/api/pull/42',
+        'external_id' => 'https://github.com/geocodio/api/pull/42',
+        'branch_name' => 'feat/retry',
+        'context' => json_encode([
+            'pr_number' => 42,
+            'head_sha' => 'abc123',
+            'base_sha' => 'def456',
+            'author' => 'mathias',
+            'title' => 'Retry',
+            'body' => 'Adds retry.',
+            'review_scope' => 'full',
+            'incremental_base_sha' => null,
+        ]),
+    ]);
+
+    $sandbox = mock(IncusSandboxManager::class);
+    $sandbox->shouldReceive('create')->andReturn('yak-task-' . $task->id);
+    $sandbox->shouldReceive('run')->andReturn(
+        Process::result(output: "app/Foo.php\n", exitCode: 0),
+    );
+    $sandbox->shouldReceive('destroy');
+    app()->instance(IncusSandboxManager::class, $sandbox);
+
+    $agent = mock(AgentRunner::class);
+    $agent->shouldReceive('run')->andReturn(new AgentRunResult(
+        sessionId: 's-1',
+        resultSummary: "Review done.\n\n```json\n{\"summary\":\"Adds retry.\",\"verdict\":\"Approve with suggestions\",\"verdict_detail\":\"ok\",\"findings\":[{\"file\":\"app/Foo.php\",\"line\":12,\"severity\":\"must_fix\",\"category\":\"Performance\",\"body\":\"Null check missing.\"}]}\n```",
+        costUsd: 0.12,
+        numTurns: 3,
+        durationMs: 1000,
+        isError: false,
+        clarificationNeeded: false,
+        clarificationOptions: [],
+        rawOutput: '',
+    ));
+    app()->instance(AgentRunner::class, $agent);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('getInstallationToken')->andReturn('tok');
+    $github->shouldReceive('createPullRequestReview')->andReturn([
+        'id' => 7777,
+        'comments' => [
+            ['id' => 111, 'path' => 'app/Foo.php', 'line' => 12, 'body' => 'Null check missing.'],
+        ],
+    ]);
+    app()->instance(GitHubAppService::class, $github);
+
+    (new RunYakReviewJob($task))->handle($agent);
+
+    $task->refresh();
+
+    expect($task->status)->toBe(TaskStatus::Success)
+        ->and(PrReview::where('yak_task_id', $task->id)->exists())->toBeTrue()
+        ->and(PrReviewComment::count())->toBe(1);
+});

--- a/tests/Feature/Livewire/PrReviewFeedbackTest.php
+++ b/tests/Feature/Livewire/PrReviewFeedbackTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Livewire\PrReviewFeedback;
+use App\Models\PrReviewComment;
+use App\Models\User;
+use Livewire\Livewire;
+
+it('renders the feedback table with comments', function () {
+    $user = User::factory()->create();
+
+    PrReviewComment::factory()->count(3)->create();
+
+    Livewire::actingAs($user)
+        ->test(PrReviewFeedback::class)
+        ->assertOk()
+        ->assertSee('PR Reviews');
+});
+
+it('filters by severity', function () {
+    $user = User::factory()->create();
+
+    PrReviewComment::factory()->create(['severity' => 'must_fix']);
+    PrReviewComment::factory()->create(['severity' => 'consider']);
+
+    $component = Livewire::actingAs($user)
+        ->test(PrReviewFeedback::class)
+        ->set('severity_filter', 'must_fix');
+
+    expect($component->instance()->comments()->count())->toBe(1);
+});
+
+it('shows an empty state when no reviews exist', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(PrReviewFeedback::class)
+        ->assertSee('No Yak reviews yet');
+});
+
+it('is accessible at /pr-reviews route', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('pr-reviews'))
+        ->assertOk();
+});

--- a/tests/Feature/Livewire/PrReviewForPrTest.php
+++ b/tests/Feature/Livewire/PrReviewForPrTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Enums\TaskMode;
+use App\Livewire\PrReviewForPr;
+use App\Models\PrReview;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\YakTask;
+use App\Services\GitHubAppService;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    config()->set('yak.channels.github.installation_id', 12345);
+});
+
+it('lists reviews for a PR in reverse chronological order', function () {
+    $user = User::factory()->create();
+
+    $older = PrReview::factory()->create([
+        'repo' => 'geocodio/api',
+        'pr_number' => 50,
+        'submitted_at' => now()->subDay(),
+    ]);
+    $newer = PrReview::factory()->create([
+        'repo' => 'geocodio/api',
+        'pr_number' => 50,
+        'submitted_at' => now(),
+    ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(PrReviewForPr::class, ['repoSlug' => 'geocodio/api', 'prNumber' => 50]);
+
+    $reviews = $component->instance()->reviews();
+
+    expect($reviews->first()->id)->toBe($newer->id)
+        ->and($reviews->last()->id)->toBe($older->id);
+});
+
+it('is accessible at the deep-link route', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get('/pr-reviews/for/geocodio/api/50')
+        ->assertOk();
+});
+
+it('rerunReview enqueues a task', function () {
+    $user = User::factory()->create();
+    Repository::factory()->create(['slug' => 'geocodio/api']);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('getPullRequest')->andReturn([
+        'number' => 50, 'html_url' => 'https://github.com/geocodio/api/pull/50',
+        'title' => '', 'body' => '', 'draft' => false, 'user' => ['login' => 'm'],
+        'head' => ['ref' => 'h', 'sha' => 's'], 'base' => ['ref' => 'main', 'sha' => 'b'],
+    ]);
+    app()->instance(GitHubAppService::class, $github);
+
+    Livewire::actingAs($user)
+        ->test(PrReviewForPr::class, ['repoSlug' => 'geocodio/api', 'prNumber' => 50])
+        ->call('rerunReview');
+
+    expect(YakTask::where('mode', TaskMode::Review)->count())->toBe(1);
+});

--- a/tests/Feature/Livewire/PrReviewIntroTest.php
+++ b/tests/Feature/Livewire/PrReviewIntroTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Livewire\PrReviewFeedback;
+use App\Models\User;
+use Livewire\Livewire;
+
+it('shows intro card for users who have not seen it', function () {
+    $user = User::factory()->create(['has_seen_pr_review_intro_at' => null]);
+
+    Livewire::actingAs($user)
+        ->test(PrReviewFeedback::class)
+        ->assertSee('Yak now reviews your pull requests');
+});
+
+it('does not show intro card after dismissal', function () {
+    $user = User::factory()->create(['has_seen_pr_review_intro_at' => null]);
+
+    Livewire::actingAs($user)
+        ->test(PrReviewFeedback::class)
+        ->call('dismissIntro')
+        ->assertDontSee('Yak now reviews your pull requests');
+
+    expect($user->fresh()->has_seen_pr_review_intro_at)->not->toBeNull();
+});
+
+it('does not show intro card for users who have seen it', function () {
+    $user = User::factory()->create(['has_seen_pr_review_intro_at' => now()]);
+
+    Livewire::actingAs($user)
+        ->test(PrReviewFeedback::class)
+        ->assertDontSee('Yak now reviews your pull requests');
+});

--- a/tests/Feature/Livewire/RepoListBadgeTest.php
+++ b/tests/Feature/Livewire/RepoListBadgeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Livewire\Repos\RepoList;
+use App\Models\PrReview;
+use App\Models\Repository;
+use App\Models\User;
+use Livewire\Livewire;
+
+it('includes a 30-day review count on each repo', function () {
+    $user = User::factory()->create();
+    $repo = Repository::factory()->create(['pr_review_enabled' => true, 'slug' => 'geocodio/api']);
+
+    PrReview::factory()->create(['repo' => 'geocodio/api', 'submitted_at' => now()->subDays(10)]);
+    PrReview::factory()->create(['repo' => 'geocodio/api', 'submitted_at' => now()->subDays(5)]);
+    PrReview::factory()->create(['repo' => 'geocodio/api', 'submitted_at' => now()->subDays(40)]); // outside window
+
+    $component = Livewire::actingAs($user)->test(RepoList::class);
+    $loaded = $component->instance()->repositories();
+
+    expect($loaded->firstWhere('slug', 'geocodio/api')->pr_reviews_30d_count)->toBe(2);
+});

--- a/tests/Feature/Livewire/TaskDetailRerunReviewTest.php
+++ b/tests/Feature/Livewire/TaskDetailRerunReviewTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Enums\TaskMode;
+use App\Livewire\Tasks\TaskDetail;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\YakTask;
+use App\Services\GitHubAppService;
+use Illuminate\Support\Facades\Bus;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    config()->set('yak.channels.github.installation_id', 12345);
+});
+
+it('rerun button enqueues a new review task', function () {
+    Bus::fake();
+
+    $user = User::factory()->create();
+    Repository::factory()->create(['slug' => 'geocodio/api']);
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => 'geocodio/api',
+        'pr_url' => 'https://github.com/geocodio/api/pull/1',
+        'context' => json_encode(['pr_number' => 1]),
+    ]);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('getPullRequest')->andReturn([
+        'number' => 1,
+        'html_url' => 'https://github.com/geocodio/api/pull/1',
+        'title' => 't', 'body' => '', 'draft' => false,
+        'user' => ['login' => 'maria'],
+        'head' => ['ref' => 'h', 'sha' => 'new-sha'],
+        'base' => ['ref' => 'main', 'sha' => 'b'],
+    ]);
+    app()->instance(GitHubAppService::class, $github);
+
+    Livewire::actingAs($user)
+        ->test(TaskDetail::class, ['task' => $task])
+        ->call('rerunReview');
+
+    expect(YakTask::where('mode', TaskMode::Review)->count())->toBe(2);
+});
+
+it('skips re-run when one is already pending', function () {
+    $user = User::factory()->create();
+    Repository::factory()->create(['slug' => 'geocodio/api']);
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => 'geocodio/api',
+        'pr_url' => 'https://github.com/geocodio/api/pull/1',
+        'status' => 'success',
+        'context' => json_encode(['pr_number' => 1]),
+    ]);
+
+    // Existing pending task
+    YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'repo' => 'geocodio/api',
+        'pr_url' => 'https://github.com/geocodio/api/pull/1',
+        'external_id' => 'https://github.com/geocodio/api/pull/1',
+        'status' => 'pending',
+    ]);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldNotReceive('getPullRequest');
+    app()->instance(GitHubAppService::class, $github);
+
+    Livewire::actingAs($user)
+        ->test(TaskDetail::class, ['task' => $task])
+        ->call('rerunReview');
+
+    expect(YakTask::where('mode', TaskMode::Review)->count())->toBe(2); // unchanged
+});

--- a/tests/Feature/Livewire/TaskDetailReviewPanelsTest.php
+++ b/tests/Feature/Livewire/TaskDetailReviewPanelsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Enums\TaskMode;
+use App\Livewire\Tasks\TaskDetail;
+use App\Models\PrReview;
+use App\Models\PrReviewComment;
+use App\Models\User;
+use App\Models\YakTask;
+use Livewire\Livewire;
+
+it('renders review panels for a review task', function () {
+    $user = User::factory()->create();
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'pr_url' => 'https://github.com/geocodio/api/pull/1',
+    ]);
+
+    $review = PrReview::factory()->create([
+        'yak_task_id' => $task->id,
+        'summary' => 'Adds retry to geocode client.',
+        'verdict' => 'Approve with suggestions',
+    ]);
+
+    PrReviewComment::factory()->create([
+        'pr_review_id' => $review->id,
+        'severity' => 'consider',
+        'file_path' => 'app/Foo.php',
+        'line_number' => 5,
+        'category' => 'Simplicity',
+        'body' => 'Minor nit.',
+    ]);
+
+    $component = Livewire::actingAs($user)->test(TaskDetail::class, ['task' => $task]);
+    $html = $component->instance()->renderedReviewBody();
+
+    expect($html)->toContain('<h2>Summary</h2>')
+        ->and($html)->toContain('Adds retry to geocode client.')
+        ->and($html)->toContain('app/Foo.php:5')
+        ->and($html)->toContain('Approve with suggestions');
+});
+
+it('returns empty string when task is not a review', function () {
+    $user = User::factory()->create();
+    $task = YakTask::factory()->create(['mode' => TaskMode::Fix]);
+
+    $component = Livewire::actingAs($user)->test(TaskDetail::class, ['task' => $task]);
+
+    expect($component->instance()->renderedReviewBody())->toBe('');
+});

--- a/tests/Feature/Livewire/TaskListPrReviewTabTest.php
+++ b/tests/Feature/Livewire/TaskListPrReviewTabTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Enums\TaskMode;
+use App\Livewire\Tasks\TaskList;
+use App\Models\User;
+use App\Models\YakTask;
+use Livewire\Livewire;
+
+it('filters tasks by review mode when reviews tab is active', function () {
+    $user = User::factory()->create();
+
+    YakTask::factory()->count(2)->create(['mode' => TaskMode::Review]);
+    YakTask::factory()->count(3)->create(['mode' => TaskMode::Fix]);
+
+    $component = Livewire::actingAs($user)
+        ->test(TaskList::class)
+        ->set('tab', 'reviews');
+
+    expect($component->instance()->tasks()->count())->toBe(2);
+});
+
+it('reports review count', function () {
+    $user = User::factory()->create();
+
+    YakTask::factory()->count(4)->create(['mode' => TaskMode::Review]);
+
+    $component = Livewire::actingAs($user)->test(TaskList::class);
+
+    expect($component->instance()->reviewsCount())->toBe(4);
+});

--- a/tests/Feature/PRMergeTrackingTest.php
+++ b/tests/Feature/PRMergeTrackingTest.php
@@ -150,7 +150,7 @@ test('webhook skips non-pull_request events', function () {
 
     $response = postGitHubWebhook($this, $payload, $secret, 'check_suite');
 
-    $response->assertOk()->assertJson(['skipped' => 'not a pull_request.closed event']);
+    $response->assertOk()->assertJson(['skipped' => 'not a pull_request event']);
 });
 
 test('webhook skips when no task matches PR URL', function () {

--- a/tests/Feature/PrReviewClosedWebhookTest.php
+++ b/tests/Feature/PrReviewClosedWebhookTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Enums\TaskMode;
+use App\Models\PrReview;
+use App\Models\YakTask;
+
+beforeEach(function () {
+    config()->set('yak.channels.github.webhook_secret', 'secret');
+});
+
+function signClosedPayload(string $payload): string
+{
+    return 'sha256=' . hash_hmac('sha256', $payload, 'secret');
+}
+
+it('updates pr_reviews.pr_closed_at and pr_merged_at on pull_request.closed merged', function () {
+    $prUrl = 'https://github.com/geocodio/api/pull/100';
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'pr_url' => $prUrl,
+    ]);
+
+    $review = PrReview::factory()->create([
+        'yak_task_id' => $task->id,
+        'pr_url' => $prUrl,
+        'pr_number' => 100,
+        'repo' => 'geocodio/api',
+    ]);
+
+    $payload = [
+        'action' => 'closed',
+        'pull_request' => [
+            'html_url' => $prUrl,
+            'merged' => true,
+            'merged_at' => '2026-04-17T00:00:00Z',
+            'closed_at' => '2026-04-17T00:00:00Z',
+        ],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signClosedPayload($body),
+    ])->assertOk();
+
+    $review->refresh();
+    expect($review->pr_closed_at)->not->toBeNull()
+        ->and($review->pr_merged_at)->not->toBeNull();
+});
+
+it('sets only pr_closed_at when merged=false', function () {
+    $prUrl = 'https://github.com/geocodio/api/pull/101';
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Review,
+        'pr_url' => $prUrl,
+    ]);
+
+    $review = PrReview::factory()->create([
+        'yak_task_id' => $task->id,
+        'pr_url' => $prUrl,
+        'pr_number' => 101,
+        'repo' => 'geocodio/api',
+    ]);
+
+    $payload = [
+        'action' => 'closed',
+        'pull_request' => [
+            'html_url' => $prUrl,
+            'merged' => false,
+            'closed_at' => '2026-04-17T00:00:00Z',
+        ],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signClosedPayload($body),
+    ])->assertOk();
+
+    $review->refresh();
+    expect($review->pr_closed_at)->not->toBeNull()
+        ->and($review->pr_merged_at)->toBeNull();
+});

--- a/tests/Feature/PrReviewCommentModelTest.php
+++ b/tests/Feature/PrReviewCommentModelTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Models\PrReview;
+use App\Models\PrReviewComment;
+
+it('creates a comment row tied to a review', function () {
+    $review = PrReview::factory()->create();
+
+    $comment = PrReviewComment::create([
+        'pr_review_id' => $review->id,
+        'github_comment_id' => 99,
+        'file_path' => 'app/Services/Foo.php',
+        'line_number' => 87,
+        'body' => 'Consider extracting this.',
+        'category' => 'Simplicity',
+        'severity' => 'should_fix',
+        'is_suggestion' => true,
+        'thumbs_up' => 0,
+        'thumbs_down' => 0,
+    ]);
+
+    expect($comment->review->id)->toBe($review->id)
+        ->and($comment->is_suggestion)->toBeTrue();
+});

--- a/tests/Feature/PrReviewCommentReactionModelTest.php
+++ b/tests/Feature/PrReviewCommentReactionModelTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Models\PrReviewComment;
+use App\Models\PrReviewCommentReaction;
+
+it('creates a reaction tied to a comment', function () {
+    $comment = PrReviewComment::factory()->create();
+
+    $reaction = PrReviewCommentReaction::create([
+        'pr_review_comment_id' => $comment->id,
+        'github_reaction_id' => 123,
+        'github_user_login' => 'maria',
+        'github_user_id' => 5,
+        'content' => '+1',
+        'reacted_at' => now(),
+    ]);
+
+    expect($reaction->comment->id)->toBe($comment->id);
+});

--- a/tests/Feature/PrReviewModelTest.php
+++ b/tests/Feature/PrReviewModelTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\PrReview;
+use App\Models\YakTask;
+
+it('creates a pr_review row with required fields', function () {
+    $task = YakTask::factory()->create();
+
+    $review = PrReview::create([
+        'yak_task_id' => $task->id,
+        'repo' => 'geocodio/api',
+        'pr_number' => 42,
+        'pr_url' => 'https://github.com/geocodio/api/pull/42',
+        'github_review_id' => 12345,
+        'commit_sha_reviewed' => 'abc123',
+        'review_scope' => 'full',
+        'summary' => 'Adds retry on timeout.',
+        'verdict' => 'Approve with suggestions',
+        'submitted_at' => now(),
+    ]);
+
+    expect($review->yak_task_id)->toBe($task->id)
+        ->and($review->review_scope)->toBe('full')
+        ->and($review->dismissed_at)->toBeNull()
+        ->and($review->incremental_base_sha)->toBeNull();
+});
+
+it('has a belongsTo task relation', function () {
+    $task = YakTask::factory()->create();
+    $review = PrReview::factory()->for($task, 'task')->create();
+
+    expect($review->task->id)->toBe($task->id);
+});

--- a/tests/Feature/PromptEditorPrReviewTest.php
+++ b/tests/Feature/PromptEditorPrReviewTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Prompts\PromptDefinitions;
+use App\Prompts\PromptFixtures;
+use App\Services\PromptResolver;
+
+it('registers the tasks-review prompt definition', function () {
+    expect(PromptDefinitions::has('tasks-review'))->toBeTrue();
+
+    $def = PromptDefinitions::for('tasks-review');
+
+    expect($def['view'])->toBe('prompts.tasks.review')
+        ->and($def['label'])->toBe('PR Review')
+        ->and($def['variables'])->toContain('prNumber', 'prTitle', 'pathExcludes', 'linearTicket');
+});
+
+it('renders the review prompt against the fixture', function () {
+    $fixture = PromptFixtures::firstData('tasks-review');
+    $rendered = app(PromptResolver::class)->render('tasks-review', $fixture);
+
+    expect($rendered)->not->toBeEmpty()
+        ->and($rendered)->toContain('PR');
+});

--- a/tests/Feature/Repos/PrReviewColumnsTest.php
+++ b/tests/Feature/Repos/PrReviewColumnsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Models\Repository;
+
+it('has the pr_review_enabled column defaulting to false', function () {
+    $repo = Repository::factory()->create();
+
+    expect($repo->pr_review_enabled)->toBeFalse();
+});
+
+it('casts pr_review_path_excludes to array and allows null', function () {
+    $repo = Repository::factory()->create([
+        'pr_review_path_excludes' => ['vendor/**', 'node_modules/**'],
+    ]);
+
+    expect($repo->pr_review_path_excludes)->toBe(['vendor/**', 'node_modules/**']);
+
+    $repo->update(['pr_review_path_excludes' => null]);
+
+    expect($repo->fresh()->pr_review_path_excludes)->toBeNull();
+});

--- a/tests/Feature/Repos/RepoPathExcludesTest.php
+++ b/tests/Feature/Repos/RepoPathExcludesTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Livewire\Repos\RepoForm;
+use App\Models\Repository;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->create());
+});
+
+it('adds a pattern to path excludes', function () {
+    $repo = Repository::factory()->create(['pr_review_enabled' => true, 'pr_review_path_excludes' => null]);
+
+    Livewire::test(RepoForm::class, ['repository' => $repo])
+        ->set('path_exclude_input', 'custom/**')
+        ->call('addPathExclude')
+        ->assertSet('path_excludes', ['custom/**']);
+});
+
+it('removes a pattern', function () {
+    $repo = Repository::factory()->create([
+        'pr_review_enabled' => true,
+        'pr_review_path_excludes' => ['a/**', 'b/**'],
+    ]);
+
+    Livewire::test(RepoForm::class, ['repository' => $repo])
+        ->call('removePathExclude', 0)
+        ->assertSet('path_excludes', ['b/**']);
+});
+
+it('resets to default on reset', function () {
+    $repo = Repository::factory()->create([
+        'pr_review_enabled' => true,
+        'pr_review_path_excludes' => ['only-this/**'],
+    ]);
+
+    Livewire::test(RepoForm::class, ['repository' => $repo])
+        ->call('resetPathExcludes')
+        ->set('apply_to_open_prs', false)
+        ->call('save');
+
+    expect($repo->fresh()->pr_review_path_excludes)->toBeNull();
+});
+
+it('rejects invalid glob patterns', function () {
+    $repo = Repository::factory()->create(['pr_review_enabled' => true, 'pr_review_path_excludes' => null]);
+
+    Livewire::test(RepoForm::class, ['repository' => $repo])
+        ->set('path_exclude_input', 'bad; rm -rf')
+        ->call('addPathExclude')
+        ->assertHasErrors('path_exclude_input');
+});

--- a/tests/Feature/Repos/RepoPrReviewToggleTest.php
+++ b/tests/Feature/Repos/RepoPrReviewToggleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Enums\TaskMode;
+use App\Livewire\Repos\RepoForm;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\YakTask;
+use App\Services\GitHubAppService;
+use Illuminate\Support\Facades\Bus;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    config()->set('yak.channels.github.installation_id', 12345);
+    config()->set('yak.channels.github.app_bot_login', 'yak-bot[bot]');
+    $this->actingAs(User::factory()->create());
+});
+
+it('toggles pr_review_enabled', function () {
+    $repo = Repository::factory()->create(['pr_review_enabled' => false]);
+
+    Livewire::test(RepoForm::class, ['repository' => $repo])
+        ->set('pr_review_enabled', true)
+        ->set('apply_to_open_prs', false)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect($repo->fresh()->pr_review_enabled)->toBeTrue();
+});
+
+it('enqueues retroactive review tasks when enabling with apply_to_open_prs', function () {
+    Bus::fake();
+    $repo = Repository::factory()->create(['pr_review_enabled' => false, 'slug' => 'geocodio/api']);
+
+    $github = mock(GitHubAppService::class);
+    $github->shouldReceive('listOpenPullRequests')->andReturn([
+        ['number' => 1, 'html_url' => 'u1', 'title' => '', 'body' => '', 'draft' => false, 'user' => ['login' => 'maria'], 'head' => ['ref' => 'h', 'sha' => 's1'], 'base' => ['ref' => 'main', 'sha' => 'b1']],
+    ]);
+    app()->instance(GitHubAppService::class, $github);
+
+    Livewire::test(RepoForm::class, ['repository' => $repo])
+        ->set('pr_review_enabled', true)
+        ->set('apply_to_open_prs', true)
+        ->call('save');
+
+    expect(YakTask::where('mode', TaskMode::Review)->count())->toBe(1);
+});

--- a/tests/Feature/Services/GitHubAppServicePrReviewTest.php
+++ b/tests/Feature/Services/GitHubAppServicePrReviewTest.php
@@ -47,3 +47,21 @@ it('posts a COMMENT review with line-level comments', function () {
             && $body['comments'][0]['path'] === 'app/Foo.php';
     });
 });
+
+it('dismisses a review with a message', function () {
+    Http::fake([
+        'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'x', 'expires_at' => now()->addHour()->toIso8601String()]),
+        'api.github.com/repos/geocodio/api/pulls/42/reviews/77/dismissals' => Http::response(['id' => 77, 'state' => 'DISMISSED']),
+    ]);
+
+    app(GitHubAppService::class)
+        ->dismissPullRequestReview(12345, 'geocodio/api', 42, 77, 'Superseded.');
+
+    Http::assertSent(function ($request): bool {
+        if (! str_contains($request->url(), '/reviews/77/dismissals')) {
+            return false;
+        }
+
+        return str_contains((string) $request->body(), 'Superseded');
+    });
+});

--- a/tests/Feature/Services/GitHubAppServicePrReviewTest.php
+++ b/tests/Feature/Services/GitHubAppServicePrReviewTest.php
@@ -64,6 +64,21 @@ it('lists open PRs with pagination', function () {
     expect($prs)->toHaveCount(2);
 });
 
+it('lists reactions on a review comment', function () {
+    Http::fake([
+        'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'x', 'expires_at' => now()->addHour()->toIso8601String()]),
+        'api.github.com/repos/geocodio/api/pulls/comments/999/reactions' => Http::response([
+            ['id' => 1, 'user' => ['login' => 'maria', 'id' => 10], 'content' => '+1', 'created_at' => '2026-04-17T00:00:00Z'],
+            ['id' => 2, 'user' => ['login' => 'bob', 'id' => 11], 'content' => '-1', 'created_at' => '2026-04-17T00:00:00Z'],
+        ]),
+    ]);
+
+    $reactions = app(GitHubAppService::class)->listCommentReactions(12345, 'geocodio/api', 999);
+
+    expect($reactions)->toHaveCount(2)
+        ->and($reactions[0]['content'])->toBe('+1');
+});
+
 it('dismisses a review with a message', function () {
     Http::fake([
         'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'x', 'expires_at' => now()->addHour()->toIso8601String()]),

--- a/tests/Feature/Services/GitHubAppServicePrReviewTest.php
+++ b/tests/Feature/Services/GitHubAppServicePrReviewTest.php
@@ -48,6 +48,22 @@ it('posts a COMMENT review with line-level comments', function () {
     });
 });
 
+it('lists open PRs with pagination', function () {
+    Http::fake([
+        'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'x', 'expires_at' => now()->addHour()->toIso8601String()]),
+        'api.github.com/repos/geocodio/api/pulls?state=open*' => Http::sequence()
+            ->push([
+                ['number' => 1, 'html_url' => 'u1', 'title' => 't', 'body' => 'b', 'draft' => false, 'user' => ['login' => 'a'], 'head' => ['ref' => 'h', 'sha' => 's1'], 'base' => ['ref' => 'main', 'sha' => 'b1']],
+                ['number' => 2, 'html_url' => 'u2', 'title' => 't', 'body' => 'b', 'draft' => true, 'user' => ['login' => 'a'], 'head' => ['ref' => 'h', 'sha' => 's2'], 'base' => ['ref' => 'main', 'sha' => 'b2']],
+            ])
+            ->push([]),
+    ]);
+
+    $prs = app(GitHubAppService::class)->listOpenPullRequests(12345, 'geocodio/api');
+
+    expect($prs)->toHaveCount(2);
+});
+
 it('dismisses a review with a message', function () {
     Http::fake([
         'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'x', 'expires_at' => now()->addHour()->toIso8601String()]),

--- a/tests/Feature/Services/GitHubAppServicePrReviewTest.php
+++ b/tests/Feature/Services/GitHubAppServicePrReviewTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Services\GitHubAppService;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $keyPair = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+    openssl_pkey_export($keyPair, $privateKey);
+
+    config()->set('yak.channels.github.installation_id', 12345);
+    config()->set('yak.channels.github.app_id', '999');
+    config()->set('yak.channels.github.private_key', $privateKey);
+});
+
+it('posts a COMMENT review with line-level comments', function () {
+    Http::fake([
+        'api.github.com/app/installations/*/access_tokens' => Http::response(['token' => 'tok-abc', 'expires_at' => now()->addHour()->toIso8601String()]),
+        'api.github.com/repos/geocodio/api/pulls/42/reviews' => Http::response([
+            'id' => 77777,
+            'state' => 'COMMENTED',
+        ]),
+    ]);
+
+    $result = app(GitHubAppService::class)->createPullRequestReview(
+        12345,
+        'geocodio/api',
+        42,
+        'Review body text.',
+        'COMMENT',
+        [
+            ['path' => 'app/Foo.php', 'line' => 12, 'body' => 'Fix me.'],
+        ],
+    );
+
+    expect($result['id'])->toBe(77777);
+
+    Http::assertSent(function ($request): bool {
+        if (! str_contains($request->url(), '/pulls/42/reviews')) {
+            return false;
+        }
+
+        $body = json_decode((string) $request->body(), true);
+
+        return $body['event'] === 'COMMENT'
+            && $body['body'] === 'Review body text.'
+            && count($body['comments']) === 1
+            && $body['comments'][0]['path'] === 'app/Foo.php';
+    });
+});

--- a/tests/Feature/Settings/LinearConnectionTest.php
+++ b/tests/Feature/Settings/LinearConnectionTest.php
@@ -12,7 +12,7 @@ beforeEach(function () {
 });
 
 test('unauthenticated user cannot start the Linear OAuth flow', function () {
-    $this->get('/auth/linear')->assertRedirect('/auth/google');
+    $this->get('/auth/linear')->assertRedirect('/login');
 });
 
 test('redirect route sends the user to Linear with correct params', function () {

--- a/tests/Unit/CommonMarkTest.php
+++ b/tests/Unit/CommonMarkTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use League\CommonMark\CommonMarkConverter;
+
+it('converts markdown to HTML', function () {
+    $html = (new CommonMarkConverter)->convert('**bold**')->getContent();
+
+    expect($html)->toContain('<strong>bold</strong>');
+});

--- a/tests/Unit/Enums/TaskModeTest.php
+++ b/tests/Unit/Enums/TaskModeTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Enums\TaskMode;
+
+it('has a Review case with value "review"', function () {
+    expect(TaskMode::Review->value)->toBe('review');
+});
+
+it('exposes all current cases', function () {
+    $values = array_map(fn (TaskMode $m) => $m->value, TaskMode::cases());
+
+    expect($values)->toContain('fix', 'research', 'setup', 'review');
+});

--- a/tests/Unit/Services/ReviewOutputParserTest.php
+++ b/tests/Unit/Services/ReviewOutputParserTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Services\ReviewOutputParser;
+
+it('parses a well-formed JSON block from the agent output', function () {
+    $output = <<<'TEXT'
+Here is my review.
+
+```json
+{
+  "summary": "This PR adds retry.",
+  "verdict": "Approve with suggestions",
+  "verdict_detail": "One blocker found.",
+  "findings": [
+    {"file": "app/Foo.php", "line": 12, "severity": "must_fix", "category": "Performance", "body": "Null check", "suggestion_loc": 2}
+  ]
+}
+```
+TEXT;
+
+    $parsed = app(ReviewOutputParser::class)->parse($output);
+
+    expect($parsed->summary)->toBe('This PR adds retry.')
+        ->and($parsed->verdict)->toBe('Approve with suggestions')
+        ->and($parsed->findings)->toHaveCount(1)
+        ->and($parsed->findings[0]->severity)->toBe('must_fix')
+        ->and($parsed->findings[0]->suggestionLoc)->toBe(2);
+});
+
+it('throws when no JSON block is present', function () {
+    app(ReviewOutputParser::class)->parse('No JSON here');
+})->throws(RuntimeException::class);
+
+it('throws when required keys are missing', function () {
+    app(ReviewOutputParser::class)->parse("```json\n{\"summary\": \"x\"}\n```");
+})->throws(RuntimeException::class);
+
+it('accepts a finding without suggestion_loc', function () {
+    $output = <<<'TEXT'
+```json
+{
+  "summary": "x",
+  "verdict": "Approve",
+  "verdict_detail": "y",
+  "findings": [{"file":"a.php","line":1,"severity":"consider","category":"Simplicity","body":"b"}]
+}
+```
+TEXT;
+
+    $parsed = app(ReviewOutputParser::class)->parse($output);
+
+    expect($parsed->findings[0]->suggestionLoc)->toBeNull();
+});

--- a/tests/Unit/Services/TaskJobResolverTest.php
+++ b/tests/Unit/Services/TaskJobResolverTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Enums\TaskMode;
+use App\Jobs\RunYakJob;
+use App\Jobs\RunYakReviewJob;
+use App\Models\YakTask;
+use App\Services\TaskJobResolver;
+
+it('resolves a fix task to RunYakJob', function () {
+    $task = YakTask::factory()->make(['mode' => TaskMode::Fix]);
+
+    expect(TaskJobResolver::jobClass($task))->toBe(RunYakJob::class);
+});
+
+it('resolves a research task to RunYakJob', function () {
+    $task = YakTask::factory()->make(['mode' => TaskMode::Research]);
+
+    expect(TaskJobResolver::jobClass($task))->toBe(RunYakJob::class);
+});
+
+it('resolves a review task to RunYakReviewJob', function () {
+    $task = YakTask::factory()->make(['mode' => TaskMode::Review]);
+
+    expect(TaskJobResolver::jobClass($task))->toBe(RunYakReviewJob::class);
+});

--- a/tests/Unit/Support/LinearIdentifierExtractorTest.php
+++ b/tests/Unit/Support/LinearIdentifierExtractorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Support\LinearIdentifierExtractor;
+
+it('extracts a ticket id from body text', function () {
+    expect(LinearIdentifierExtractor::firstFrom('Fixes GEO-1234.'))->toBe('GEO-1234');
+});
+
+it('extracts a ticket id from a linear.app URL', function () {
+    expect(LinearIdentifierExtractor::firstFrom('See https://linear.app/geocodio/issue/GEO-42/foo'))->toBe('GEO-42');
+});
+
+it('returns null when no identifier is present', function () {
+    expect(LinearIdentifierExtractor::firstFrom('No ticket here'))->toBeNull();
+});
+
+it('does not match lowercase or malformed ids', function () {
+    expect(LinearIdentifierExtractor::firstFrom('geo-1234'))->toBeNull();
+    expect(LinearIdentifierExtractor::firstFrom('GEO1234'))->toBeNull();
+});

--- a/tests/Unit/Support/PathMatcherTest.php
+++ b/tests/Unit/Support/PathMatcherTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Support\PathMatcher;
+
+it('matches a literal vendor/** pattern', function () {
+    expect(PathMatcher::matches('vendor/laravel/framework/src/Str.php', ['vendor/**']))->toBeTrue()
+        ->and(PathMatcher::matches('app/Services/Foo.php', ['vendor/**']))->toBeFalse();
+});
+
+it('handles multiple patterns (any-match)', function () {
+    $patterns = ['vendor/**', 'node_modules/**', '*.lock'];
+
+    expect(PathMatcher::matches('composer.lock', $patterns))->toBeTrue()
+        ->and(PathMatcher::matches('node_modules/react/index.js', $patterns))->toBeTrue()
+        ->and(PathMatcher::matches('src/index.ts', $patterns))->toBeFalse();
+});
+
+it('returns false for empty pattern list', function () {
+    expect(PathMatcher::matches('app/Foo.php', []))->toBeFalse();
+});
+
+it('matches nested globs', function () {
+    expect(PathMatcher::matches('public/build/app.abc.js', ['public/build/**']))->toBeTrue();
+});
+
+it('matches files with matching basename against top-level glob', function () {
+    expect(PathMatcher::matches('app/deep/nested.min.js', ['*.min.js']))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- New `TaskMode::Review` routed through a dedicated `RunYakReviewJob` that reuses the existing Incus sandbox + agent pipeline
- Webhook-driven intake (`opened` / `ready_for_review` / `reopened` = full, `synchronize` = incremental with force-push fallback); draft and Yak-authored PRs skipped
- Per-repo toggle on `/repos/{id}/edit`, retroactive apply to all open PRs, path-filter chip list with sensible defaults
- Posts line-level GitHub reviews (category + severity), 1–10 line `suggestion` blocks, collapsed "Nitpicks" for `consider` findings; dismisses prior full reviews on new full run
- Linear ticket context injected when PR text has an identifier (e.g. `GEO-1234`) and a `LinearOauthConnection` exists
- New hourly `PollPullRequestReactionsJob` captures 👍/👎 reactions with reactor identity
- `/pr-reviews` dashboard with filters + per-reviewer drilldown, `/pr-reviews/for/{repoSlug}/{prNumber}` deep-link, new "PR Reviews" tab on `/tasks`, TaskDetail panels with markdown preview + re-run button, first-use intro card
- `docs/pr-review.md` guide + updates to README, repositories, architecture, prompting, channels, troubleshooting
- Landing page "Reviews PRs, too" section

44 commits; 4,396 insertions, 18 deletions. Dependency added: `league/commonmark`.

## Test plan
- [ ] `php artisan test --compact` (expect: all PR-review tests pass; 3 pre-existing unrelated failures around login/Google auth remain)
- [ ] Manually enable PR Review on a repo, open a non-draft PR, verify review posts with expected findings and verdict
- [ ] Push a new commit to the same PR, verify an incremental review lands (base == prior head SHA)
- [ ] Mark a PR as draft → ready-for-review, verify a full review triggers
- [ ] Merge the PR, verify `pr_reviews.pr_merged_at` / `pr_closed_at` populate
- [ ] 👍 a Yak review comment, run `php artisan schedule:run`, verify the dashboard shows the reaction
- [ ] Visit `/pr-reviews`, `/pr-reviews/for/{repo}/{pr}`, and TaskDetail for a review task — confirm all panels render
- [ ] Visit `/` as a guest, confirm the "Reviews PRs, too" landing section renders correctly on desktop + 960px breakpoint
- [ ] Confirm path filters work (add/remove/reset patterns on repo settings)
- [ ] Confirm Yak-authored PRs and drafts are skipped