### PR TITLE
fix(pr-review): stop excluding migrations and lockfiles

### DIFF
--- a/config/yak.php
+++ b/config/yak.php
@@ -201,8 +201,8 @@ return [
         'enabled_globally' => (bool) env('YAK_PR_REVIEW_ENABLED_GLOBALLY', true),
         'default_path_excludes' => [
             'vendor/**', 'node_modules/**', 'public/build/**', 'public/hot',
-            'storage/**', '*.lock', '*.min.js', '*.min.css',
-            'database/migrations/**', '.idea/**', '.vscode/**',
+            'storage/**', '*.min.js', '*.min.css',
+            '.idea/**', '.vscode/**',
         ],
     ],
 

--- a/docs/pr-review.md
+++ b/docs/pr-review.md
@@ -17,7 +17,7 @@ PRs authored by the Yak app bot itself are skipped to avoid recursive reviews.
 
 ## Path Filters
 
-Yak ships with sensible defaults for what to exclude from review — `vendor/**`, `node_modules/**`, lockfiles, minified assets, etc. The full default list is in `config/yak.php` under `pr_review.default_path_excludes`.
+Yak ships with sensible defaults for what to exclude from review — `vendor/**`, `node_modules/**`, build output, minified assets, editor config. The full default list is in `config/yak.php` under `pr_review.default_path_excludes`. Migrations and lockfiles are **not** excluded by default: migrations contain real logic (schema changes, indexes, destructive drops) worth a look, and lockfile diffs can surface dependency version bumps the author didn't highlight.
 
 If the defaults are wrong for a repo, the repo settings page has a **PR review path filters** section. You can add glob patterns (e.g. `custom/generated/**`), remove specific patterns, or reset back to the global defaults. The patterns support `*`, `**`, and `?` just like `.gitignore`.
 


### PR DESCRIPTION
## Summary
- Removes `database/migrations/**` and `*.lock` from `pr_review.default_path_excludes`
- Migrations carry real logic (schema changes, indexes, destructive drops) that's worth reviewing
- Lockfile diffs can surface dependency version bumps the PR description didn't mention
- Updated `docs/pr-review.md` to reflect the change

## Test plan
- [ ] `php artisan test --compact --filter=ConfigurationTest` still passes
- [ ] Post-deploy: open a PR that touches a migration and verify Yak reviews it