### PR TITLE
fix(agents): pipe claude -p prompt via stdin to avoid E2BIG

### DIFF
--- a/app/Agents/SandboxedAgentRunner.php
+++ b/app/Agents/SandboxedAgentRunner.php
@@ -244,7 +244,8 @@ class SandboxedAgentRunner implements AgentRunner
 
         [$process, $pipes] = $this->sandbox->streamExec($containerName, $command);
 
-        fclose($pipes[0]); // Close stdin
+        $this->writePromptToStdin($pipes[0], $request->prompt);
+        fclose($pipes[0]);
 
         $lineCount = 0;
         $stdout = $pipes[1];
@@ -472,13 +473,66 @@ class SandboxedAgentRunner implements AgentRunner
         $containerName = $request->containerName;
         $command = $this->buildClaudeCommand($request);
 
-        $result = $this->sandbox->run($containerName, $command, $request->timeoutSeconds);
+        $result = $this->sandbox->run(
+            $containerName,
+            $command,
+            $request->timeoutSeconds,
+            input: $request->prompt,
+        );
 
         if (ClaudeAuthDetector::isAuthError($result)) {
             throw new ClaudeAuthException(ClaudeAuthDetector::formatErrorMessage($result));
         }
 
         return ClaudeCodeOutputParser::parse(trim($result->output()));
+    }
+
+    /**
+     * Write the prompt to `claude -p`'s stdin, draining the pipe via
+     * stream_select so we don't deadlock when the prompt exceeds the
+     * OS pipe buffer (64KB on Linux by default, up to 1MB). claude
+     * reads stdin as the user prompt when no positional prompt arg
+     * is given — this is the documented `cat | claude -p` pattern.
+     *
+     * @param  resource  $stdin
+     */
+    private function writePromptToStdin($stdin, string $prompt): void
+    {
+        if ($prompt === '') {
+            return;
+        }
+
+        stream_set_blocking($stdin, false);
+
+        $len = strlen($prompt);
+        $offset = 0;
+        $startedAt = microtime(true);
+
+        while ($offset < $len) {
+            if ((microtime(true) - $startedAt) > 60.0) {
+                Log::channel('yak')->warning('Claude stream: stdin write timed out', [
+                    'bytes_written' => $offset,
+                    'bytes_total' => $len,
+                ]);
+                break;
+            }
+
+            $write = [$stdin];
+            $read = null;
+            $except = null;
+
+            if (@stream_select($read, $write, $except, 5) === false) {
+                break;
+            }
+
+            $bytes = @fwrite($stdin, substr($prompt, $offset));
+
+            if ($bytes === false) {
+                break;
+            }
+
+            $offset += $bytes;
+        }
     }
 
     private function processLine(string $line, StreamEventHandler $handler): void
@@ -517,10 +571,15 @@ class SandboxedAgentRunner implements AgentRunner
 
         $workspacePath = (string) config('yak.sandbox.workspace_path', '/workspace');
 
+        // The user prompt is streamed to `claude -p` via stdin rather
+        // than embedded as an argv argument. Linux caps a single argv
+        // entry at MAX_ARG_STRLEN (~128KB); a large PR review prompt
+        // exceeds that and `proc_open()` fails with E2BIG
+        // ("posix_spawn(): Argument list too long"). Documented claude
+        // -p pattern: `cat context.txt | claude -p --flags...`.
         $command = sprintf(
-            'cd %s && claude -p %s --dangerously-skip-permissions --output-format %s%s --model %s --max-turns %d --max-budget-usd %s --append-system-prompt %s',
+            'cd %s && claude -p --dangerously-skip-permissions --output-format %s%s --model %s --max-turns %d --max-budget-usd %s --append-system-prompt %s',
             escapeshellarg($workspacePath),
-            escapeshellarg($request->prompt),
             $outputFormat,
             $verboseFlag,
             escapeshellarg($request->model),

--- a/app/Services/IncusSandboxManager.php
+++ b/app/Services/IncusSandboxManager.php
@@ -110,11 +110,15 @@ class IncusSandboxManager
      *
      * Returns the raw process result for callers that need stdout/stderr.
      */
-    public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false): ProcessResult
+    public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
     {
         $cmd = $this->buildExecCommand($containerName, $command, $asRoot);
 
         $process = Process::timeout($timeout ?? 600);
+
+        if ($input !== null) {
+            $process = $process->input($input);
+        }
 
         return $process->run($cmd);
     }

--- a/tests/Feature/Agents/SandboxedAgentRunnerTest.php
+++ b/tests/Feature/Agents/SandboxedAgentRunnerTest.php
@@ -25,7 +25,7 @@ class RecordingSandboxManager extends IncusSandboxManager
         $this->responses[$pattern] = $result;
     }
 
-    public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false): ProcessResult
+    public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
     {
         $this->calls[] = ['command' => $command, 'asRoot' => $asRoot, 'timeout' => $timeout];
 
@@ -103,7 +103,7 @@ it('logs the before/after Claude versions on the task when a task is attached', 
     {
         private int $versionCalls = 0;
 
-        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false): ProcessResult
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
         {
             $this->calls[] = ['command' => $command, 'asRoot' => $asRoot, 'timeout' => $timeout];
 
@@ -143,7 +143,7 @@ it('logs a friendlier line when Claude was already up to date (no version change
 
     $sandbox = new class extends RecordingSandboxManager
     {
-        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false): ProcessResult
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
         {
             $this->calls[] = ['command' => $command, 'asRoot' => $asRoot, 'timeout' => $timeout];
 
@@ -423,7 +423,7 @@ it('is tolerant of a failed npm install and still invokes claude -p', function (
 
     $sandbox = new class extends RecordingSandboxManager
     {
-        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false): ProcessResult
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
         {
             $this->calls[] = ['command' => $command, 'asRoot' => $asRoot, 'timeout' => $timeout];
 
@@ -475,4 +475,153 @@ test('claude command contains no environment-export prefix (env comes from Incus
         ->not->toContain('ghp_should_not_appear_here');
 
     putenv('NODE_AUTH_TOKEN');
+});
+
+test('user prompt is piped to claude -p via stdin, never embedded as an argv argument', function () {
+    // Regression: a 144KB PR review prompt (task 4505) overflowed
+    // Linux's MAX_ARG_STRLEN (~128KB per argv entry) when embedded in
+    // the shell command, producing
+    // "proc_open(): posix_spawn() failed: Argument list too long".
+    // The prompt must travel through stdin — which has no ARG_MAX —
+    // not through argv.
+    $task = YakTask::factory()->running()->create();
+
+    $largePrompt = str_repeat('A', 200_000) . '[SENTINEL-MARKER]';
+    $capturedStdin = tempnam(sys_get_temp_dir(), 'yak-stdin-');
+
+    $sandbox = new class($capturedStdin) extends RecordingSandboxManager
+    {
+        public function __construct(public string $stdinCaptureFile) {}
+
+        public function streamExec(string $containerName, string $command, bool $asRoot = false): array
+        {
+            $this->calls[] = ['command' => $command, 'asRoot' => $asRoot, 'timeout' => null];
+
+            $descriptors = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+
+            // Drain stdin to a capture file, then emit a valid result
+            // event so the runner exits cleanly. bash makes the stdin
+            // redirection a separate process step from the printf,
+            // which lets us capture AFTER the runner finishes writing.
+            $resultEvent = json_encode([
+                'type' => 'result',
+                'is_error' => false,
+                'result' => 'prompt received',
+                'num_turns' => 1,
+                'total_cost_usd' => 0.0,
+                'duration_ms' => 1,
+                'session_id' => 'sess_stdin_capture',
+            ]);
+
+            $shellCommand = sprintf(
+                'cat > %s; printf "%%s\n" %s',
+                escapeshellarg($this->stdinCaptureFile),
+                escapeshellarg($resultEvent),
+            );
+
+            $process = proc_open(['bash', '-c', $shellCommand], $descriptors, $pipes);
+
+            return [$process, $pipes];
+        }
+    };
+
+    $runner = new SandboxedAgentRunner(
+        sandbox: $sandbox,
+        postResultGraceSeconds: 0.5,
+        streamIdleTimeoutSeconds: 30,
+        streamPollIntervalSeconds: 0,
+    );
+
+    $request = new AgentRunRequest(
+        prompt: $largePrompt,
+        systemPrompt: 'you are yak agent',
+        containerName: 'task-stdin-test',
+        timeoutSeconds: 600,
+        maxBudgetUsd: 5.0,
+        maxTurns: 300,
+        model: 'opus',
+        task: $task,
+    );
+
+    $result = $runner->run($request);
+
+    $claudeCall = collect($sandbox->calls)
+        ->first(fn (array $c): bool => str_contains($c['command'], 'claude -p'));
+
+    expect($claudeCall)->not->toBeNull();
+    // argv-size guard: the shell command we hand to proc_open must
+    // stay far below MAX_ARG_STRLEN regardless of prompt size.
+    expect(strlen($claudeCall['command']))->toBeLessThan(10_000);
+    expect($claudeCall['command'])->not->toContain('[SENTINEL-MARKER]');
+    expect($claudeCall['command'])->not->toContain(str_repeat('A', 1000));
+
+    // stdin path: the prompt arrived at the child process via the
+    // stdin pipe, byte-for-byte.
+    expect(file_get_contents($capturedStdin))->toBe($largePrompt);
+
+    expect($result->isError)->toBeFalse();
+    expect($result->resultSummary)->toBe('prompt received');
+
+    @unlink($capturedStdin);
+});
+
+test('batch mode feeds the prompt to claude -p via stdin, not argv', function () {
+    // Same regression as the streaming test, but for runBatch() —
+    // invoked when AgentRunRequest has no task attached.
+    $largePrompt = str_repeat('B', 180_000) . '[BATCH-SENTINEL]';
+
+    $sandbox = new class extends RecordingSandboxManager
+    {
+        public ?string $capturedInput = null;
+
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
+        {
+            $this->calls[] = ['command' => $command, 'asRoot' => $asRoot, 'timeout' => $timeout];
+
+            if (str_contains($command, 'claude -p')) {
+                $this->capturedInput = $input;
+
+                return Process::result(json_encode([
+                    'type' => 'result',
+                    'is_error' => false,
+                    'result' => 'batch ok',
+                    'num_turns' => 1,
+                    'total_cost_usd' => 0.0,
+                    'duration_ms' => 1,
+                    'session_id' => 'sess_batch',
+                ]));
+            }
+
+            if (str_contains($command, 'claude --version')) {
+                return Process::result("2.1.118 (Claude Code)\n");
+            }
+
+            return Process::result('');
+        }
+    };
+
+    $request = new AgentRunRequest(
+        prompt: $largePrompt,
+        systemPrompt: 'system',
+        containerName: 'task-batch-stdin',
+        timeoutSeconds: 600,
+        maxBudgetUsd: 5.0,
+        maxTurns: 50,
+        model: 'opus',
+    );
+
+    $runner = new SandboxedAgentRunner($sandbox);
+    $runner->run($request);
+
+    $claudeCall = collect($sandbox->calls)
+        ->first(fn (array $c): bool => str_contains($c['command'], 'claude -p'));
+
+    expect($claudeCall)->not->toBeNull();
+    expect(strlen($claudeCall['command']))->toBeLessThan(10_000);
+    expect($claudeCall['command'])->not->toContain('[BATCH-SENTINEL]');
+    expect($sandbox->capturedInput)->toBe($largePrompt);
 });

--- a/tests/Feature/ClarificationReplyJobTest.php
+++ b/tests/Feature/ClarificationReplyJobTest.php
@@ -103,7 +103,7 @@ test('refreshes git credential helper immediately before push', function () {
         /** @var array<int, string> */
         public array $commands = [];
 
-        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false): ProcessResult
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
         {
             $this->commands[] = $command;
 

--- a/tests/Feature/RetryYakJobTest.php
+++ b/tests/Feature/RetryYakJobTest.php
@@ -175,7 +175,7 @@ test('refreshes git credential helper immediately before push', function () {
         /** @var array<int, string> */
         public array $commands = [];
 
-        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false): ProcessResult
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
         {
             $this->commands[] = $command;
 

--- a/tests/Feature/RunYakJobTest.php
+++ b/tests/Feature/RunYakJobTest.php
@@ -334,7 +334,7 @@ test('branch name gets a counter suffix when remote already has the branch', fun
         /** @param  array<int, string>  $existingRemoteBranches */
         public function __construct(private array $existingRemoteBranches) {}
 
-        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false): ProcessResult
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
         {
             if (preg_match("/git ls-remote --heads origin '([^']+)'/", $command, $m)) {
                 return in_array($m[1], $this->existingRemoteBranches, true)
@@ -805,7 +805,7 @@ test('refreshes git credential helper immediately before push', function () {
         /** @var array<int, string> */
         public array $commands = [];
 
-        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false): ProcessResult
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
         {
             $this->commands[] = $command;
 

--- a/tests/Support/FakeSandboxManager.php
+++ b/tests/Support/FakeSandboxManager.php
@@ -63,7 +63,7 @@ class FakeSandboxManager extends IncusSandboxManager
         return $name;
     }
 
-    public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false): ProcessResult
+    public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
     {
         if (str_contains($command, 'git rev-list --count origin/')) {
             return Process::result((string) $this->commitCount);

--- a/tests/Unit/GitOperationsHasUncommittedChangesTest.php
+++ b/tests/Unit/GitOperationsHasUncommittedChangesTest.php
@@ -13,7 +13,7 @@ function fakeSandboxReturningPorcelain(string $stdout, int $exit = 0): IncusSand
 
         public function __construct(private string $stdout, private int $exit) {}
 
-        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false): ProcessResult
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
         {
             $this->lastCommand = $command;
 


### PR DESCRIPTION
## Summary

- Large PR review prompts (144KB on prod task 4505) overflowed Linux's `MAX_ARG_STRLEN` (~128KB per argv entry) when embedded in the shell command, producing `proc_open(): posix_spawn() failed: Argument list too long`.
- Fix: stream the user prompt to `claude -p` via stdin instead of embedding it as an argv argument. Matches the documented `cat context.txt | claude -p` pattern and has no ARG_MAX limit.
- `writePromptToStdin()` uses a non-blocking `stream_select` write loop so prompts larger than the OS pipe buffer (64KB on Linux) don't deadlock the producer/consumer.
- `IncusSandboxManager::run()` gains optional `?string $input` which threads through to `Process::input()` for the batch path.

## Root cause

From `storage/logs/laravel.log` on prod:

```
[2026-04-23 11:11:56] production.ERROR: RunYakReviewJob failed
{"task_id":4505,"error":"proc_open(): posix_spawn() failed: Argument list too long"}
[2026-04-23 11:11:56] production.INFO: Claude stream starting (sandboxed)
{"task_id":4505,"container":"task-4505","command_length":144348, ...}
```

The previous `buildClaudeCommand()` embedded `escapeshellarg($request->prompt)` inline; that whole shell command became the final argv entry passed to `proc_open` in `IncusSandboxManager::buildExecArgv()`. 144,348 > 131,072 → `E2BIG`.

## Test plan

- [x] New regression test (streaming path): 200KB prompt — asserts command stays under 10KB and the full bytes reach the child process's stdin
- [x] New regression test (batch path): 180KB prompt — same assertions via `Process::input()`
- [x] `tests/Feature/Agents` (13), `tests/Feature/Services`, `tests/Unit`, `tests/Feature/Jobs`, `RunYakJobTest`, `RetryYakJobTest`, `ClarificationReplyJobTest`, `SetupYakJobTest` — 386 tests pass, 1 unrelated skip
- [x] **E2E proof that `claude -p` accepts stdin-only prompts** — ran live in the prod yak container with the same flag set the runner uses:
  ```
  echo "Reply with only the word banana..." \
    | claude -p --dangerously-skip-permissions --output-format stream-json --verbose \
      --model sonnet --max-turns 1 --max-budget-usd 0.05 --no-session-persistence \
      --append-system-prompt "You are a test assistant."
  ```
  Result (stream-json): `{"type":"assistant","message":{"content":[{"type":"text","text":"banana"}]...,"usage":{"input_tokens":2,...}}}` — claude read the prompt from stdin with zero positional args and responded correctly.
- [ ] Post-deploy: retry task 4505 via `RunYakReviewJob::dispatch(YakTask::find(4505))`; verify the stream completes without `Argument list too long`