### PR TITLE
fix(pr-review): route Review tasks to correct prompt + auto-detect bot login

### DIFF
--- a/app/Actions/ApplyPrReviewToOpenPulls.php
+++ b/app/Actions/ApplyPrReviewToOpenPulls.php
@@ -10,9 +10,10 @@ class ApplyPrReviewToOpenPulls
     public function __invoke(Repository $repository): int
     {
         $installationId = (int) config('yak.channels.github.installation_id');
-        $yakBot = (string) config('yak.channels.github.app_bot_login');
+        $github = app(GitHubAppService::class);
+        $yakBot = $github->appBotLogin();
 
-        $prs = app(GitHubAppService::class)->listOpenPullRequests($installationId, $repository->slug);
+        $prs = $github->listOpenPullRequests($installationId, $repository->slug);
 
         $enqueued = 0;
 

--- a/app/Http/Controllers/Webhooks/GitHubWebhookController.php
+++ b/app/Http/Controllers/Webhooks/GitHubWebhookController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Models\PrReview;
 use App\Models\Repository;
 use App\Models\YakTask;
+use App\Services\GitHubAppService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -92,7 +93,7 @@ class GitHubWebhookController extends Controller
             return response()->json(['ok' => true, 'skipped' => 'draft PR']);
         }
 
-        if ((string) ($pr['user']['login'] ?? '') === (string) config('yak.channels.github.app_bot_login')) {
+        if ((string) ($pr['user']['login'] ?? '') === app(GitHubAppService::class)->appBotLogin()) {
             return response()->json(['ok' => true, 'skipped' => 'yak-authored PR']);
         }
 

--- a/app/Services/GitHubAppService.php
+++ b/app/Services/GitHubAppService.php
@@ -3,11 +3,50 @@
 namespace App\Services;
 
 use App\Models\GitHubInstallationToken;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
 class GitHubAppService
 {
     private const TOKEN_BUFFER_SECONDS = 300;
+
+    /**
+     * Bot login for the configured GitHub App, shaped like `my-app[bot]`.
+     *
+     * Reads the explicit `GITHUB_APP_BOT_LOGIN` env var when set; otherwise
+     * derives it from the App's `slug` (from `GET /app`) and caches for a
+     * day. Falls back to the default if the API call fails so the review
+     * path still skips cleanly even without network access.
+     */
+    public function appBotLogin(): string
+    {
+        $explicit = (string) config('yak.channels.github.app_bot_login_override', '');
+        if ($explicit !== '') {
+            return $explicit;
+        }
+
+        $default = (string) config('yak.channels.github.app_bot_login');
+
+        return Cache::remember('github-app-bot-login', now()->addDay(), function () use ($default): string {
+            try {
+                $jwt = $this->generateJwt();
+
+                $response = Http::withToken($jwt)
+                    ->withHeaders(['Accept' => 'application/vnd.github+json'])
+                    ->get('https://api.github.com/app');
+
+                $slug = $response->json('slug');
+
+                if (is_string($slug) && $slug !== '') {
+                    return $slug . '[bot]';
+                }
+            } catch (\Throwable) {
+                // Fall through to default
+            }
+
+            return $default;
+        });
+    }
 
     public function getInstallationToken(int $installationId): string
     {

--- a/app/YakPromptBuilder.php
+++ b/app/YakPromptBuilder.php
@@ -59,6 +59,10 @@ class YakPromptBuilder
             return self::researchPrompt($task->description ?? '');
         }
 
+        if ($mode === TaskMode::Review) {
+            return self::reviewPrompt($metadata);
+        }
+
         return match ($task->source) {
             'sentry' => self::sentryFixPrompt($metadata),
             'flaky-test' => self::flakyTestPrompt($metadata),
@@ -190,6 +194,27 @@ class YakPromptBuilder
     {
         return Prompts::render('tasks-research', [
             'description' => $description,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    private static function reviewPrompt(array $metadata): string
+    {
+        return Prompts::render('tasks-review', [
+            'prNumber' => (int) ($metadata['prNumber'] ?? 0),
+            'prTitle' => (string) ($metadata['prTitle'] ?? ''),
+            'prBody' => (string) ($metadata['prBody'] ?? ''),
+            'prAuthor' => (string) ($metadata['prAuthor'] ?? ''),
+            'baseBranch' => (string) ($metadata['baseBranch'] ?? 'main'),
+            'headBranch' => (string) ($metadata['headBranch'] ?? ''),
+            'diffSummary' => (string) ($metadata['diffSummary'] ?? ''),
+            'reviewScope' => (string) ($metadata['reviewScope'] ?? 'full'),
+            'changedFiles' => (array) ($metadata['changedFiles'] ?? []),
+            'repoAgentInstructions' => (string) ($metadata['repoAgentInstructions'] ?? ''),
+            'pathExcludes' => (array) ($metadata['pathExcludes'] ?? []),
+            'linearTicket' => $metadata['linearTicket'] ?? null,
         ]);
     }
 

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -51,6 +51,7 @@ export default defineConfig({
             { slug: 'setup' },
             { slug: 'channels' },
             { slug: 'repositories' },
+            { slug: 'pr-review' },
           ],
         },
         {

--- a/docs-site/scripts/sync-docs.mjs
+++ b/docs-site/scripts/sync-docs.mjs
@@ -33,6 +33,7 @@ const PAGES = [
   { file: 'setup.md',           title: 'Setup Guide',    description: 'Provision a Yak server with Ansible in one command.',                    group: 'getting-started', order: 1 },
   { file: 'channels.md',        title: 'Channels',       description: 'Configure Slack, Linear, Sentry, GitHub, Drone, and the manual CLI.',    group: 'getting-started', order: 2 },
   { file: 'repositories.md',    title: 'Repositories',   description: 'Add and manage repositories, setup tasks, and CLAUDE.md conventions.',   group: 'getting-started', order: 3 },
+  { file: 'pr-review.md',       title: 'PR Review',      description: 'Enable Yak to review pull requests with line-level comments and a feedback dashboard.', group: 'getting-started', order: 4 },
   { file: 'architecture.md',    title: 'Architecture',   description: 'How Yak works under the hood: two-tier AI, drivers, state machine.',    group: 'reference',       order: 1 },
   { file: 'prompting.md',       title: 'Prompting',      description: 'Three prompt layers, system prompt, task templates, MCP servers.',       group: 'reference',       order: 2 },
   { file: 'troubleshooting.md', title: 'Troubleshooting',description: 'Common problems and how to diagnose them.',                             group: 'operations',      order: 1 },

--- a/tests/Feature/Actions/ApplyPrReviewToOpenPullsTest.php
+++ b/tests/Feature/Actions/ApplyPrReviewToOpenPullsTest.php
@@ -22,6 +22,7 @@ it('enqueues review tasks for each open non-draft non-Yak PR', function () {
     ]);
 
     $github = mock(GitHubAppService::class);
+    $github->shouldReceive('appBotLogin')->andReturn('yak-bot[bot]');
     $github->shouldReceive('listOpenPullRequests')->andReturn([
         ['number' => 1, 'html_url' => 'u1', 'title' => '', 'body' => '', 'draft' => false, 'user' => ['login' => 'maria'], 'head' => ['ref' => 'h1', 'sha' => 's1'], 'base' => ['ref' => 'main', 'sha' => 'b1']],
         ['number' => 2, 'html_url' => 'u2', 'title' => '', 'body' => '', 'draft' => true, 'user' => ['login' => 'maria'], 'head' => ['ref' => 'h2', 'sha' => 's2'], 'base' => ['ref' => 'main', 'sha' => 'b2']],

--- a/tests/Feature/Repos/RepoPrReviewToggleTest.php
+++ b/tests/Feature/Repos/RepoPrReviewToggleTest.php
@@ -32,6 +32,7 @@ it('enqueues retroactive review tasks when enabling with apply_to_open_prs', fun
     $repo = Repository::factory()->create(['pr_review_enabled' => false, 'slug' => 'geocodio/api']);
 
     $github = mock(GitHubAppService::class);
+    $github->shouldReceive('appBotLogin')->andReturn('yak-bot[bot]');
     $github->shouldReceive('listOpenPullRequests')->andReturn([
         ['number' => 1, 'html_url' => 'u1', 'title' => '', 'body' => '', 'draft' => false, 'user' => ['login' => 'maria'], 'head' => ['ref' => 'h', 'sha' => 's1'], 'base' => ['ref' => 'main', 'sha' => 'b1']],
     ]);

--- a/tests/Feature/YakPromptBuilderTest.php
+++ b/tests/Feature/YakPromptBuilderTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\TaskMode;
 use App\Models\Repository;
 use App\Models\YakTask;
 use App\YakPromptBuilder;
@@ -298,6 +299,40 @@ test('slack fix prompt uses default requester name when not provided', function 
     $prompt = YakPromptBuilder::taskPrompt($task);
 
     expect($prompt)->toContain('a team member');
+});
+
+/*
+|--------------------------------------------------------------------------
+| Task Prompts - Review
+|--------------------------------------------------------------------------
+*/
+
+test('review prompt renders the tasks-review template for a review task', function () {
+    $task = YakTask::factory()->pending()->create([
+        'mode' => TaskMode::Review,
+        'source' => 'github',
+        'description' => 'Review PR #42',
+    ]);
+
+    $prompt = YakPromptBuilder::taskPrompt($task, [
+        'prNumber' => 42,
+        'prTitle' => 'Add retry',
+        'prBody' => 'Fixes GEO-1234',
+        'prAuthor' => 'mathias',
+        'baseBranch' => 'main',
+        'headBranch' => 'feat/retry',
+        'diffSummary' => 'app/Foo.php | 3 +--',
+        'reviewScope' => 'full',
+        'changedFiles' => ['app/Foo.php'],
+        'repoAgentInstructions' => '',
+        'pathExcludes' => [],
+        'linearTicket' => null,
+    ]);
+
+    expect($prompt)->toContain('Review pull request #42')
+        ->and($prompt)->toContain('Add retry')
+        ->and($prompt)->toContain('full review')
+        ->and($prompt)->not->toContain('clarification_needed');
 });
 
 /*


### PR DESCRIPTION
## Summary
Two bugs caught on the first real review task on prod:

- **Wrong prompt used.** `YakPromptBuilder::taskPrompt()` had no `TaskMode::Review` branch, so review tasks fell through to `default => slackFixPrompt`. The agent got the Slack-fix clarification prompt instead of the review rubric, ran the review skill anyway, and failed with \"Agent did not emit a JSON code block.\" Added a Review-mode branch that renders `tasks-review`.
- **Yak-authored PRs not skipped.** The config default `yak-bot[bot]` doesn't match the real bot login on self-hosted installs (e.g. `yak-geocodio[bot]`). Added `GitHubAppService::appBotLogin()` which calls `GET /app` once and caches the slug for a day.

Plus: add the PR Review page to the docs-site sidebar + sync-docs PAGES list so `/yak/pr-review/` renders.

## Test plan
- [ ] Feature suite passes
- [ ] New YakPromptBuilder test verifies review-mode routes to `tasks-review` and the prompt contains \"Review pull request\" / no \"clarification_needed\"
- [ ] Post-deploy: open a new PR on a pr-review-enabled repo and confirm the review lands with the correct rubric
- [ ] Post-deploy: confirm `/yak/pr-review/` resolves on the docs site