### PR TITLE
feat: two-way feedback — chat with Yak to update an open PR (all surfaces)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           php-version: '8.4'
           tools: composer:v2
           extensions: sqlite3, pdo_sqlite
-          coverage: xdebug
+          coverage: none
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -53,4 +53,4 @@ jobs:
         run: npm run build
 
       - name: Run Tests
-        run: php -d memory_limit=-1 ./vendor/bin/pest --ci --exclude-group=contract
+        run: ./vendor/bin/pest --ci --exclude-group=contract

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,4 +53,4 @@ jobs:
         run: npm run build
 
       - name: Run Tests
-        run: ./vendor/bin/pest --ci --exclude-group=contract
+        run: php -d memory_limit=-1 ./vendor/bin/pest --ci --exclude-group=contract

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           php-version: '8.4'
           tools: composer:v2
           extensions: sqlite3, pdo_sqlite
-          coverage: none
+          coverage: xdebug
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/ansible/roles/github-app/templates/app-manifest.json.j2
+++ b/ansible/roles/github-app/templates/app-manifest.json.j2
@@ -10,13 +10,15 @@
   "default_permissions": {
     "contents": "write",
     "pull_requests": "write",
-    "issues": "read",
+    "issues": "write",
     "checks": "read",
     "metadata": "read"
   },
   "default_events": [
     "check_suite",
     "pull_request",
-    "pull_request_review"
+    "pull_request_review",
+    "issue_comment",
+    "pull_request_review_comment"
   ]
 }

--- a/app/Channels/GitHub/AppService.php
+++ b/app/Channels/GitHub/AppService.php
@@ -237,13 +237,17 @@ class AppService
             ]);
     }
 
-    public function addReaction(int $installationId, string $repoSlug, int $commentId, string $content): void
+    public function addReaction(int $installationId, string $repoSlug, int $commentId, string $content, bool $isReviewComment = false): void
     {
         $token = $this->getInstallationToken($installationId);
 
+        $path = $isReviewComment
+            ? "https://api.github.com/repos/{$repoSlug}/pulls/comments/{$commentId}/reactions"
+            : "https://api.github.com/repos/{$repoSlug}/issues/comments/{$commentId}/reactions";
+
         Http::withToken($token)
             ->withHeaders(['Accept' => 'application/vnd.github+json'])
-            ->post("https://api.github.com/repos/{$repoSlug}/issues/comments/{$commentId}/reactions", [
+            ->post($path, [
                 'content' => $content,
             ]);
     }

--- a/app/Channels/GitHub/AppService.php
+++ b/app/Channels/GitHub/AppService.php
@@ -202,6 +202,42 @@ class AppService
     }
 
     /**
+     * Return the first open PR whose head is the given branch, or null.
+     * Used to keep PR creation idempotent — a follow-up pushes to an
+     * existing branch, so a PR already exists.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function findOpenPullRequestForBranch(int $installationId, string $repoSlug, string $branch): ?array
+    {
+        $token = $this->getInstallationToken($installationId);
+        $owner = explode('/', $repoSlug)[0];
+
+        $response = Http::withToken($token)
+            ->withHeaders(['Accept' => 'application/vnd.github+json'])
+            ->get("https://api.github.com/repos/{$repoSlug}/pulls", [
+                'head' => "{$owner}:{$branch}",
+                'state' => 'open',
+            ]);
+
+        /** @var array<int, array<string, mixed>> $prs */
+        $prs = $response->successful() ? $response->json() : [];
+
+        return $prs[0] ?? null;
+    }
+
+    public function commentOnPullRequest(int $installationId, string $repoSlug, int $prNumber, string $body): void
+    {
+        $token = $this->getInstallationToken($installationId);
+
+        Http::withToken($token)
+            ->withHeaders(['Accept' => 'application/vnd.github+json'])
+            ->post("https://api.github.com/repos/{$repoSlug}/issues/{$prNumber}/comments", [
+                'body' => $body,
+            ]);
+    }
+
+    /**
      * @param  array<int, string>  $labels
      */
     public function addLabels(int $installationId, string $repoSlug, int $prNumber, array $labels): void

--- a/app/Channels/GitHub/AppService.php
+++ b/app/Channels/GitHub/AppService.php
@@ -237,6 +237,17 @@ class AppService
             ]);
     }
 
+    public function addReaction(int $installationId, string $repoSlug, int $commentId, string $content): void
+    {
+        $token = $this->getInstallationToken($installationId);
+
+        Http::withToken($token)
+            ->withHeaders(['Accept' => 'application/vnd.github+json'])
+            ->post("https://api.github.com/repos/{$repoSlug}/issues/comments/{$commentId}/reactions", [
+                'content' => $content,
+            ]);
+    }
+
     /**
      * @param  array<int, string>  $labels
      */

--- a/app/Channels/GitHub/FollowUpCommentParser.php
+++ b/app/Channels/GitHub/FollowUpCommentParser.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Channels\GitHub;
+
+class FollowUpCommentParser
+{
+    /**
+     * Return the instructions from a PR comment addressed to Yak via a
+     * configured prefix (case-insensitive, anchored to the first non-empty
+     * line), or null if the comment isn't for Yak / has no instructions.
+     */
+    public function parse(string $body): ?string
+    {
+        $trimmed = ltrim($body);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        foreach ($this->prefixes() as $prefix) {
+            if ($prefix === '') {
+                continue;
+            }
+
+            if (mb_strtolower(mb_substr($trimmed, 0, mb_strlen($prefix))) === mb_strtolower($prefix)) {
+                $instructions = trim(mb_substr($trimmed, mb_strlen($prefix)));
+
+                return $instructions === '' ? null : $instructions;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function prefixes(): array
+    {
+        $raw = (string) config('yak.followup.github_prefixes', '');
+
+        return array_values(array_filter(array_map('trim', explode(',', $raw)), fn (string $p): bool => $p !== ''));
+    }
+}

--- a/app/Channels/GitHub/WebhookController.php
+++ b/app/Channels/GitHub/WebhookController.php
@@ -154,6 +154,12 @@ class WebhookController extends Controller
             }
         }
 
+        // Stamp the whole follow-up chain (children share the root's pr_url) so
+        // the merged/closed guard (prIsOpen) is correct for every task in the
+        // conversation, not just the first row found.
+        $timestampColumn = $merged ? 'pr_merged_at' : 'pr_closed_at';
+        YakTask::where('pr_url', $prUrl)->whereNull($timestampColumn)->update([$timestampColumn => now()]);
+
         $prReviews = PrReview::where('pr_url', $prUrl)->get();
 
         foreach ($prReviews as $pr) {

--- a/app/Channels/GitHub/WebhookController.php
+++ b/app/Channels/GitHub/WebhookController.php
@@ -8,8 +8,10 @@ use App\Http\Controllers\Controller;
 use App\Jobs\Deployments\DeployBranchJob;
 use App\Jobs\Deployments\DestroyDeploymentJob;
 use App\Jobs\Deployments\UpdateDeploymentJob;
+use App\Jobs\FlushFollowUpBatchJob;
 use App\Jobs\ProcessCIResultJob;
 use App\Models\BranchDeployment;
+use App\Models\FollowUpPendingComment;
 use App\Models\PrReview;
 use App\Models\Repository;
 use App\Models\YakTask;
@@ -42,6 +44,14 @@ class WebhookController extends Controller
 
         if ($event === 'delete') {
             return $this->handleDeploymentDelete($request);
+        }
+
+        if ($event === 'issue_comment') {
+            return $this->handleIssueComment($request, $github);
+        }
+
+        if ($event === 'pull_request_review_comment') {
+            return $this->handlePullRequestReviewComment($request, $github);
         }
 
         if ($event !== 'pull_request') {
@@ -282,6 +292,113 @@ class WebhookController extends Controller
         }
 
         return response()->json(['ok' => true]);
+    }
+
+    private function handleIssueComment(Request $request, AppService $github): JsonResponse
+    {
+        if ($request->input('action') !== 'created') {
+            return response()->json(['ok' => true, 'skipped' => 'not a created comment']);
+        }
+
+        $issue = (array) $request->input('issue', []);
+
+        if (! isset($issue['pull_request'])) {
+            return response()->json(['ok' => true, 'skipped' => 'not a PR comment']);
+        }
+
+        $prUrl = (string) data_get($request->all(), 'issue.pull_request.html_url', '');
+
+        return $this->processFollowUpComment($request, $github, $prUrl, isReviewComment: false);
+    }
+
+    private function handlePullRequestReviewComment(Request $request, AppService $github): JsonResponse
+    {
+        if ($request->input('action') !== 'created') {
+            return response()->json(['ok' => true, 'skipped' => 'not a created comment']);
+        }
+
+        $prUrl = (string) $request->input('pull_request.html_url', '');
+
+        return $this->processFollowUpComment($request, $github, $prUrl, isReviewComment: true);
+    }
+
+    private function processFollowUpComment(Request $request, AppService $github, string $prUrl, bool $isReviewComment): JsonResponse
+    {
+        $comment = (array) $request->input('comment', []);
+        $authorLogin = (string) ($comment['user']['login'] ?? '');
+
+        if ($authorLogin !== '' && $authorLogin === $github->appBotLogin()) {
+            return response()->json(['ok' => true, 'skipped' => 'yak authored comment']);
+        }
+
+        $instructions = app(FollowUpCommentParser::class)->parse((string) ($comment['body'] ?? ''));
+
+        if ($instructions === null) {
+            return response()->json(['ok' => true, 'skipped' => 'no yak prefix']);
+        }
+
+        if ($prUrl === '') {
+            return response()->json(['ok' => true, 'skipped' => 'no pr url']);
+        }
+
+        $task = YakTask::where('pr_url', $prUrl)->first();
+
+        if ($task === null) {
+            return response()->json(['ok' => true, 'skipped' => 'no yak task for pr']);
+        }
+
+        $installationId = (int) config('yak.channels.github.installation_id');
+        $repoSlug = (string) ($request->input('repository.full_name') ?? $task->repo);
+        $commentId = (int) ($comment['id'] ?? 0);
+
+        if ($installationId > 0 && $commentId > 0) {
+            $github->addReaction($installationId, $repoSlug, $commentId, 'eyes', isReviewComment: $isReviewComment);
+        }
+
+        if (! $task->prIsOpen()) {
+            if ($installationId > 0) {
+                $prNumber = (int) ($task->pr_number ?? $this->extractPrNumber($prUrl));
+
+                if ($prNumber > 0) {
+                    $github->commentOnPullRequest(
+                        $installationId,
+                        $repoSlug,
+                        $prNumber,
+                        "This PR is already merged or closed, so I can't push more changes here. Open a new issue or task and I'll pick it up.",
+                    );
+                }
+            }
+
+            return response()->json(['ok' => true, 'skipped' => 'pr not open']);
+        }
+
+        $hadPending = FollowUpPendingComment::where('pr_url', $prUrl)->exists();
+
+        FollowUpPendingComment::create([
+            'yak_task_id' => $task->id,
+            'pr_url' => $prUrl,
+            'body' => $instructions,
+            'file' => $isReviewComment ? ($comment['path'] ?? null) : null,
+            'line' => $isReviewComment ? ($comment['line'] ?? $comment['original_line'] ?? null) : null,
+            'diff_hunk' => $isReviewComment ? ($comment['diff_hunk'] ?? null) : null,
+            'github_comment_id' => $commentId ?: null,
+        ]);
+
+        if (! $hadPending) {
+            FlushFollowUpBatchJob::dispatch($prUrl)
+                ->delay(now()->addSeconds((int) config('yak.followup.github_batch_window_seconds', 60)));
+        }
+
+        return response()->json(['ok' => true]);
+    }
+
+    private function extractPrNumber(string $prUrl): int
+    {
+        if (preg_match('#/pull/(\d+)#', $prUrl, $m)) {
+            return (int) $m[1];
+        }
+
+        return 0;
     }
 
     private function resolveRepositoryFromPayload(Request $request): ?Repository

--- a/app/Channels/Linear/NotificationDriver.php
+++ b/app/Channels/Linear/NotificationDriver.php
@@ -49,6 +49,25 @@ class NotificationDriver implements NotificationDriverContract
     }
 
     /**
+     * Post an `action` activity to the Linear agent session timeline,
+     * recording a concrete action taken and its optional outcome.
+     * Used for milestones like "PR opened" where a result URL is available.
+     */
+    public function postAction(string $sessionId, string $action, ?string $result = null): void
+    {
+        $accessToken = $this->resolveAccessToken();
+        if ($accessToken === null || $sessionId === '') {
+            return;
+        }
+
+        $this->sendAgentActivityContent($accessToken, $sessionId, [
+            'type' => 'action',
+            'action' => $action,
+            'result' => $result,
+        ]);
+    }
+
+    /**
      * Move the Linear issue associated with a task to a specific
      * workflow state. Returns silently when no connection or issue UUID
      * is available.
@@ -120,16 +139,24 @@ class NotificationDriver implements NotificationDriverContract
 
     private function sendAgentActivity(string $accessToken, string $sessionId, string $type, string $body): void
     {
+        $this->sendAgentActivityContent($accessToken, $sessionId, [
+            'type' => $type,
+            'body' => $body,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $content
+     */
+    private function sendAgentActivityContent(string $accessToken, string $sessionId, array $content): void
+    {
         Http::withToken($accessToken)
             ->post(self::GRAPHQL_ENDPOINT, [
                 'query' => 'mutation($input: AgentActivityCreateInput!) { agentActivityCreate(input: $input) { success } }',
                 'variables' => [
                     'input' => [
                         'agentSessionId' => $sessionId,
-                        'content' => [
-                            'type' => $type,
-                            'body' => $body,
-                        ],
+                        'content' => $content,
                     ],
                 ],
             ]);

--- a/app/Channels/Linear/WebhookController.php
+++ b/app/Channels/Linear/WebhookController.php
@@ -131,6 +131,11 @@ class WebhookController extends Controller
         app(NotificationDriver::class)
             ->send($task, NotificationType::Acknowledgment, $ackMessage);
 
+        $startedStateId = (string) config('yak.channels.linear.started_state_id');
+        if ($startedStateId !== '') {
+            app(NotificationDriver::class)->setIssueState($task, $startedStateId);
+        }
+
         $this->dispatchAgentJob($task);
 
         return response()->json(['ok' => true]);

--- a/app/Channels/Linear/WebhookController.php
+++ b/app/Channels/Linear/WebhookController.php
@@ -102,6 +102,14 @@ class WebhookController extends Controller
 
         // Unassignment: stop any in-flight work on that issue.
         if (str_contains(strtolower($type), 'unassign') && $issueId !== '') {
+            // Reject ids that contain LIKE metacharacters (%, _) or other
+            // characters outside the Linear id alphabet. This blocks wildcard
+            // injection: a payload with issueId='%' would otherwise broaden
+            // the LIKE match to every in-flight Linear task and cancel them all.
+            if (! preg_match('/^[A-Za-z0-9_-]+$/', $issueId)) {
+                return response()->json(['ok' => true]);
+            }
+
             $cancellable = [
                 TaskStatus::Pending,
                 TaskStatus::Running,
@@ -110,8 +118,17 @@ class WebhookController extends Controller
                 TaskStatus::Retrying,
             ];
 
+            // Escape LIKE metacharacters as defense-in-depth (the regex above
+            // already rejects '%', but this keeps the query correct if the
+            // allowlist ever widens). Linear issue ids are globally-unique UUIDs,
+            // so cross-workspace task collisions are not practical; a per-workspace
+            // DB filter would require a schema change (YakTask has no workspace_id
+            // column). The resolveConnection() guard above already ensures only
+            // events from connected workspaces reach this point.
+            $escaped = addcslashes($issueId, '%_\\');
+
             $tasks = YakTask::where('source', 'linear')
-                ->where('context', 'like', '%' . $issueId . '%')
+                ->where('context', 'like', '%' . $escaped . '%')
                 ->get()
                 ->filter(fn (YakTask $t) => in_array($t->status, $cancellable, strict: true));
 

--- a/app/Channels/Linear/WebhookController.php
+++ b/app/Channels/Linear/WebhookController.php
@@ -130,7 +130,12 @@ class WebhookController extends Controller
             $tasks = YakTask::where('source', 'linear')
                 ->where('context', 'like', '%' . $escaped . '%')
                 ->get()
-                ->filter(fn (YakTask $t) => in_array($t->status, $cancellable, strict: true));
+                ->filter(function (YakTask $t) use ($cancellable): bool {
+                    /** @var TaskStatus $status */
+                    $status = $t->status;
+
+                    return in_array($status, $cancellable, strict: true);
+                });
 
             foreach ($tasks as $task) {
                 $task->update(['status' => TaskStatus::Cancelled, 'completed_at' => now()]);
@@ -272,6 +277,9 @@ class WebhookController extends Controller
             return response()->json(['ok' => true]);
         }
 
+        /** @var TaskStatus $status */
+        $status = $task->status;
+
         // Read the message body from either the nested content shape
         // (agentActivity.content.body) or the flat shape (agentActivity.body).
         $message = (string) ($request->input('agentActivity.content.body')
@@ -288,7 +296,7 @@ class WebhookController extends Controller
                 TaskStatus::Retrying,
             ];
 
-            if (in_array($task->status, $cancellable, strict: true)) {
+            if (in_array($status, $cancellable, strict: true)) {
                 $task->update(['status' => TaskStatus::Cancelled, 'completed_at' => now()]);
             }
 
@@ -297,7 +305,7 @@ class WebhookController extends Controller
             return response()->json(['ok' => true]);
         }
 
-        if ($task->status === TaskStatus::AwaitingClarification) {
+        if ($status === TaskStatus::AwaitingClarification) {
             ClarificationReplyJob::dispatch($task, $message);
 
             return response()->json(['ok' => true]);

--- a/app/Channels/Linear/WebhookController.php
+++ b/app/Channels/Linear/WebhookController.php
@@ -45,7 +45,13 @@ class WebhookController extends Controller
             return response()->json(['ok' => true, 'skipped' => 'duplicate delivery']);
         }
 
-        if ($request->header('Linear-Event') !== 'AgentSessionEvent') {
+        $event = (string) $request->header('Linear-Event', '');
+
+        if ($event === 'InboxNotificationEvent') {
+            return $this->handleInboxNotification($request);
+        }
+
+        if ($event !== 'AgentSessionEvent') {
             return response()->json(['ok' => true]);
         }
 
@@ -72,6 +78,62 @@ class WebhookController extends Controller
         }
 
         return LinearOauthConnection::activeForWorkspace($workspaceId);
+    }
+
+    /**
+     * Handle Linear's InboxNotificationEvent webhook.
+     *
+     * - issueUnassignedFromYou → cancel any in-flight task for that issue.
+     * - Reaction types (e.g. issueEmojiReaction) → acknowledge, no action needed.
+     * - All other inbox types → ignore.
+     *
+     * Defensive throughout: missing or unexpected fields silently return ok.
+     *
+     * TODO: confirm InboxNotificationEvent payload shape against a real Linear delivery.
+     */
+    private function handleInboxNotification(Request $request): JsonResponse
+    {
+        if ($this->resolveConnection($request) === null) {
+            return response()->json(['ok' => true]);
+        }
+
+        $type = (string) $request->input('notification.type', '');
+        $issueId = (string) $request->input('notification.issue.id', '');
+
+        // Unassignment: stop any in-flight work on that issue.
+        if (str_contains(strtolower($type), 'unassign') && $issueId !== '') {
+            $cancellable = [
+                TaskStatus::Pending,
+                TaskStatus::Running,
+                TaskStatus::AwaitingCi,
+                TaskStatus::AwaitingClarification,
+                TaskStatus::Retrying,
+            ];
+
+            $tasks = YakTask::where('source', 'linear')
+                ->where('context', 'like', '%' . $issueId . '%')
+                ->get()
+                ->filter(fn (YakTask $t) => in_array($t->status, $cancellable, strict: true));
+
+            foreach ($tasks as $task) {
+                $task->update(['status' => TaskStatus::Cancelled, 'completed_at' => now()]);
+                TaskLogger::info($task, 'Cancelled — unassigned from the Linear issue');
+
+                $sessionId = (string) $task->linear_agent_session_id;
+                if ($sessionId !== '') {
+                    app(NotificationDriver::class)->postAgentActivity(
+                        $sessionId,
+                        type: 'thought',
+                        body: 'Stopped — I was unassigned from this issue.',
+                    );
+                }
+            }
+
+            return response()->json(['ok' => true]);
+        }
+
+        // Reactions and other inbox types: acknowledge, no action needed.
+        return response()->json(['ok' => true]);
     }
 
     /**

--- a/app/Channels/Linear/WebhookController.php
+++ b/app/Channels/Linear/WebhookController.php
@@ -4,12 +4,15 @@ namespace App\Channels\Linear;
 
 use App\Enums\NotificationType;
 use App\Enums\TaskMode;
+use App\Enums\TaskStatus;
 use App\Http\Concerns\VerifiesWebhookSignature;
 use App\Http\Controllers\Controller;
+use App\Jobs\ClarificationReplyJob;
 use App\Jobs\ResearchYakJob;
 use App\Jobs\RunYakJob;
 use App\Models\LinearOauthConnection;
 use App\Models\YakTask;
+use App\Services\FollowUpTaskFactory;
 use App\Services\RepoDetector;
 use App\Services\TaskLogger;
 use App\Services\YakPersonality;
@@ -138,11 +141,16 @@ class WebhookController extends Controller
     }
 
     /**
-     * Handle follow-up messages inside an existing agent session. Yak
-     * does not currently support multi-turn Linear conversations —
-     * respond with a polite error so the session surfaces the guidance.
-     * Runs the message through the personality agent (timed) so the
-     * voice stays consistent with the rest of the session.
+     * Handle follow-up messages inside an existing agent session. Routes
+     * the prompt to the correct handler based on task state:
+     *
+     * - stop signal → cancel the task
+     * - AwaitingClarification → dispatch ClarificationReplyJob
+     * - open PR → create a chained follow-up via FollowUpTaskFactory
+     * - merged/closed → post a polite decline
+     * - unknown session → no-op (200 OK)
+     *
+     * Always posts an immediate thought ack within the 10-second SLA.
      */
     private function handlePrompted(Request $request): JsonResponse
     {
@@ -152,18 +160,62 @@ class WebhookController extends Controller
             return response()->json(['ok' => true]);
         }
 
-        $context = "I can't continue this conversation inside Linear. To adjust the task, comment on the pull request or mention me in a fresh Linear issue.";
-
-        $body = YakPersonality::generateWithTimeout(
-            NotificationType::Error,
-            $context,
+        // Immediate ack within the 10-second SLA — use same personality
+        // call as handleCreated (2-second timeout, falls back to template).
+        $ackMessage = YakPersonality::generateWithTimeout(
+            NotificationType::Acknowledgment,
+            'Follow-up received',
             timeoutSeconds: 2,
         );
+        app(NotificationDriver::class)->postAgentActivity($sessionId, type: 'thought', body: $ackMessage);
+
+        $task = YakTask::where('linear_agent_session_id', $sessionId)->latest()->first();
+
+        if ($task === null) {
+            return response()->json(['ok' => true]);
+        }
+
+        // Read the message body from either the nested content shape
+        // (agentActivity.content.body) or the flat shape (agentActivity.body).
+        $message = (string) ($request->input('agentActivity.content.body')
+            ?? $request->input('agentActivity.body')
+            ?? '');
+        $signal = (string) ($request->input('agentActivity.signal') ?? '');
+
+        if ($signal === 'stop') {
+            $cancellable = [
+                TaskStatus::Pending,
+                TaskStatus::Running,
+                TaskStatus::AwaitingCi,
+                TaskStatus::AwaitingClarification,
+                TaskStatus::Retrying,
+            ];
+
+            if (in_array($task->status, $cancellable, strict: true)) {
+                $task->update(['status' => TaskStatus::Cancelled, 'completed_at' => now()]);
+            }
+
+            app(NotificationDriver::class)->postAgentActivity($sessionId, type: 'response', body: 'Stopped.');
+
+            return response()->json(['ok' => true]);
+        }
+
+        if ($task->status === TaskStatus::AwaitingClarification) {
+            ClarificationReplyJob::dispatch($task, $message);
+
+            return response()->json(['ok' => true]);
+        }
+
+        if ($task->prIsOpen()) {
+            app(FollowUpTaskFactory::class)->create($task, $message, 'linear');
+
+            return response()->json(['ok' => true]);
+        }
 
         app(NotificationDriver::class)->postAgentActivity(
             $sessionId,
-            type: 'error',
-            body: $body,
+            type: 'response',
+            body: "This PR is already merged or closed — mention me in a fresh issue and I'll pick it up.",
         );
 
         return response()->json(['ok' => true]);

--- a/app/Channels/Linear/WebhookController.php
+++ b/app/Channels/Linear/WebhookController.php
@@ -18,6 +18,7 @@ use App\Services\TaskLogger;
 use App\Services\YakPersonality;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class WebhookController extends Controller
 {
@@ -31,6 +32,18 @@ class WebhookController extends Controller
             'Linear-Signature',
             prefix: '',
         );
+
+        // Replay protection: reject stale events when Linear includes a timestamp.
+        $timestampMs = $request->input('webhookTimestamp');
+        if ($timestampMs !== null && abs(now()->getTimestampMs() - (int) $timestampMs) > 60_000) {
+            return response()->json(['ok' => true, 'skipped' => 'stale webhook']);
+        }
+
+        // Idempotency: skip a delivery we've already processed (Linear retries).
+        $deliveryId = (string) $request->header('Linear-Delivery', '');
+        if ($deliveryId !== '' && ! Cache::add("linear-delivery:{$deliveryId}", true, now()->addMinutes(10))) {
+            return response()->json(['ok' => true, 'skipped' => 'duplicate delivery']);
+        }
 
         if ($request->header('Linear-Event') !== 'AgentSessionEvent') {
             return response()->json(['ok' => true]);

--- a/app/Channels/Slack/WebhookController.php
+++ b/app/Channels/Slack/WebhookController.php
@@ -11,6 +11,7 @@ use App\Jobs\ResearchYakJob;
 use App\Jobs\RunYakJob;
 use App\Jobs\SendNotificationJob;
 use App\Models\YakTask;
+use App\Services\FollowUpTaskFactory;
 use App\Services\RepoClarificationResolver;
 use App\Services\RepoDetector;
 use App\Services\TaskLogger;
@@ -291,9 +292,10 @@ class WebhookController extends Controller
     }
 
     /**
-     * Handle a thread reply — dispatch ClarificationReplyJob if task is awaiting clarification.
+     * Handle a thread reply — dispatch ClarificationReplyJob if the task is
+     * awaiting clarification, or create a follow-up when the task has an open PR.
      *
-     * @param  array{channel?: string, thread_ts?: string, text?: string}  $event
+     * @param  array{channel?: string, thread_ts?: string, text?: string, subtype?: string, bot_id?: string}  $event
      */
     private function handleThreadReply(array $event): JsonResponse
     {
@@ -304,20 +306,45 @@ class WebhookController extends Controller
             return response()->json(['ok' => true]);
         }
 
-        $task = YakTask::where('slack_channel', $channel)
+        $clarificationTask = YakTask::where('slack_channel', $channel)
             ->where('slack_thread_ts', $threadTs)
             ->where('status', 'awaiting_clarification')
             ->first();
 
-        if ($task !== null) {
+        if ($clarificationTask !== null) {
             $replyText = $event['text'] ?? '';
-            TaskLogger::info($task, 'Clarification received');
+            TaskLogger::info($clarificationTask, 'Clarification received');
 
-            if (RepoClarificationResolver::awaitingRepoChoice($task)) {
-                RepoClarificationResolver::resolve($task, $replyText);
+            if (RepoClarificationResolver::awaitingRepoChoice($clarificationTask)) {
+                RepoClarificationResolver::resolve($clarificationTask, $replyText);
             } else {
-                ClarificationReplyJob::dispatch($task, $replyText);
+                ClarificationReplyJob::dispatch($clarificationTask, $replyText);
             }
+
+            return response()->json(['ok' => true]);
+        }
+
+        $followUpTask = YakTask::where('slack_channel', $channel)
+            ->where('slack_thread_ts', $threadTs)
+            ->whereNotNull('pr_url')
+            ->latest()
+            ->first();
+
+        if ($followUpTask !== null) {
+            $text = (string) ($event['text'] ?? '');
+
+            if (trim($text) === '') {
+                return response()->json(['ok' => true]);
+            }
+
+            if (! $followUpTask->prIsOpen()) {
+                SendNotificationJob::dispatch($followUpTask, NotificationType::Error, "This PR is already merged or closed — start a new request and I'll pick it up.");
+
+                return response()->json(['ok' => true]);
+            }
+
+            TaskLogger::info($followUpTask, 'Follow-up received via Slack thread');
+            app(FollowUpTaskFactory::class)->create($followUpTask, $text, 'slack');
         }
 
         return response()->json(['ok' => true]);

--- a/app/Jobs/ClarificationReplyJob.php
+++ b/app/Jobs/ClarificationReplyJob.php
@@ -9,6 +9,7 @@ use App\Enums\NotificationType;
 use App\Enums\TaskStatus;
 use App\Exceptions\ClaudeAuthException;
 use App\Jobs\Concerns\HandlesAgentJobFailure;
+use App\Jobs\Concerns\ResumesAgentOnExistingBranch;
 use App\Jobs\Middleware\EnsureDailyBudget;
 use App\Jobs\Middleware\EnsureRepoReady;
 use App\Jobs\Middleware\PausesDuringDrain;
@@ -31,6 +32,7 @@ class ClarificationReplyJob implements ShouldQueue
 {
     use HandlesAgentJobFailure;
     use Queueable;
+    use ResumesAgentOnExistingBranch;
 
     public int $timeout = 3600;
 
@@ -135,19 +137,9 @@ class ClarificationReplyJob implements ShouldQueue
 
     private function prepareBranch(IncusSandboxManager $sandbox, string $containerName, Repository $repository): void
     {
-        $workspacePath = IncusSandboxManager::workspacePath();
-
-        $sandbox->configureGitIdentity($containerName);
-        $sandbox->injectGitCredentials($containerName);
-
-        // Refresh origin/{default} so any diff or comparison the agent
-        // does against master sees commits merged since the snapshot.
-        $sandbox->run($containerName, "cd {$workspacePath} && git fetch origin {$repository->default_branch}", timeout: 60);
-
-        // Fetch and checkout the task branch
         $branchName = $this->task->branch_name ?? 'yak/' . $this->task->external_id;
-        $sandbox->run($containerName, "cd {$workspacePath} && git fetch origin {$branchName}", timeout: 60);
-        $sandbox->run($containerName, "cd {$workspacePath} && git checkout {$branchName}", timeout: 30);
+
+        $this->prepareExistingBranch($sandbox, $containerName, $repository, $branchName);
     }
 
     private function handleSuccess(Repository $repository, AgentRunResult $result, IncusSandboxManager $sandbox, string $containerName): void
@@ -171,27 +163,7 @@ class ClarificationReplyJob implements ShouldQueue
         DailyCost::accumulate($result->costUsd);
 
         if ($this->task->branch_name !== null) {
-            $workspacePath = IncusSandboxManager::workspacePath();
-
-            // Safety check
-            $branchResult = $sandbox->run($containerName, "cd {$workspacePath} && git rev-parse --abbrev-ref HEAD", timeout: 10);
-            $currentBranch = trim($branchResult->output());
-
-            if ($currentBranch === $repository->default_branch) {
-                throw new \RuntimeException("Sandbox is on the default branch '{$currentBranch}'. Refusing to push.");
-            }
-
-            // Refresh the baked-in credential helper — the agent may have run
-            // long enough for the token fetched during prepareBranch() to
-            // expire, which would surface as a 401 on push.
-            $sandbox->injectGitCredentials($containerName);
-
-            // Force push from sandbox
-            $pushResult = $sandbox->run($containerName, "cd {$workspacePath} && git push --force-with-lease origin {$this->task->branch_name}", timeout: 60);
-
-            if ($pushResult->exitCode() !== 0) {
-                throw new \RuntimeException("Git push failed in sandbox: {$pushResult->errorOutput()}");
-            }
+            $this->pushExistingBranch($sandbox, $containerName, $repository, $this->task->branch_name);
 
             TaskLogger::info($this->task, 'Fix pushed', ['branch' => $this->task->branch_name]);
         }

--- a/app/Jobs/ClarificationReplyJob.php
+++ b/app/Jobs/ClarificationReplyJob.php
@@ -13,6 +13,7 @@ use App\Jobs\Concerns\ResumesAgentOnExistingBranch;
 use App\Jobs\Middleware\EnsureDailyBudget;
 use App\Jobs\Middleware\EnsureRepoReady;
 use App\Jobs\Middleware\PausesDuringDrain;
+use App\Jobs\Middleware\PreventBranchOverlap;
 use App\Models\DailyCost;
 use App\Models\Repository;
 use App\Models\YakTask;
@@ -52,6 +53,7 @@ class ClarificationReplyJob implements ShouldQueue
     public function middleware(): array
     {
         return [
+            new PreventBranchOverlap($this->task),
             new PausesDuringDrain,
             new EnsureRepoReady,
             new EnsureDailyBudget,

--- a/app/Jobs/Concerns/HandlesAgentJobFailure.php
+++ b/app/Jobs/Concerns/HandlesAgentJobFailure.php
@@ -43,7 +43,10 @@ trait HandlesAgentJobFailure
         }
 
         $terminal = [TaskStatus::Success, TaskStatus::Failed, TaskStatus::Expired, TaskStatus::Cancelled];
-        if (! in_array($task->status, $terminal, true)) {
+
+        /** @var TaskStatus $currentStatus */
+        $currentStatus = $task->status;
+        if (! in_array($currentStatus, $terminal, true)) {
             $task->update([
                 'status' => TaskStatus::Failed,
                 'error_log' => $errorMessage,
@@ -51,7 +54,9 @@ trait HandlesAgentJobFailure
             ]);
         }
 
-        if ($task->status === TaskStatus::Failed && $task->source !== 'system') {
+        /** @var TaskStatus $statusAfter */
+        $statusAfter = $task->status;
+        if ($statusAfter === TaskStatus::Failed && $task->source !== 'system') {
             try {
                 SendNotificationJob::dispatch($task, NotificationType::Error, $errorMessage);
             } catch (Throwable $dispatchError) {

--- a/app/Jobs/Concerns/ResumesAgentOnExistingBranch.php
+++ b/app/Jobs/Concerns/ResumesAgentOnExistingBranch.php
@@ -12,7 +12,7 @@ trait ResumesAgentOnExistingBranch
      * existing task branch. Never creates a branch — the branch already
      * exists from the original run.
      */
-    private function prepareExistingBranch(
+    protected function prepareExistingBranch(
         IncusSandboxManager $sandbox,
         string $containerName,
         Repository $repository,
@@ -33,7 +33,7 @@ trait ResumesAgentOnExistingBranch
      * helper (the token may have expired during a long run), then force-push
      * with lease.
      */
-    private function pushExistingBranch(
+    protected function pushExistingBranch(
         IncusSandboxManager $sandbox,
         string $containerName,
         Repository $repository,

--- a/app/Jobs/Concerns/ResumesAgentOnExistingBranch.php
+++ b/app/Jobs/Concerns/ResumesAgentOnExistingBranch.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Jobs\Concerns;
+
+use App\Models\Repository;
+use App\Services\IncusSandboxManager;
+
+trait ResumesAgentOnExistingBranch
+{
+    /**
+     * Configure git, refresh the default branch, then fetch + checkout the
+     * existing task branch. Never creates a branch — the branch already
+     * exists from the original run.
+     */
+    private function prepareExistingBranch(
+        IncusSandboxManager $sandbox,
+        string $containerName,
+        Repository $repository,
+        string $branchName,
+    ): void {
+        $workspacePath = IncusSandboxManager::workspacePath();
+
+        $sandbox->configureGitIdentity($containerName);
+        $sandbox->injectGitCredentials($containerName);
+
+        $sandbox->run($containerName, "cd {$workspacePath} && git fetch origin {$repository->default_branch}", timeout: 60);
+        $sandbox->run($containerName, "cd {$workspacePath} && git fetch origin {$branchName}", timeout: 60);
+        $sandbox->run($containerName, "cd {$workspacePath} && git checkout {$branchName}", timeout: 30);
+    }
+
+    /**
+     * Refuse-to-push-on-default-branch safety check, refresh the credential
+     * helper (the token may have expired during a long run), then force-push
+     * with lease.
+     */
+    private function pushExistingBranch(
+        IncusSandboxManager $sandbox,
+        string $containerName,
+        Repository $repository,
+        string $branchName,
+    ): void {
+        $workspacePath = IncusSandboxManager::workspacePath();
+
+        $branchResult = $sandbox->run($containerName, "cd {$workspacePath} && git rev-parse --abbrev-ref HEAD", timeout: 10);
+        $currentBranch = trim($branchResult->output());
+
+        if ($currentBranch === $repository->default_branch) {
+            throw new \RuntimeException("Sandbox is on the default branch '{$currentBranch}'. Refusing to push.");
+        }
+
+        $sandbox->injectGitCredentials($containerName);
+
+        $pushResult = $sandbox->run($containerName, "cd {$workspacePath} && git push --force-with-lease origin {$branchName}", timeout: 60);
+
+        if ($pushResult->exitCode() !== 0) {
+            throw new \RuntimeException("Git push failed in sandbox: {$pushResult->errorOutput()}");
+        }
+    }
+}

--- a/app/Jobs/CreatePullRequestJob.php
+++ b/app/Jobs/CreatePullRequestJob.php
@@ -41,12 +41,31 @@ class CreatePullRequestJob implements ShouldQueue
     {
         $repository = Repository::where('slug', $this->task->repo)->firstOrFail();
         $installationId = (int) config('yak.channels.github.installation_id');
+
+        // A follow-up pushes to an existing branch, so a PR already exists.
+        // Detect it and post a summary comment instead of POSTing a new PR
+        // (which GitHub rejects with 422).
+        $existing = $gitHub->findOpenPullRequestForBranch($installationId, $repository->slug, (string) $this->task->branch_name);
+
+        if ($existing !== null) {
+            $this->task->update([
+                'pr_url' => $existing['html_url'],
+                'pr_number' => $existing['number'],
+            ]);
+
+            $summary = $this->task->result_summary ?? '_No summary available._';
+            $gitHub->commentOnPullRequest(
+                $installationId,
+                $repository->slug,
+                (int) $existing['number'],
+                mb_convert_encoding("Yak pushed changes addressing your feedback:\n\n{$summary}", 'UTF-8', 'UTF-8'),
+            );
+
+            return;
+        }
+
         $signedUrls = $this->generateSignedUrls();
 
-        // Defensive: agent-produced strings (description, result_summary)
-        // occasionally contain byte sequences that aren't valid UTF-8, which
-        // Guzzle's json_encode rejects and leaves the task stranded. Strip
-        // invalid bytes at the boundary so a stray character can't block the PR.
         $title = mb_convert_encoding($this->buildPrTitle(), 'UTF-8', 'UTF-8');
         $body = mb_convert_encoding($this->buildPrBody($signedUrls), 'UTF-8', 'UTF-8');
 
@@ -72,7 +91,7 @@ class CreatePullRequestJob implements ShouldQueue
 
         $gitHub->addLabels($installationId, $repository->slug, $prNumber, $labels);
 
-        $this->task->update(['pr_url' => $prUrl]);
+        $this->task->update(['pr_url' => $prUrl, 'pr_number' => $prNumber]);
     }
 
     private function buildPrTitle(): string

--- a/app/Jobs/CreatePullRequestJob.php
+++ b/app/Jobs/CreatePullRequestJob.php
@@ -48,6 +48,10 @@ class CreatePullRequestJob implements ShouldQueue
         $existing = $gitHub->findOpenPullRequestForBranch($installationId, $repository->slug, (string) $this->task->branch_name);
 
         if ($existing !== null) {
+            if (! isset($existing['number'], $existing['html_url'])) {
+                throw new \RuntimeException('GitHub returned an existing PR without expected fields.');
+            }
+
             $this->task->update([
                 'pr_url' => $existing['html_url'],
                 'pr_number' => $existing['number'],

--- a/app/Jobs/FlushFollowUpBatchJob.php
+++ b/app/Jobs/FlushFollowUpBatchJob.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Channels\GitHub\AppService;
+use App\Models\FollowUpPendingComment;
+use App\Models\YakTask;
+use App\Services\FollowUpTaskFactory;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Collection;
+
+class FlushFollowUpBatchJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $timeout = 30;
+
+    public function __construct(
+        public readonly string $prUrl,
+    ) {
+        $this->onQueue('default');
+    }
+
+    public function handle(FollowUpTaskFactory $factory, AppService $gitHub): void
+    {
+        $comments = FollowUpPendingComment::where('pr_url', $this->prUrl)->orderBy('id')->get();
+
+        if ($comments->isEmpty()) {
+            return;
+        }
+
+        // Resolve the conversation root (or any task) for this PR.
+        $parent = YakTask::where('pr_url', $this->prUrl)->whereNull('parent_task_id')->first()
+            ?? YakTask::where('pr_url', $this->prUrl)->first();
+
+        if ($parent === null) {
+            FollowUpPendingComment::where('pr_url', $this->prUrl)->delete();
+
+            return;
+        }
+
+        $instructions = $this->composeInstructions($comments);
+
+        // Clear the buffer BEFORE running so comments arriving during the run
+        // start a fresh batch (the next run serializes behind this one via the
+        // branch-overlap middleware on RunFollowUpJob).
+        FollowUpPendingComment::where('pr_url', $this->prUrl)->delete();
+
+        $child = $factory->create($parent, $instructions, 'github');
+
+        if ($child === null) {
+            // PR merged/closed — decline politely.
+            $installationId = (int) config('yak.channels.github.installation_id');
+            $prNumber = (int) ($parent->pr_number ?? 0);
+
+            if ($installationId > 0 && $prNumber > 0) {
+                $gitHub->commentOnPullRequest(
+                    $installationId,
+                    (string) $parent->repo,
+                    $prNumber,
+                    "This PR is already merged or closed, so I can't push more changes here. Open a new issue or task and I'll pick it up.",
+                );
+            }
+        }
+    }
+
+    /**
+     * @param  Collection<int, FollowUpPendingComment>  $comments
+     */
+    private function composeInstructions(Collection $comments): string
+    {
+        $lines = ['The following feedback was left on the pull request:', ''];
+
+        foreach ($comments as $comment) {
+            $anchor = $comment->file !== null
+                ? "{$comment->file}" . ($comment->line !== null ? ":{$comment->line}" : '') . ' — '
+                : '';
+
+            $lines[] = "- {$anchor}{$comment->body}";
+
+            if ($comment->diff_hunk !== null && $comment->diff_hunk !== '') {
+                $lines[] = '';
+                $lines[] = '  ```diff';
+                foreach (explode("\n", $comment->diff_hunk) as $hunkLine) {
+                    $lines[] = '  ' . $hunkLine;
+                }
+                $lines[] = '  ```';
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/app/Jobs/FlushFollowUpBatchJob.php
+++ b/app/Jobs/FlushFollowUpBatchJob.php
@@ -30,22 +30,22 @@ class FlushFollowUpBatchJob implements ShouldQueue
             return;
         }
 
+        // Capture the IDs of comments we're processing so we can delete only these
+        // rows after create() succeeds. This ensures comments that arrive during the
+        // run are not swept up and can be retried if create() throws.
+        $ids = $comments->pluck('id')->all();
+
         // Resolve the conversation root (or any task) for this PR.
         $parent = YakTask::where('pr_url', $this->prUrl)->whereNull('parent_task_id')->first()
             ?? YakTask::where('pr_url', $this->prUrl)->first();
 
         if ($parent === null) {
-            FollowUpPendingComment::where('pr_url', $this->prUrl)->delete();
+            FollowUpPendingComment::whereIn('id', $ids)->delete();
 
             return;
         }
 
         $instructions = $this->composeInstructions($comments);
-
-        // Clear the buffer BEFORE running so comments arriving during the run
-        // start a fresh batch (the next run serializes behind this one via the
-        // branch-overlap middleware on RunFollowUpJob).
-        FollowUpPendingComment::where('pr_url', $this->prUrl)->delete();
 
         $child = $factory->create($parent, $instructions, 'github');
 
@@ -63,6 +63,10 @@ class FlushFollowUpBatchJob implements ShouldQueue
                 );
             }
         }
+
+        // Delete only the buffered comments we processed. Comments that arrived
+        // during the run have new IDs not in $ids, so they survive for the next batch.
+        FollowUpPendingComment::whereIn('id', $ids)->delete();
     }
 
     /**

--- a/app/Jobs/Middleware/PreventBranchOverlap.php
+++ b/app/Jobs/Middleware/PreventBranchOverlap.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Jobs\Middleware;
+
+use App\Models\YakTask;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+
+/**
+ * Serializes jobs that push to the same branch so two follow-up runs (or a
+ * follow-up colliding with an in-flight run) never push concurrently. A
+ * second job for the same branch is released back to the queue and retried.
+ */
+class PreventBranchOverlap extends WithoutOverlapping
+{
+    public function __construct(YakTask $task)
+    {
+        $key = $task->repo . ':' . ($task->branch_name ?? 'task-' . $task->id);
+
+        parent::__construct($key);
+
+        $this->releaseAfter(30)->expireAfter(3600);
+    }
+}

--- a/app/Jobs/Middleware/PreventBranchOverlap.php
+++ b/app/Jobs/Middleware/PreventBranchOverlap.php
@@ -9,6 +9,10 @@ use Illuminate\Queue\Middleware\WithoutOverlapping;
  * Serializes jobs that push to the same branch so two follow-up runs (or a
  * follow-up colliding with an in-flight run) never push concurrently. A
  * second job for the same branch is released back to the queue and retried.
+ *
+ * Note: expireAfter (4200s) intentionally outlasts RunFollowUpJob's 3600s
+ * timeout so the lock cannot expire mid-run and allow a second job to push
+ * to the same branch concurrently.
  */
 class PreventBranchOverlap extends WithoutOverlapping
 {
@@ -18,6 +22,8 @@ class PreventBranchOverlap extends WithoutOverlapping
 
         parent::__construct($key);
 
-        $this->releaseAfter(30)->expireAfter(3600);
+        // expireAfter must outlast RunFollowUpJob's 3600s timeout so the lock
+        // can't expire mid-run and let a second job push to the same branch.
+        $this->releaseAfter(30)->expireAfter(4200);
     }
 }

--- a/app/Jobs/ProcessCIResultJob.php
+++ b/app/Jobs/ProcessCIResultJob.php
@@ -119,8 +119,9 @@ class ProcessCIResultJob implements ShouldQueue
         if ($this->task->source === 'linear') {
             if ($prUrl !== '') {
                 $sessionId = (string) $this->task->linear_agent_session_id;
+                $actionLabel = $this->task->parent_task_id !== null ? 'Pushed changes' : 'Opened pull request';
                 app(LinearNotificationDriver::class)
-                    ->postAction($sessionId, 'Opened pull request', $prUrl);
+                    ->postAction($sessionId, $actionLabel, $prUrl);
             }
 
             $this->moveLinearToInReview();

--- a/app/Jobs/ProcessCIResultJob.php
+++ b/app/Jobs/ProcessCIResultJob.php
@@ -117,6 +117,12 @@ class ProcessCIResultJob implements ShouldQueue
         $this->postToSource($message);
 
         if ($this->task->source === 'linear') {
+            if ($prUrl !== '') {
+                $sessionId = (string) $this->task->linear_agent_session_id;
+                app(LinearNotificationDriver::class)
+                    ->postAction($sessionId, 'Opened pull request', $prUrl);
+            }
+
             $this->moveLinearToInReview();
         }
 

--- a/app/Jobs/RetryYakJob.php
+++ b/app/Jobs/RetryYakJob.php
@@ -13,6 +13,7 @@ use App\Jobs\Concerns\HandlesAgentJobFailure;
 use App\Jobs\Middleware\EnsureDailyBudget;
 use App\Jobs\Middleware\EnsureRepoReady;
 use App\Jobs\Middleware\PausesDuringDrain;
+use App\Jobs\Middleware\PreventBranchOverlap;
 use App\Models\DailyCost;
 use App\Models\Repository;
 use App\Models\YakTask;
@@ -51,6 +52,7 @@ class RetryYakJob implements ShouldQueue
     public function middleware(): array
     {
         return [
+            new PreventBranchOverlap($this->task),
             new PausesDuringDrain,
             new EnsureRepoReady,
             new EnsureDailyBudget,

--- a/app/Jobs/RunFollowUpJob.php
+++ b/app/Jobs/RunFollowUpJob.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Contracts\AgentRunner;
+use App\DataTransferObjects\AgentRunRequest;
+use App\DataTransferObjects\AgentRunResult;
+use App\Enums\NotificationType;
+use App\Enums\TaskStatus;
+use App\Exceptions\ClaudeAuthException;
+use App\Jobs\Concerns\HandlesAgentJobFailure;
+use App\Jobs\Concerns\ResumesAgentOnExistingBranch;
+use App\Jobs\Middleware\EnsureDailyBudget;
+use App\Jobs\Middleware\EnsureRepoReady;
+use App\Jobs\Middleware\PausesDuringDrain;
+use App\Models\DailyCost;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\ArtifactPersister;
+use App\Services\IncusSandboxManager;
+use App\Services\SandboxArtifactCollector;
+use App\Services\TaskLogger;
+use App\Services\TaskMetricsAccumulator;
+use App\Services\YakPersonality;
+use App\Support\TaskContext;
+use App\YakPromptBuilder;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class RunFollowUpJob implements ShouldQueue
+{
+    use HandlesAgentJobFailure;
+    use Queueable;
+    use ResumesAgentOnExistingBranch;
+
+    public int $timeout = 3600;
+
+    /** @var array<int, int> */
+    public array $backoff = [1, 5, 10];
+
+    public function __construct(
+        public readonly YakTask $task,
+    ) {
+        $this->onQueue('yak-claude');
+    }
+
+    /**
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [
+            new PausesDuringDrain,
+            new EnsureRepoReady,
+            new EnsureDailyBudget,
+        ];
+    }
+
+    public function handle(AgentRunner $agent): void
+    {
+        TaskContext::set($this->task);
+
+        try {
+            $this->runFollowUp($agent);
+        } finally {
+            TaskContext::clear();
+        }
+    }
+
+    private function runFollowUp(AgentRunner $agent): void
+    {
+        $repository = Repository::where('slug', $this->task->repo)->firstOrFail();
+        $sandbox = app(IncusSandboxManager::class);
+        $containerName = null;
+
+        $this->task->update(['status' => TaskStatus::Running]);
+        TaskLogger::info($this->task, 'Picked up by worker — follow-up');
+
+        try {
+            $containerName = $sandbox->create($this->task, $repository);
+            TaskLogger::info($this->task, 'Sandbox created for follow-up', ['container' => $containerName]);
+
+            $branchName = $this->task->branch_name ?? 'yak/' . $this->task->external_id;
+            $this->prepareExistingBranch($sandbox, $containerName, $repository, $branchName);
+
+            $result = $agent->run(new AgentRunRequest(
+                prompt: YakPromptBuilder::followUpPrompt((string) $this->task->description),
+                systemPrompt: YakPromptBuilder::systemPrompt($this->task),
+                containerName: $containerName,
+                timeoutSeconds: $this->timeout - 30,
+                maxBudgetUsd: (float) config('yak.max_budget_per_task'),
+                maxTurns: (int) config('yak.max_turns'),
+                model: (string) config('yak.default_model'),
+                resumeSessionId: $this->task->session_id,
+                mcpConfigPath: config('yak.mcp_config_path'),
+                task: $this->task,
+            ));
+
+            if ($result->isError) {
+                $this->handleError($result->failureMessage());
+
+                return;
+            }
+
+            SandboxArtifactCollector::collect($sandbox, $containerName, $this->task);
+            ArtifactPersister::persist($this->task);
+
+            $this->handleSuccess($repository, $result, $sandbox, $containerName);
+        } catch (ClaudeAuthException $e) {
+            Log::error('RunFollowUpJob auth failure', ['task_id' => $this->task->id, 'error' => $e->getMessage()]);
+            $this->handleError($e->getMessage());
+            SendNotificationJob::dispatch($this->task, NotificationType::Error, $e->getMessage());
+        } catch (\Throwable $e) {
+            Log::error('RunFollowUpJob failed', ['task_id' => $this->task->id, 'error' => $e->getMessage()]);
+            $this->handleError($e->getMessage());
+        } finally {
+            if ($containerName !== null) {
+                $sandbox->pullClaudeCredentials($containerName);
+                $sandbox->destroy($containerName);
+            }
+        }
+    }
+
+    private function handleSuccess(Repository $repository, AgentRunResult $result, IncusSandboxManager $sandbox, string $containerName): void
+    {
+        TaskMetricsAccumulator::applyAccumulated($this->task, $result);
+
+        $update = [
+            'result_summary' => $result->resultSummary,
+            'model_used' => config('yak.default_model'),
+        ];
+
+        if ($repository->ci_system !== 'none') {
+            $update['status'] = TaskStatus::AwaitingCi;
+        }
+
+        $this->task->update($update);
+
+        DailyCost::accumulate($result->costUsd);
+
+        $branchName = $this->task->branch_name ?? 'yak/' . $this->task->external_id;
+        $this->pushExistingBranch($sandbox, $containerName, $repository, $branchName);
+        TaskLogger::info($this->task, 'Follow-up pushed', ['branch' => $branchName]);
+
+        if ($repository->ci_system === 'none') {
+            ProcessCIResultJob::dispatch($this->task, passed: true)->afterCommit();
+        } else {
+            $message = YakPersonality::generate(NotificationType::Progress, "Pushed your changes on branch {$branchName} — waiting for CI before updating the PR.");
+            SendNotificationJob::dispatch($this->task, NotificationType::Progress, $message);
+        }
+    }
+
+    private function handleError(string $errorMessage): void
+    {
+        $this->task->update([
+            'status' => TaskStatus::Failed,
+            'error_log' => $errorMessage,
+            'completed_at' => now(),
+        ]);
+
+        TaskLogger::error($this->task, 'Follow-up failed', ['error' => $errorMessage]);
+    }
+}

--- a/app/Jobs/RunFollowUpJob.php
+++ b/app/Jobs/RunFollowUpJob.php
@@ -77,11 +77,17 @@ class RunFollowUpJob implements ShouldQueue
         $this->task->update(['status' => TaskStatus::Running]);
         TaskLogger::info($this->task, 'Picked up by worker — follow-up');
 
+        if ($this->task->branch_name === null) {
+            $this->handleError('Follow-up task has no branch to push to.');
+
+            return;
+        }
+
         try {
             $containerName = $sandbox->create($this->task, $repository);
             TaskLogger::info($this->task, 'Sandbox created for follow-up', ['container' => $containerName]);
 
-            $branchName = $this->task->branch_name ?? 'yak/' . $this->task->external_id;
+            $branchName = $this->task->branch_name;
             $this->prepareExistingBranch($sandbox, $containerName, $repository, $branchName);
 
             $result = $agent->run(new AgentRunRequest(
@@ -139,7 +145,7 @@ class RunFollowUpJob implements ShouldQueue
 
         DailyCost::accumulate($result->costUsd);
 
-        $branchName = $this->task->branch_name ?? 'yak/' . $this->task->external_id;
+        $branchName = $this->task->branch_name;
         $this->pushExistingBranch($sandbox, $containerName, $repository, $branchName);
         TaskLogger::info($this->task, 'Follow-up pushed', ['branch' => $branchName]);
 

--- a/app/Jobs/RunFollowUpJob.php
+++ b/app/Jobs/RunFollowUpJob.php
@@ -13,6 +13,7 @@ use App\Jobs\Concerns\ResumesAgentOnExistingBranch;
 use App\Jobs\Middleware\EnsureDailyBudget;
 use App\Jobs\Middleware\EnsureRepoReady;
 use App\Jobs\Middleware\PausesDuringDrain;
+use App\Jobs\Middleware\PreventBranchOverlap;
 use App\Models\DailyCost;
 use App\Models\Repository;
 use App\Models\YakTask;
@@ -51,6 +52,7 @@ class RunFollowUpJob implements ShouldQueue
     public function middleware(): array
     {
         return [
+            new PreventBranchOverlap($this->task),
             new PausesDuringDrain,
             new EnsureRepoReady,
             new EnsureDailyBudget,

--- a/app/Jobs/RunFollowUpJob.php
+++ b/app/Jobs/RunFollowUpJob.php
@@ -148,6 +148,11 @@ class RunFollowUpJob implements ShouldQueue
         DailyCost::accumulate($result->costUsd);
 
         $branchName = $this->task->branch_name;
+
+        if ($branchName === null) {
+            throw new \RuntimeException('Follow-up reached the push step with no branch name.');
+        }
+
         $this->pushExistingBranch($sandbox, $containerName, $repository, $branchName);
         TaskLogger::info($this->task, 'Follow-up pushed', ['branch' => $branchName]);
 

--- a/app/Jobs/SendNotificationJob.php
+++ b/app/Jobs/SendNotificationJob.php
@@ -69,6 +69,11 @@ class SendNotificationJob implements ShouldQueue
             }
         }
 
+        // Dashboard tasks are UI-only; never fall back to a public PR comment.
+        if ($this->task->source === 'dashboard') {
+            return null;
+        }
+
         // Fallback: if the task has an open PR, notify via GitHub.
         if ($this->task->pr_url === null) {
             return null;

--- a/app/Livewire/Tasks/CreateTask.php
+++ b/app/Livewire/Tasks/CreateTask.php
@@ -52,7 +52,10 @@ class CreateTask extends Component
 
         TaskLogger::info($task, 'Task created', ['source' => 'dashboard', 'repo' => $task->repo]);
 
-        if ($task->mode === TaskMode::Research) {
+        /** @var TaskMode $mode */
+        $mode = $task->mode;
+
+        if ($mode === TaskMode::Research) {
             ResearchYakJob::dispatch($task);
         } else {
             RunYakJob::dispatch($task);

--- a/app/Livewire/Tasks/CreateTask.php
+++ b/app/Livewire/Tasks/CreateTask.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Livewire\Tasks;
+
+use App\Enums\TaskMode;
+use App\Jobs\ResearchYakJob;
+use App\Jobs\RunYakJob;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\TaskLogger;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+class CreateTask extends Component
+{
+    public bool $open = false;
+
+    public string $repo = '';
+
+    public string $taskMode = 'fix';
+
+    public string $description = '';
+
+    /**
+     * @return Collection<int, Repository>
+     */
+    #[Computed]
+    public function repos(): Collection
+    {
+        return Repository::where('is_active', true)->orderBy('slug')->get();
+    }
+
+    public function save(): void
+    {
+        $validated = $this->validate([
+            'repo' => ['required', 'string', Rule::exists('repositories', 'slug')->where('is_active', true)],
+            'taskMode' => ['required', Rule::in(['fix', 'research'])],
+            'description' => ['required', 'string', 'min:3'],
+        ]);
+
+        $task = YakTask::create([
+            'source' => 'dashboard',
+            'repo' => $validated['repo'],
+            'external_id' => 'DASH-' . Str::upper(Str::random(8)),
+            'description' => trim($validated['description']),
+            'mode' => $validated['taskMode'],
+        ]);
+
+        TaskLogger::info($task, 'Task created', ['source' => 'dashboard', 'repo' => $task->repo]);
+
+        if ($task->mode === TaskMode::Research) {
+            ResearchYakJob::dispatch($task);
+        } else {
+            RunYakJob::dispatch($task);
+        }
+
+        $this->reset(['repo', 'taskMode', 'description', 'open']);
+
+        $this->redirect(route('tasks.show', $task), navigate: true);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.tasks.create-task');
+    }
+}

--- a/app/Livewire/Tasks/TaskDetail.php
+++ b/app/Livewire/Tasks/TaskDetail.php
@@ -19,6 +19,7 @@ use App\Models\PrReview;
 use App\Models\Repository;
 use App\Models\TaskLog;
 use App\Models\YakTask;
+use App\Services\FollowUpTaskFactory;
 use App\Services\IncusSandboxManager;
 use App\Services\RepoClarificationResolver;
 use App\Services\TaskLogger;
@@ -26,6 +27,7 @@ use App\Support\TaskSourceUrl;
 use Flux\Flux;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use League\CommonMark\CommonMarkConverter;
@@ -38,6 +40,7 @@ use Livewire\Component;
  * @property-read ?PrReview $prReview
  * @property-read string $renderedReviewBody
  * @property-read bool $canReroute
+ * @property-read SupportCollection<int, YakTask> $conversation
  */
 #[Title('Task Detail')]
 class TaskDetail extends Component
@@ -66,6 +69,8 @@ class TaskDetail extends Component
     public array $expandedGroups = [];
 
     public string $clarificationReplyText = '';
+
+    public string $followUpText = '';
 
     /**
      * Outcome of a re-review request that redirected here, surfaced as a
@@ -408,6 +413,49 @@ class TaskDetail extends Component
         $this->task->refresh();
 
         Flux::toast('Reply sent. Yak is continuing the task.');
+    }
+
+    /**
+     * The full follow-up chain this task belongs to, root-first ordered by
+     * created_at. Delegates to YakTask::conversation() so the view always
+     * sees the complete picture even when viewing a child task directly.
+     *
+     * @return SupportCollection<int, YakTask>
+     */
+    #[Computed]
+    public function conversation(): SupportCollection
+    {
+        return $this->task->conversation();
+    }
+
+    /**
+     * Submit a follow-up instruction from the dashboard when the PR is still
+     * open. Creates a chained child task via FollowUpTaskFactory and
+     * dispatches RunFollowUpJob.
+     */
+    public function sendFollowUp(): void
+    {
+        $this->validate(['followUpText' => ['required', 'string', 'min:1']]);
+
+        if (! $this->task->prIsOpen()) {
+            Flux::toast('This PR is no longer open for changes.', variant: 'warning');
+
+            return;
+        }
+
+        $child = app(FollowUpTaskFactory::class)
+            ->create($this->task, trim($this->followUpText), 'dashboard');
+
+        $this->followUpText = '';
+
+        if ($child === null) {
+            Flux::toast('This PR is no longer open for changes.', variant: 'warning');
+
+            return;
+        }
+
+        $this->task->refresh();
+        Flux::toast('Sent to Yak. It will push changes to this PR.');
     }
 
     public function toggleDebug(): void

--- a/app/Livewire/Tasks/TaskList.php
+++ b/app/Livewire/Tasks/TaskList.php
@@ -17,6 +17,9 @@ use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
 
+/**
+ * @property-read LengthAwarePaginator<int, YakTask> $tasks
+ */
 #[Title('Tasks')]
 class TaskList extends Component
 {
@@ -56,12 +59,12 @@ class TaskList extends Component
      * branch_name, so this captures the whole chain (children, grandchildren,
      * ...) in a single query — `$task->followUps` would only get direct kids.
      *
-     * @return Collection<string, Collection<int, YakTask>>
+     * @return Collection<string, \Illuminate\Database\Eloquent\Collection<int, YakTask>>
      */
     #[Computed]
     public function descendantsByBranch(): Collection
     {
-        $branches = $this->tasks->pluck('branch_name')->filter()->unique()->values();
+        $branches = collect($this->tasks->items())->pluck('branch_name')->filter()->unique()->values();
 
         if ($branches->isEmpty()) {
             return collect();

--- a/app/Livewire/Tasks/TaskList.php
+++ b/app/Livewire/Tasks/TaskList.php
@@ -10,6 +10,7 @@ use App\Models\YakTask;
 use App\Support\Docs;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
 use Livewire\Attributes\Url;
@@ -40,13 +41,38 @@ class TaskList extends Component
     public function tasks(): LengthAwarePaginator
     {
         return $this->scopedQuery($this->tab)
-            ->with(['repository', 'followUps'])
+            ->with(['repository'])
             ->whereNull('parent_task_id')
             ->when($this->status !== '', fn ($query) => $query->where('status', $this->status))
             ->when($this->tab === 'tasks' && $this->source !== '', fn ($query) => $query->where('source', $this->source))
             ->when($this->repo !== '', fn ($query) => $query->where('repo', $this->repo))
             ->latest()
             ->paginate(50);
+    }
+
+    /**
+     * Follow-up descendants for the roots on the current page, grouped by
+     * branch_name. Every task in a follow-up chain shares the root's
+     * branch_name, so this captures the whole chain (children, grandchildren,
+     * ...) in a single query — `$task->followUps` would only get direct kids.
+     *
+     * @return Collection<string, Collection<int, YakTask>>
+     */
+    #[Computed]
+    public function descendantsByBranch(): Collection
+    {
+        $branches = $this->tasks->pluck('branch_name')->filter()->unique()->values();
+
+        if ($branches->isEmpty()) {
+            return collect();
+        }
+
+        return YakTask::query()
+            ->whereNotNull('parent_task_id')
+            ->whereIn('branch_name', $branches)
+            ->orderBy('created_at')
+            ->get()
+            ->groupBy('branch_name');
     }
 
     /**
@@ -64,19 +90,19 @@ class TaskList extends Component
     #[Computed]
     public function tasksCount(): int
     {
-        return $this->scopedQuery('tasks')->count();
+        return $this->scopedQuery('tasks')->whereNull('parent_task_id')->count();
     }
 
     #[Computed]
     public function setupCount(): int
     {
-        return $this->scopedQuery('setup')->count();
+        return $this->scopedQuery('setup')->whereNull('parent_task_id')->count();
     }
 
     #[Computed]
     public function reviewsCount(): int
     {
-        return $this->scopedQuery('reviews')->count();
+        return $this->scopedQuery('reviews')->whereNull('parent_task_id')->count();
     }
 
     public function updatedTab(): void

--- a/app/Livewire/Tasks/TaskList.php
+++ b/app/Livewire/Tasks/TaskList.php
@@ -40,7 +40,8 @@ class TaskList extends Component
     public function tasks(): LengthAwarePaginator
     {
         return $this->scopedQuery($this->tab)
-            ->with('repository')
+            ->with(['repository', 'followUps'])
+            ->whereNull('parent_task_id')
             ->when($this->status !== '', fn ($query) => $query->where('status', $this->status))
             ->when($this->tab === 'tasks' && $this->source !== '', fn ($query) => $query->where('source', $this->source))
             ->when($this->repo !== '', fn ($query) => $query->where('repo', $this->repo))

--- a/app/Models/FollowUpPendingComment.php
+++ b/app/Models/FollowUpPendingComment.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FollowUpPendingComment extends Model
+{
+    protected $guarded = [];
+
+    /**
+     * @return BelongsTo<YakTask, $this>
+     */
+    public function task(): BelongsTo
+    {
+        return $this->belongsTo(YakTask::class, 'yak_task_id');
+    }
+}

--- a/app/Models/YakTask.php
+++ b/app/Models/YakTask.php
@@ -113,6 +113,9 @@ class YakTask extends Model
      * parent is the previous head, so the chain is walked up to the root
      * and then fully down.
      *
+     * Issues one query per node in the chain; intended for short follow-up
+     * chains, not large trees.
+     *
      * @return Collection<int, YakTask>
      */
     public function conversation(): Collection
@@ -125,7 +128,7 @@ class YakTask extends Model
         /** @var Collection<int, YakTask> $chain */
         $chain = collect([$root]);
 
-        $gather = function (YakTask $task) use (&$gather, $chain): void {
+        $gather = function (YakTask $task) use (&$gather, &$chain): void {
             foreach ($task->followUps()->get() as $child) {
                 $chain->push($child);
                 $gather($child);

--- a/app/Models/YakTask.php
+++ b/app/Models/YakTask.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
 
 class YakTask extends Model
 {
@@ -77,5 +78,61 @@ class YakTask extends Model
     public function artifacts(): HasMany
     {
         return $this->hasMany(Artifact::class, 'yak_task_id');
+    }
+
+    /**
+     * @return BelongsTo<YakTask, $this>
+     */
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_task_id');
+    }
+
+    /**
+     * @return HasMany<YakTask, $this>
+     */
+    public function followUps(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_task_id')->orderBy('created_at');
+    }
+
+    /**
+     * True when a PR exists and is neither merged nor closed — i.e. the
+     * branch is still live and can accept follow-up commits.
+     */
+    public function prIsOpen(): bool
+    {
+        return $this->pr_url !== null
+            && $this->pr_merged_at === null
+            && $this->pr_closed_at === null;
+    }
+
+    /**
+     * The whole follow-up conversation this task belongs to: the chain's
+     * root plus every descendant, ordered oldest-first. Each follow-up's
+     * parent is the previous head, so the chain is walked up to the root
+     * and then fully down.
+     *
+     * @return Collection<int, YakTask>
+     */
+    public function conversation(): Collection
+    {
+        $root = $this;
+        while ($root->parent_task_id !== null && $root->parent !== null) {
+            $root = $root->parent;
+        }
+
+        /** @var Collection<int, YakTask> $chain */
+        $chain = collect([$root]);
+
+        $gather = function (YakTask $task) use (&$gather, $chain): void {
+            foreach ($task->followUps()->get() as $child) {
+                $chain->push($child);
+                $gather($child);
+            }
+        };
+        $gather($root);
+
+        return $chain->sortBy('created_at')->values();
     }
 }

--- a/app/Prompts/PromptDefinitions.php
+++ b/app/Prompts/PromptDefinitions.php
@@ -95,6 +95,13 @@ class PromptDefinitions
                 'type' => 'task',
                 'variables' => ['chosenOption'],
             ],
+            'tasks-follow-up' => [
+                'view' => 'prompts.tasks.follow-up',
+                'label' => 'Follow-up',
+                'category' => 'advanced',
+                'type' => 'task',
+                'variables' => ['instructions'],
+            ],
             'tasks-review' => [
                 'view' => 'prompts.tasks.review',
                 'label' => 'PR Review',

--- a/app/Services/FollowUpTaskFactory.php
+++ b/app/Services/FollowUpTaskFactory.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Enums\TaskStatus;
 use App\Jobs\RunFollowUpJob;
 use App\Models\YakTask;
+use Illuminate\Support\Facades\DB;
 
 class FollowUpTaskFactory
 {
@@ -15,46 +16,49 @@ class FollowUpTaskFactory
      */
     public function create(YakTask $parent, string $instructions, string $source): ?YakTask
     {
-        $head = $this->chainHead($parent);
+        // One conversation() walk gives us both ends of the chain: the root
+        // (stable base for external_id) and the head (newest task — its branch
+        // /session/PR state is what a follow-up continues from).
+        $chain = $parent->conversation();
+        $head = $chain->last() ?? $parent;
+        $root = $chain->first() ?? $parent;
 
         if (! $head->prIsOpen()) {
             return null;
         }
 
-        $followUpNumber = $head->conversation()->count();
+        $child = DB::transaction(function () use ($head, $root, $instructions, $source): YakTask {
+            $child = YakTask::create([
+                'parent_task_id' => $head->id,
+                'source' => $source,
+                'repo' => $head->repo,
+                'mode' => $head->mode,
+                'branch_name' => $head->branch_name,
+                'session_id' => $head->session_id,
+                'pr_url' => $head->pr_url,
+                'pr_number' => $head->pr_number,
+                'linear_agent_session_id' => $head->linear_agent_session_id,
+                'slack_channel' => $head->slack_channel,
+                'slack_thread_ts' => $head->slack_thread_ts,
+                'slack_user_id' => $head->slack_user_id,
+                'external_url' => $head->external_url,
+                'external_id' => $root->external_id . '-followup',
+                'description' => $instructions,
+                'status' => TaskStatus::Pending,
+            ]);
 
-        $child = YakTask::create([
-            'parent_task_id' => $head->id,
-            'source' => $source,
-            'repo' => $head->repo,
-            'mode' => $head->mode,
-            'branch_name' => $head->branch_name,
-            'session_id' => $head->session_id,
-            'pr_url' => $head->pr_url,
-            'pr_number' => $head->pr_number,
-            'linear_agent_session_id' => $head->linear_agent_session_id,
-            'slack_channel' => $head->slack_channel,
-            'slack_thread_ts' => $head->slack_thread_ts,
-            'slack_user_id' => $head->slack_user_id,
-            'external_url' => $head->external_url,
-            'external_id' => $head->external_id . '-followup-' . $followUpNumber,
-            'description' => $instructions,
-            'status' => TaskStatus::Pending,
-        ]);
+            // Derive a collision-free, non-compounding external_id from the
+            // chain root plus this row's own primary key — avoids the
+            // count-based race and prevents '-followup-N-followup-M' growth.
+            $child->update(['external_id' => $root->external_id . '-followup-' . $child->id]);
+
+            return $child;
+        });
 
         TaskLogger::info($child, 'Follow-up task created', ['source' => $source, 'parent_id' => $head->id]);
 
-        RunFollowUpJob::dispatch($child);
+        RunFollowUpJob::dispatch($child)->afterCommit();
 
         return $child;
-    }
-
-    /**
-     * The newest task in the conversation, so replies always continue from
-     * the latest state of the branch.
-     */
-    private function chainHead(YakTask $task): YakTask
-    {
-        return $task->conversation()->last() ?? $task;
     }
 }

--- a/app/Services/FollowUpTaskFactory.php
+++ b/app/Services/FollowUpTaskFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\TaskStatus;
+use App\Jobs\RunFollowUpJob;
+use App\Models\YakTask;
+
+class FollowUpTaskFactory
+{
+    /**
+     * Create a chained follow-up task for an open PR and dispatch the runner.
+     * Returns null (and dispatches nothing) when the PR is already merged or
+     * closed — the caller should post a polite decline.
+     */
+    public function create(YakTask $parent, string $instructions, string $source): ?YakTask
+    {
+        $head = $this->chainHead($parent);
+
+        if (! $head->prIsOpen()) {
+            return null;
+        }
+
+        $followUpNumber = $head->conversation()->count();
+
+        $child = YakTask::create([
+            'parent_task_id' => $head->id,
+            'source' => $source,
+            'repo' => $head->repo,
+            'mode' => $head->mode,
+            'branch_name' => $head->branch_name,
+            'session_id' => $head->session_id,
+            'pr_url' => $head->pr_url,
+            'pr_number' => $head->pr_number,
+            'linear_agent_session_id' => $head->linear_agent_session_id,
+            'slack_channel' => $head->slack_channel,
+            'slack_thread_ts' => $head->slack_thread_ts,
+            'slack_user_id' => $head->slack_user_id,
+            'external_url' => $head->external_url,
+            'external_id' => $head->external_id . '-followup-' . $followUpNumber,
+            'description' => $instructions,
+            'status' => TaskStatus::Pending,
+        ]);
+
+        TaskLogger::info($child, 'Follow-up task created', ['source' => $source, 'parent_id' => $head->id]);
+
+        RunFollowUpJob::dispatch($child);
+
+        return $child;
+    }
+
+    /**
+     * The newest task in the conversation, so replies always continue from
+     * the latest state of the branch.
+     */
+    private function chainHead(YakTask $task): YakTask
+    {
+        return $task->conversation()->last() ?? $task;
+    }
+}

--- a/app/YakPromptBuilder.php
+++ b/app/YakPromptBuilder.php
@@ -100,6 +100,18 @@ class YakPromptBuilder
     }
 
     /**
+     * Build a follow-up prompt for refining an already-open PR. The Claude
+     * session is resumed (it carries the original task history), so this is
+     * intentionally terse — just the user's new instructions.
+     */
+    public static function followUpPrompt(string $instructions): string
+    {
+        return Prompts::render('tasks-follow-up', [
+            'instructions' => $instructions,
+        ]);
+    }
+
+    /**
      * Build a retry prompt with the original task description, the
      * previous attempt's result summary, and CI failure output.
      *

--- a/config/yak.php
+++ b/config/yak.php
@@ -158,6 +158,7 @@ return [
             'done_state_id' => env('YAK_LINEAR_DONE_STATE_ID'),
             'cancelled_state_id' => env('YAK_LINEAR_CANCELLED_STATE_ID'),
             'in_review_state_id' => env('YAK_LINEAR_IN_REVIEW_STATE_ID'),
+            'started_state_id' => env('YAK_LINEAR_STARTED_STATE_ID'),
 
             // OAuth2 app credentials — used by the outbound driver to post
             // comments and update issue state as the Yak app.

--- a/config/yak.php
+++ b/config/yak.php
@@ -253,6 +253,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Follow-Up Configuration
+    |--------------------------------------------------------------------------
+    */
+
+    'followup' => [
+        'github_prefixes' => env('YAK_FOLLOWUP_GITHUB_PREFIXES', '/yak,@yak-bot[bot],yak:'),
+        'github_batch_window_seconds' => (int) env('YAK_FOLLOWUP_GITHUB_BATCH_WINDOW_SECONDS', 60),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | PR Review Configuration
     |--------------------------------------------------------------------------
     */

--- a/database/migrations/2026_06_03_000001_add_parent_task_id_to_tasks_table.php
+++ b/database/migrations/2026_06_03_000001_add_parent_task_id_to_tasks_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table): void {
+            $table->foreignId('parent_task_id')
+                ->nullable()
+                ->after('id')
+                ->constrained('tasks')
+                ->nullOnDelete();
+            $table->unsignedInteger('pr_number')->nullable()->after('pr_url');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('parent_task_id');
+            $table->dropColumn('pr_number');
+        });
+    }
+};

--- a/database/migrations/2026_06_03_000002_create_follow_up_pending_comments_table.php
+++ b/database/migrations/2026_06_03_000002_create_follow_up_pending_comments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('follow_up_pending_comments', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('yak_task_id')->constrained('tasks')->cascadeOnDelete();
+            $table->string('pr_url')->index();
+            $table->text('body');
+            $table->string('file')->nullable();
+            $table->unsignedInteger('line')->nullable();
+            $table->text('diff_hunk')->nullable();
+            $table->unsignedBigInteger('github_comment_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('follow_up_pending_comments');
+    }
+};

--- a/docs-site/src/content/docs-static/index.mdx
+++ b/docs-site/src/content/docs-static/index.mdx
@@ -34,9 +34,10 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     Screenshots and video walkthroughs for UI changes. A human reviews every
     PR before merge. Yak has no merge authority. No exceptions.
   </Card>
-  <Card title="Responds where asked" icon="comment">
-    Slack message → Slack thread reply. Linear issue → Linear comment.
-    You never have to check a separate UI to see what happened.
+  <Card title="Two-way feedback" icon="comment">
+    Reply in the same Slack thread, on the Linear issue, or with `/yak` on the
+    PR, and Yak refines the work — pushing follow-up commits to the same
+    branch. No separate UI to check.
   </Card>
 </CardGrid>
 
@@ -63,8 +64,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 ## Design philosophy
 
-- **One-shot by design.** A task fits in a paragraph. Yak resolves it in a single pass. If it needs back-and-forth, it's not a Yak task.
-- **Meet the user where they are.** Slack in, Slack out. Linear in, Linear out. No separate dashboard check required.
+- **First pass in one shot, then refine.** A task fits in a paragraph, and Yak resolves it in a single pass. Not quite right? Reply where you already are and Yak pushes follow-up commits to the same PR until it's done.
+- **Meet the user where they are.** Slack in, Slack out. Linear in, Linear out. The whole back-and-forth happens in the channel you started from — no separate dashboard check required.
 - **Clarify, don't guess.** Ambiguous requests get multiple-choice options grounded in actual code, not generic guesses.
 - **Yak never ships.** Output is always a PR requiring human review. No merge authority, no exceptions.
 - **Channels are optional.** GitHub plus the manual CLI is the minimum. Enable the rest as you need them.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -395,7 +395,7 @@ Artifacts embedded in GitHub PRs (screenshots, videos) use HMAC-SHA256 signed UR
 
 - **Not a merge bot.** See above — no merge authority, no bypass.
 - **Not horizontally scaled.** Four concurrent workers on one server. The architecture supports future scaling to multiple hosts but doesn't need it.
-- **Not a long-running agent.** Every task is one-shot. No back-and-forth refinement. If a task needs iterative discussion, use a normal Claude session.
+- **Not a long-running interactive agent.** Each task is a focused, mostly autonomous pass. You can give feedback on an open PR — in the originating channel, as a `/yak` PR comment, or from the dashboard — and Yak resumes the session and pushes follow-up commits to the same branch. But it's not a chat session for open-ended discussion or large multi-step features.
 - **Not a frontend framework.** Dashboard is Livewire (server-rendered) with Livewire polling for live updates. No SPA, no websockets.
 - **Not Kubernetes-anything.** Two Docker containers (app + MariaDB) + Incus for sandboxed task execution on a dedicated server. Laravel's database queue driver. Boring stack.
 - **Not a production deploy platform.** Previews are preview environments only. Merging a PR does not deploy it anywhere; the existing production deploy pipeline remains the source of truth.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -33,7 +33,7 @@ The minimum viable setup is **GitHub + manual CLI**. Everything else is optional
 
 GitHub is the only channel Yak cannot run without — it needs it to push branches and open PRs.
 
-**Roles:** CI (via Actions), notification (PR bodies and comments).
+**Roles:** CI (via Actions), notification (PR bodies and comments), input (follow-up commands on open PRs).
 
 ### Setup
 
@@ -47,7 +47,7 @@ If you already have a GitHub App and want to reuse it, fill in `github_app_id`, 
 |---|---|
 | Contents | Read & Write (push branches) |
 | Pull requests | Read & Write (create PRs, add labels) |
-| Issues | Read |
+| Issues | Read & Write (react to follow-up comments) |
 | Checks | Read (CI results) |
 | Metadata | Read (default) |
 
@@ -59,14 +59,34 @@ The GitHub App subscribes to:
 - `pull_request.closed` — merge/close tracking (also denormalizes onto `pr_reviews`)
 - `pull_request.opened` / `ready_for_review` / `reopened` — triggers a full PR review when `pr_review_enabled` is on
 - `pull_request.synchronize` — triggers an incremental PR review
+- `issue_comment.created` — `/yak` follow-up comments on an open PR (see [Follow-ups](#follow-ups) below)
+- `pull_request_review_comment.created` — `/yak` follow-up replies on an inline review comment (the file, line, and diff hunk are passed to Yak as context)
 
-Webhook URL: `https://{your-domain}/webhooks/ci/github` for CI; `https://{your-domain}/webhooks/github` for PR review events.
+Webhook URL: `https://{your-domain}/webhooks/ci/github` for CI; `https://{your-domain}/webhooks/github` for PR review and follow-up events.
+
+> **Subscribing an existing app.** Freshly provisioned apps include these events and permissions via the Ansible manifest. If you reuse a pre-existing GitHub App, add **Issue comments** and **Pull request review comments** to its event subscriptions (or follow-ups won't fire) and bump **Issues** to **Read & Write** (or the 👀 acknowledgement on PR conversation comments will 403). GitHub will prompt installations to re-accept the new permission.
 
 ### Usage
 
 If your repos use GitHub Actions for CI, set `ci_system: github_actions` in the repo definition. Nothing else is required — the GitHub App receives check suite events automatically.
 
 **Important:** the GitHub App must NOT be in your branch protection bypass list and must not have permission to approve reviews. Yak has no merge authority by design.
+
+### Follow-ups
+
+Once Yak has opened a PR, you can keep refining it without a local checkout. Comment on the PR (or reply to an inline review comment) with a `/yak` prefix:
+
+```
+/yak also handle the empty-file case
+/yak the error message should mention the row number
+```
+
+Yak reacts 👀 on the comment to acknowledge receipt, resumes the original Claude session, applies the feedback, and pushes follow-up commits to the **same branch** — then posts a result comment when the push lands. CI re-runs and the existing auto-retry pipeline applies. The follow-up becomes a chained task under the original on the dashboard.
+
+- **Trigger prefixes** are configurable via `YAK_FOLLOWUP_GITHUB_PREFIXES` (default `/yak,@yak-bot[bot],yak:`, case-insensitive). A comment without a prefix is ignored.
+- **Bursts are debounced.** Multiple comments within `YAK_FOLLOWUP_GITHUB_BATCH_WINDOW_SECONDS` (default `60`) are collapsed into a single follow-up run, so a flurry of review notes produces one coherent revision rather than racing pushes.
+- **Inline review comments** carry their file, line, and surrounding diff hunk into the instruction, so "this variable name is confusing" lands with the context Yak needs.
+- **Merged or closed PRs** decline politely and point you at a fresh issue or task — follow-ups only work while the PR is open.
 
 ---
 
@@ -100,7 +120,7 @@ Results post to the PR (for fix tasks) or to the task's dashboard page (for rese
 
 ## Slack (optional)
 
-**Roles:** Input (task creation via `@yak` mention), notification (thread replies).
+**Roles:** Input (task creation via `@yak` mention, follow-ups via thread replies), notification (thread replies).
 
 ### Setup
 
@@ -108,7 +128,7 @@ Results post to the PR (for fix tasks) or to the task's dashboard page (for rese
 2. Enable **Event Subscriptions** with request URL `https://{your-domain}/webhooks/slack`
 3. Subscribe to bot events:
    - `app_mention`
-   - `message.channels` (needed for thread replies to clarifications)
+   - `message.channels` (needed for thread replies — clarification answers and follow-ups)
    - `app_home_opened` (powers the welcome DM the first time a user opens Yak's App Home)
 4. Enable the **App Home** tab (under **App Home** in the Slack app config). The tab itself can stay default — Yak uses the open event to DM the user, not to publish a Home view.
 5. Enable **Interactivity & Shortcuts** with request URL `https://{your-domain}/webhooks/slack/interactive` — powers click-to-answer buttons on clarification messages.
@@ -165,9 +185,13 @@ The task pauses in `awaiting_clarification` for up to 3 days. Reply in the threa
 
 Linear and Sentry tasks do not clarify because their inputs are already structured.
 
+### Follow-ups
+
+After Yak has opened a PR, replying in the same thread keeps the conversation going. A thread reply on a task with an open PR is treated as feedback: Yak resumes the original session, applies your message, and pushes follow-up commits to the same branch — replying in-thread when the push lands. No new mention required; just reply where the PR was announced. This is the same thread-matching that powers clarification answers, so it relies on the `channels:history` scope.
+
 ### Gotchas
 
-- **Channels history scope is required** for thread reply matching. Without it, clarification replies cannot be routed to the correct task.
+- **Channels history scope is required** for thread reply matching. Without it, clarification replies and follow-ups cannot be routed to the correct task.
 - **`reactions:write` must be granted** for status reactions to appear. Without it, reactions silently fail; everything else still works.
 - **`app_home_opened` event must be subscribed** for welcome DMs. Enable the App Home tab in the Slack app config even if you never customize it — the event only fires when the tab is enabled.
 - **Bot token rotation** requires re-running Ansible to update the container env vars.
@@ -214,7 +238,7 @@ Delegation opens an agent session on the issue. Yak immediately posts an acknowl
 - **Research tasks** — Yak posts the findings and moves the issue to "Done".
 - **Failures** — Yak posts an `error` activity explaining what went wrong; the issue state is left alone.
 
-Follow-up messages inside the agent session are not supported — Yak replies with a polite error pointing you to the pull request or a fresh Linear issue for further changes.
+Follow-up messages inside the agent session are supported. Once a PR is open, commenting in the session is routed as feedback: Yak resumes the original session, applies your message, and pushes follow-up commits to the same branch (see [Follow-ups](#follow-ups-2) below). If the PR has already merged or closed, Yak declines politely and points you at a fresh issue.
 
 #### What you'll see during a run
 
@@ -222,7 +246,11 @@ Follow-up messages inside the agent session are not supported — Yak replies wi
 - **Start-of-work progress.** As soon as the worker picks the task up (often seconds later), Yak posts a `thought` activity describing what it's about to do. Closes the silent gap between pickup and first push on longer tasks. Controlled by `YAK_EMIT_START_PROGRESS` — default on.
 - **Push + CI.** Once the agent has changes, Yak pushes to a branch and posts another progress activity noting CI is running.
 - **Final response.** On success, a `response` activity with the PR link; on failure, an `error` activity with the reason.
-- **Multi-turn replies.** Commenting *inside* the agent session isn't supported — Yak responds with an `error` activity (run through personality for tone) directing you to the pull request or a fresh issue.
+- **Multi-turn replies.** Commenting *inside* the agent session is state-aware: while Yak is `awaiting_clarification` your reply answers the question; once a PR is open it becomes a follow-up that pushes more commits; a `stop` signal cancels the in-flight task; and a merged/closed PR gets a polite decline.
+
+#### Follow-ups
+
+Yak generalizes the clarification engine into full two-way feedback. After the PR is open, post a comment in the agent session with your refinement and Yak resumes the original session, applies it, and pushes to the **same branch** — emitting a `thought` ack on receipt and a `response` when the push lands. CI re-runs through the existing auto-retry pipeline, and the follow-up appears as a chained task under the original on the dashboard. Reassigning the issue away from Yak (an unassignment) cancels any in-flight work.
 
 ### Repo Detection
 
@@ -239,12 +267,12 @@ Yak manages the Linear issue's workflow state throughout the task lifecycle:
 
 | Event | Issue state |
 |---|---|
-| Task picked up | → **In Progress** |
+| Task picked up | → **In Progress / Started** |
 | PR created (CI green) | → **In Review** |
 | Research completed | → **Done** |
 | Task failed | remains In Progress with a failure activity |
 
-Configure the state UUIDs via `linear_done_state_id`, `linear_cancelled_state_id`, and `linear_in_review_state_id` in `ansible/vault/secrets.yml`.
+Configure the state UUIDs via `linear_done_state_id`, `linear_cancelled_state_id`, `linear_in_review_state_id`, and `linear_started_state_id` (`YAK_LINEAR_STARTED_STATE_ID`, used for the picked-up → started transition) in `ansible/vault/secrets.yml`. If `linear_started_state_id` is unset, the pickup transition is skipped and the issue stays in its current state until the PR is opened.
 
 ### Gotchas
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,14 +1,44 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Call to function is_array\(\) with array\{name\?\: string\} will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: app/Channels/Linear/IssueFetcher.php
+
+		-
 			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskMode\:\:Research will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1
 			path: app/Channels/Linear/WebhookController.php
 
 		-
+			message: '#^Cannot access property \$value on string\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Channels/Slack/BlockFormatter.php
+
+		-
+			message: '#^Method App\\Channels\\Slack\\BlockFormatter\:\:contextChips\(\) never returns null so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: app/Channels/Slack/BlockFormatter.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between list\{0\: non\-falsy\-string, 1\?\: non\-falsy\-string, 2\?\: non\-falsy\-string\} and array\{\} will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Channels/Slack/BlockFormatter.php
+
+		-
 			message: '#^Cannot cast array\<mixed\>\|string to string\.$#'
 			identifier: cast.string
+			count: 1
+			path: app/Channels/Slack/InteractiveWebhookController.php
+
+		-
+			message: '#^Method App\\Channels\\Slack\\InteractiveWebhookController\:\:ackClick\(\) is unused\.$#'
+			identifier: method.unused
 			count: 1
 			path: app/Channels/Slack/InteractiveWebhookController.php
 
@@ -31,16 +61,202 @@ parameters:
 			path: app/Channels/Slack/InteractiveWebhookController.php
 
 		-
+			message: '#^Call to function is_array\(\) with string\|null will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: app/Channels/Slack/NotificationDriver.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: app/Channels/Slack/NotificationDriver.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between \*NEVER\* and array\{\} will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: app/Channels/Slack/NotificationDriver.php
+
+		-
 			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskMode\:\:Research will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1
 			path: app/Channels/Slack/WebhookController.php
 
 		-
-			message: '#^Call to function in_array\(\) with arguments string, array\{App\\Enums\\TaskStatus\:\:Success, App\\Enums\\TaskStatus\:\:Failed, App\\Enums\\TaskStatus\:\:Expired, App\\Enums\\TaskStatus\:\:Cancelled\} and true will always evaluate to false\.$#'
+			message: '#^Method App\\DataTransferObjects\\PreviewManifest\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/DataTransferObjects/PreviewManifest.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Destroyed is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Http/Controllers/Internal/DeploymentStatusController.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Destroying is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Http/Controllers/Internal/DeploymentStatusController.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Failed is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Http/Controllers/Internal/DeploymentStatusController.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Running is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Http/Controllers/Internal/DeploymentStatusController.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''pending'' and ''failed'' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Http/Controllers/Internal/DeploymentStatusController.php
+
+		-
+			message: '#^Offset ''host'' might not exist on array\{state\: ''ready'', host\?\: string, port\?\: int, reason\?\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: app/Http/Controllers/Internal/DeploymentWakeController.php
+
+		-
+			message: '#^Offset ''port'' might not exist on array\{state\: ''ready'', host\?\: string, port\?\: int, reason\?\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: app/Http/Controllers/Internal/DeploymentWakeController.php
+
+		-
+			message: '#^Parameter \#2 \$candidateCookie of method App\\Services\\DeploymentShareTokens\:\:verifyCookie\(\) expects string, array\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Controllers/Internal/DeploymentWakeController.php
+
+		-
+			message: '#^Call to function abort_unless\(\) with false and 404 will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 1
-			path: app/Jobs/ClarificationReplyJob.php
+			path: app/Http/Controllers/Tasks/RequestReReviewController.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskMode\:\:Review will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Http/Controllers/Tasks/RequestReReviewController.php
+
+		-
+			message: '#^Cannot cast float\|int\|list\<string\>\|string to string\.$#'
+			identifier: cast.string
+			count: 1
+			path: app/Http/Middleware/RestrictToIngress.php
+
+		-
+			message: '#^Property App\\Models\\BranchDeployment\:\:\$status \(string\) does not accept App\\Enums\\DeploymentStatus\:\:Failed\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Jobs/Deployments/DeployBranchJob.php
+
+		-
+			message: '#^Property App\\Models\\BranchDeployment\:\:\$status \(string\) does not accept App\\Enums\\DeploymentStatus\:\:Running\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Jobs/Deployments/DeployBranchJob.php
+
+		-
+			message: '#^Property App\\Models\\BranchDeployment\:\:\$status \(string\) does not accept App\\Enums\\DeploymentStatus\:\:Starting\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Jobs/Deployments/DeployBranchJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\DeploymentStatus\:\:Destroyed will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/Deployments/DestroyDeploymentJob.php
+
+		-
+			message: '#^Cannot access property \$slug on App\\Models\\Repository\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Jobs/Deployments/GarbageCollectTemplateSnapshotsJob.php
+
+		-
+			message: '#^Method App\\Jobs\\Deployments\\GarbageCollectTemplateSnapshotsJob\:\:computePinnedSet\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Jobs/Deployments/GarbageCollectTemplateSnapshotsJob.php
+
+		-
+			message: '#^Method App\\Jobs\\Deployments\\GarbageCollectTemplateSnapshotsJob\:\:listAllSnapshots\(\) should return list\<App\\DataTransferObjects\\TemplateSnapshotRef\> but returns array\<int, App\\DataTransferObjects\\TemplateSnapshotRef\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Jobs/Deployments/GarbageCollectTemplateSnapshotsJob.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Jobs/Deployments/GarbageCollectTemplateSnapshotsJob.php
+
+		-
+			message: '#^Parameter \#1 \$value of function collect expects Illuminate\\Contracts\\Support\\Arrayable\<int\<0, max\>, string\>\|iterable\<int\<0, max\>, string\>\|null, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Jobs/Deployments/GarbageCollectTemplateSnapshotsJob.php
+
+		-
+			message: '#^Property App\\Models\\BranchDeployment\:\:\$status \(string\) does not accept App\\Enums\\DeploymentStatus\:\:Hibernated\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Jobs/Deployments/HibernateIdleDeploymentsJob.php
+
+		-
+			message: '#^Cannot access property \$current_template_version on App\\Models\\Repository\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Jobs/Deployments/RebuildDeploymentJob.php
+
+		-
+			message: '#^Property App\\Models\\BranchDeployment\:\:\$status \(string\) does not accept App\\Enums\\DeploymentStatus\:\:Running\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Jobs/Deployments/RebuildDeploymentJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\DeploymentStatus\:\:Hibernated will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/Deployments/UpdateDeploymentJob.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\DeploymentStatus\:\:Running will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Jobs/Deployments/UpdateDeploymentJob.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and App\\Enums\\DeploymentStatus\:\:Starting will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: app/Jobs/Deployments/WakeHibernatedDeploymentJob.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: app/Jobs/Deployments/WakeHibernatedDeploymentJob.php
+
+		-
+			message: '#^Cannot access property \$value on string\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Jobs/Deployments/WatchdogStuckDeploymentsJob.php
 
 		-
 			message: '#^Call to function in_array\(\) with arguments string, array\{App\\Enums\\TaskStatus\:\:Success, App\\Enums\\TaskStatus\:\:Cancelled\} and true will always evaluate to false\.$#'
@@ -49,31 +265,7 @@ parameters:
 			path: app/Jobs/ProcessCIResultJob.php
 
 		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: app/Jobs/ClarificationReplyJob.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskStatus\:\:Failed will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: app/Jobs/ClarificationReplyJob.php
-
-		-
-			message: '#^Call to function in_array\(\) with arguments string, array\{App\\Enums\\TaskStatus\:\:Success, App\\Enums\\TaskStatus\:\:Failed, App\\Enums\\TaskStatus\:\:Expired, App\\Enums\\TaskStatus\:\:Cancelled\} and true will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: app/Jobs/ResearchYakJob.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: app/Jobs/ResearchYakJob.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskStatus\:\:Failed will always evaluate to false\.$#'
+			message: '#^Strict comparison using \=\=\= between string\|null and App\\Enums\\TaskStatus\:\:Cancelled will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1
 			path: app/Jobs/ResearchYakJob.php
@@ -82,49 +274,13 @@ parameters:
 			message: '#^Strict comparison using \=\=\= between string\|null and App\\Enums\\TaskStatus\:\:Cancelled will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1
-			path: app/Jobs/ResearchYakJob.php
-
-		-
-			message: '#^Call to function in_array\(\) with arguments string, array\{App\\Enums\\TaskStatus\:\:Success, App\\Enums\\TaskStatus\:\:Failed, App\\Enums\\TaskStatus\:\:Expired, App\\Enums\\TaskStatus\:\:Cancelled\} and true will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: app/Jobs/RetryYakJob.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: app/Jobs/RetryYakJob.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskStatus\:\:Failed will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: app/Jobs/RetryYakJob.php
-
-		-
-			message: '#^Call to function in_array\(\) with arguments string, array\{App\\Enums\\TaskStatus\:\:Success, App\\Enums\\TaskStatus\:\:Failed, App\\Enums\\TaskStatus\:\:Expired, App\\Enums\\TaskStatus\:\:Cancelled\} and true will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
 			path: app/Jobs/RunYakJob.php
 
 		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
+			message: '#^Parameter \#3 \$prUrl of method App\\Services\\PriorFindingsHydrator\:\:hydrate\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
-			path: app/Jobs/RunYakJob.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskStatus\:\:Failed will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: app/Jobs/RunYakJob.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between string\|null and App\\Enums\\TaskStatus\:\:Cancelled will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: app/Jobs/RunYakJob.php
+			path: app/Jobs/RunYakReviewJob.php
 
 		-
 			message: '#^Strict comparison using \=\=\= between string\|null and App\\Enums\\TaskStatus\:\:Cancelled will always evaluate to false\.$#'
@@ -133,20 +289,8 @@ parameters:
 			path: app/Jobs/RunYakReviewJob.php
 
 		-
-			message: '#^Call to function in_array\(\) with arguments string, array\{App\\Enums\\TaskStatus\:\:Success, App\\Enums\\TaskStatus\:\:Failed, App\\Enums\\TaskStatus\:\:Expired, App\\Enums\\TaskStatus\:\:Cancelled\} and true will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: app/Jobs/SetupYakJob.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: app/Jobs/SetupYakJob.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\TaskStatus\:\:Failed will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
+			message: '#^Property App\\Models\\Repository\:\:\$preview_manifest \(string\|null\) does not accept array\<string, mixed\>\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: app/Jobs/SetupYakJob.php
 
@@ -173,6 +317,78 @@ parameters:
 			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: app/Livewire/Channels/ChannelList.php
+
+		-
+			message: '#^Method App\\Livewire\\Deployments\\DeploymentIndex\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Deployments/DeploymentIndex.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Destroying is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Livewire/Deployments/DeploymentShow.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Pending is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Livewire/Deployments/DeploymentShow.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Starting is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Livewire/Deployments/DeploymentShow.php
+
+		-
+			message: '#^Method App\\Livewire\\Deployments\\DeploymentShow\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Deployments/DeploymentShow.php
+
+		-
+			message: '#^Method App\\Livewire\\Deployments\\ManifestForm\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Deployments/ManifestForm.php
+
+		-
+			message: '#^Offset ''checkout_refresh'' on array\{\}\|string on left side of \?\? does not exist\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: app/Livewire/Deployments/ManifestForm.php
+
+		-
+			message: '#^Offset ''cold_start'' on array\{\}\|string on left side of \?\? does not exist\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: app/Livewire/Deployments/ManifestForm.php
+
+		-
+			message: '#^Offset ''health_probe_path'' on array\{\}\|string on left side of \?\? does not exist\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: app/Livewire/Deployments/ManifestForm.php
+
+		-
+			message: '#^Offset ''port'' on array\{\}\|string on left side of \?\? does not exist\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: app/Livewire/Deployments/ManifestForm.php
+
+		-
+			message: '#^Offset ''wake_timeout_seconds'' on array\{\}\|string on left side of \?\? does not exist\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: app/Livewire/Deployments/ManifestForm.php
+
+		-
+			message: '#^Method App\\Livewire\\Repositories\\RebuildAllDeploymentsAction\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Repositories/RebuildAllDeploymentsAction.php
 
 		-
 			message: '#^Cannot call method delete\(\) on App\\Models\\User\|null\.$#'
@@ -301,6 +517,12 @@ parameters:
 			path: app/Livewire/Settings/TwoFactor/RecoveryCodes.php
 
 		-
+			message: '#^Method App\\Livewire\\Tasks\\PreviewWidget\:\:render\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Livewire/Tasks/PreviewWidget.php
+
+		-
 			message: '#^Result of && is always false\.$#'
 			identifier: booleanAnd.alwaysFalse
 			count: 2
@@ -337,10 +559,148 @@ parameters:
 			path: app/Livewire/Tasks/TaskDetail.php
 
 		-
-			message: '#^Call to function is_array\(\) with array\{name\?\: string\} will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
+			message: '#^Cannot access property \$value on string\.$#'
+			identifier: property.nonObject
 			count: 1
-			path: app/Channels/Linear/IssueFetcher.php
+			path: app/Observers/BranchDeploymentObserver.php
+
+		-
+			message: '#^Parameter \#2 \$newStatus of method App\\Services\\DeploymentGitHubSync\:\:sync\(\) expects App\\Enums\\DeploymentStatus, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Observers/BranchDeploymentObserver.php
+
+		-
+			message: '#^Cannot access property \$preview_manifest on App\\Models\\Repository\|null\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: app/Services/DeploymentContainerManager.php
+
+		-
+			message: '#^Cannot access property \$slug on App\\Models\\Repository\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Services/DeploymentContainerManager.php
+
+		-
+			message: '#^Parameter \#1 \$data of static method App\\DataTransferObjects\\PreviewManifest\:\:fromArray\(\) expects array\|null, string\|null given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Services/DeploymentContainerManager.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between '''' and '''' will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: app/Services/DeploymentContainerManager.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: app/Services/DeploymentContainerManager.php
+
+		-
+			message: '#^Cannot access property \$slug on App\\Models\\Repository\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Services/DeploymentGitHubSync.php
+
+		-
+			message: '#^Property App\\Models\\BranchDeployment\:\:\$github_deployment_id \(int\<0, max\>\|null\) does not accept int\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Services/DeploymentGitHubSync.php
+
+		-
+			message: '#^Cannot call method isPast\(\) on string\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: app/Services/DeploymentShareTokens.php
+
+		-
+			message: '#^Cannot access property \$preview_manifest on App\\Models\\Repository\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Destroyed is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Destroying is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Failed is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Hibernated is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Pending is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Running is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Match arm comparison between string and App\\Enums\\DeploymentStatus\:\:Starting is always false\.$#'
+			identifier: match.alwaysFalse
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Match expression does not handle remaining value\: string$#'
+			identifier: match.unhandled
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Method App\\Services\\DeploymentWaker\:\:dispatchWake\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Parameter \#1 \$data of static method App\\DataTransferObjects\\PreviewManifest\:\:fromArray\(\) expects array\|null, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Property App\\Models\\BranchDeployment\:\:\$status \(string\) does not accept App\\Enums\\DeploymentStatus\:\:Starting\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\DeploymentStatus\:\:Hibernated will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Services/DeploymentWaker.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Enums\\DeploymentStatus\:\:Destroyed will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: app/Services/IncusSandboxManager.php
 
 		-
 			message: '#^Binary operation "\^" between string\|false and string\|false results in an error\.$#'
@@ -361,19 +721,13 @@ parameters:
 			path: app/Services/TaskJobResolver.php
 
 		-
-			message: '#^Cannot access property \$value on string\.$#'
-			identifier: property.nonObject
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
-			path: app/Channels/Slack/BlockFormatter.php
+			path: app/Support/BranchHostname.php
 
 		-
-			message: '#^Method App\\Channels\\Slack\\BlockFormatter\:\:contextChips\(\) never returns null so it can be removed from the return type\.$#'
-			identifier: return.unusedType
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
-			path: app/Channels/Slack/BlockFormatter.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between list\{0\: non\-falsy\-string, 1\?\: non\-falsy\-string, 2\?\: non\-falsy\-string\} and array\{\} will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: app/Channels/Slack/BlockFormatter.php
+			path: app/Support/BranchHostname.php

--- a/resources/views/livewire/tasks/create-task.blade.php
+++ b/resources/views/livewire/tasks/create-task.blade.php
@@ -1,0 +1,56 @@
+<div data-testid="create-task-form">
+    <form wire:submit="save">
+        {{-- Repo picker --}}
+        <div class="mb-4">
+            <flux:select wire:model="repo" label="Repository" placeholder="Choose a repository…">
+                @foreach($this->repos as $r)
+                    <flux:select.option value="{{ $r->slug }}">{{ $r->slug }}</flux:select.option>
+                @endforeach
+            </flux:select>
+            @error('repo')
+                <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+            @enderror
+        </div>
+
+        {{-- Fix / Research toggle --}}
+        <div class="mb-4">
+            <label class="mb-2 block text-sm font-medium text-yak-slate">Mode</label>
+            <div class="flex gap-2">
+                <button
+                    type="button"
+                    wire:click="$set('taskMode', 'fix')"
+                    class="rounded-lg border px-4 py-1.5 text-sm font-medium transition-colors {{ $taskMode === 'fix' ? 'border-yak-orange bg-yak-orange/10 text-yak-orange' : 'border-yak-tan/50 bg-transparent text-yak-blue hover:border-yak-orange/50 hover:text-yak-orange' }}"
+                >
+                    Fix
+                </button>
+                <button
+                    type="button"
+                    wire:click="$set('taskMode', 'research')"
+                    class="rounded-lg border px-4 py-1.5 text-sm font-medium transition-colors {{ $taskMode === 'research' ? 'border-yak-orange bg-yak-orange/10 text-yak-orange' : 'border-yak-tan/50 bg-transparent text-yak-blue hover:border-yak-orange/50 hover:text-yak-orange' }}"
+                >
+                    Research
+                </button>
+            </div>
+            @error('taskMode')
+                <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+            @enderror
+        </div>
+
+        {{-- Description --}}
+        <div class="mb-5">
+            <flux:textarea
+                wire:model="description"
+                label="Description"
+                placeholder="Describe what you'd like Yak to do…"
+                rows="4"
+                data-testid="new-task-description"
+            />
+            @error('description')
+                <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+            @enderror
+        </div>
+
+        {{-- Submit --}}
+        <flux:button variant="primary" wire:click="save" data-testid="new-task-submit">Start task</flux:button>
+    </form>
+</div>

--- a/resources/views/livewire/tasks/create-task.blade.php
+++ b/resources/views/livewire/tasks/create-task.blade.php
@@ -19,6 +19,7 @@
                 <button
                     type="button"
                     wire:click="$set('taskMode', 'fix')"
+                    data-testid="mode-fix"
                     class="rounded-lg border px-4 py-1.5 text-sm font-medium transition-colors {{ $taskMode === 'fix' ? 'border-yak-orange bg-yak-orange/10 text-yak-orange' : 'border-yak-tan/50 bg-transparent text-yak-blue hover:border-yak-orange/50 hover:text-yak-orange' }}"
                 >
                     Fix
@@ -26,6 +27,7 @@
                 <button
                     type="button"
                     wire:click="$set('taskMode', 'research')"
+                    data-testid="mode-research"
                     class="rounded-lg border px-4 py-1.5 text-sm font-medium transition-colors {{ $taskMode === 'research' ? 'border-yak-orange bg-yak-orange/10 text-yak-orange' : 'border-yak-tan/50 bg-transparent text-yak-blue hover:border-yak-orange/50 hover:text-yak-orange' }}"
                 >
                     Research
@@ -51,6 +53,6 @@
         </div>
 
         {{-- Submit --}}
-        <flux:button variant="primary" wire:click="save" data-testid="new-task-submit">Start task</flux:button>
+        <flux:button type="submit" variant="primary" data-testid="new-task-submit">Start task</flux:button>
     </form>
 </div>

--- a/resources/views/livewire/tasks/task-detail.blade.php
+++ b/resources/views/livewire/tasks/task-detail.blade.php
@@ -310,27 +310,28 @@
                                     <span class="text-[13px] text-yak-slate">{{ $turn->description }}</span>
                                 </div>
                             @endif
-                            {{-- "Yak" line: result summary or PR outcome --}}
-                            @if($turn->result_summary || $turn->pr_url)
+                            {{-- "Yak" line: result summary (with outcome) --}}
+                            @if($turn->result_summary)
                                 <div class="flex items-start gap-2">
                                     <span class="mt-0.5 shrink-0 rounded-full bg-yak-green/15 px-2 py-0.5 text-[11px] font-medium text-yak-green">Yak</span>
                                     <div class="flex flex-col gap-0.5">
-                                        @if($turn->result_summary)
-                                            <span class="text-[13px] text-yak-slate">{{ Str::limit($turn->result_summary, 200) }}</span>
-                                        @endif
-                                        @if($turn->pr_url)
-                                            <a href="{{ $turn->pr_url }}" target="_blank" class="text-[13px] font-medium text-yak-orange hover:text-yak-orange-warm">{{ $turn->pr_url }}</a>
-                                        @endif
+                                        <span class="text-[13px] text-yak-slate">{{ Str::limit($turn->result_summary, 200) }}</span>
                                     </div>
                                 </div>
                             @endif
-                            {{-- Timestamp + run link for non-root turns only --}}
-                            @if(! $turn->is($this->conversation->first()))
-                                <div class="ml-16 flex items-center gap-3">
-                                    <span class="font-mono text-[11px] text-yak-tan">{{ $turn->created_at->diffForHumans() }}</span>
+                            {{-- Timestamp + run link for non-root turns --}}
+                            <div class="ml-16 flex items-center gap-3">
+                                <span class="font-mono text-[11px] text-yak-tan">
+                                    @if($this->isActiveStatus())
+                                        {{ $turn->created_at->diffForHumans() }}
+                                    @else
+                                        {{ $turn->created_at->format('g:i:s A') }}
+                                    @endif
+                                </span>
+                                @if(! $turn->is($this->conversation->first()))
                                     <a href="{{ route('tasks.show', $turn) }}" class="text-[11px] text-yak-blue hover:text-yak-slate">open run</a>
-                                </div>
-                            @endif
+                                @endif
+                            </div>
                         </div>
                         @if(! $loop->last)
                             <div class="border-t border-[rgba(200,184,154,0.2)]"></div>

--- a/resources/views/livewire/tasks/task-detail.blade.php
+++ b/resources/views/livewire/tasks/task-detail.blade.php
@@ -294,6 +294,77 @@
         </div>
     @endif
 
+    {{-- Section: Conversation (follow-up chain + composer) --}}
+    @if($this->conversation->count() > 1 || $task->prIsOpen())
+        <div class="mb-5 rounded-[28px] border border-[rgba(200,184,154,0.4)] bg-white p-4 sm:p-7 shadow-[0_4px_6px_rgba(61,79,95,0.03),0_12px_24px_rgba(61,79,95,0.06)]">
+            <h2 class="mb-4 text-lg font-medium text-yak-slate">Conversation</h2>
+
+            @if($this->conversation->count() > 0)
+                <div class="space-y-4">
+                    @foreach($this->conversation as $turn)
+                        <div class="flex flex-col gap-1" wire:key="turn-{{ $turn->id }}">
+                            {{-- "You" line: the original instruction / follow-up text --}}
+                            @if($turn->description)
+                                <div class="flex items-start gap-2">
+                                    <span class="mt-0.5 shrink-0 rounded-full bg-yak-orange/15 px-2 py-0.5 text-[11px] font-medium text-yak-orange">You</span>
+                                    <span class="text-[13px] text-yak-slate">{{ $turn->description }}</span>
+                                </div>
+                            @endif
+                            {{-- "Yak" line: result summary or PR outcome --}}
+                            @if($turn->result_summary || $turn->pr_url)
+                                <div class="flex items-start gap-2">
+                                    <span class="mt-0.5 shrink-0 rounded-full bg-yak-green/15 px-2 py-0.5 text-[11px] font-medium text-yak-green">Yak</span>
+                                    <div class="flex flex-col gap-0.5">
+                                        @if($turn->result_summary)
+                                            <span class="text-[13px] text-yak-slate">{{ Str::limit($turn->result_summary, 200) }}</span>
+                                        @endif
+                                        @if($turn->pr_url)
+                                            <a href="{{ $turn->pr_url }}" target="_blank" class="text-[13px] font-medium text-yak-orange hover:text-yak-orange-warm">{{ $turn->pr_url }}</a>
+                                        @endif
+                                    </div>
+                                </div>
+                            @endif
+                            {{-- Timestamp + run link for non-root turns only --}}
+                            @if(! $turn->is($this->conversation->first()))
+                                <div class="ml-16 flex items-center gap-3">
+                                    <span class="font-mono text-[11px] text-yak-tan">{{ $turn->created_at->diffForHumans() }}</span>
+                                    <a href="{{ route('tasks.show', $turn) }}" class="text-[11px] text-yak-blue hover:text-yak-slate">open run</a>
+                                </div>
+                            @endif
+                        </div>
+                        @if(! $loop->last)
+                            <div class="border-t border-[rgba(200,184,154,0.2)]"></div>
+                        @endif
+                    @endforeach
+                </div>
+            @endif
+
+            {{-- Follow-up composer (only when PR is open) --}}
+            @if($task->prIsOpen())
+                <div class="mt-5 border-t border-[rgba(200,184,154,0.3)] pt-5">
+                    <label for="follow-up-input" class="mb-2 block text-sm font-medium text-yak-slate">Send feedback to Yak</label>
+                    <textarea
+                        id="follow-up-input"
+                        wire:model="followUpText"
+                        rows="3"
+                        placeholder="Describe what you'd like Yak to change or add to this PR…"
+                        data-testid="follow-up-input"
+                        class="w-full rounded-xl border border-[rgba(200,184,154,0.5)] bg-[#faf7f1] p-3 text-sm text-yak-slate focus:border-yak-orange focus:outline-none focus:ring-1 focus:ring-yak-orange"
+                    ></textarea>
+                    @error('followUpText')
+                        <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+                    @enderror
+                    <div class="mt-3 flex items-center justify-between gap-3">
+                        <p class="text-xs text-yak-blue">Yak will push changes to this PR.</p>
+                        <flux:button wire:click="sendFollowUp" variant="primary" size="sm">
+                            Send to Yak
+                        </flux:button>
+                    </div>
+                </div>
+            @endif
+        </div>
+    @endif
+
     {{-- Video walkthrough (Reviewer Cut + Director's Cut) --}}
     @if($task->mode !== \App\Enums\TaskMode::Review)
         <livewire:tasks.video-walkthrough-card :task="$task" :key="'video-walkthrough-' . $task->id" />

--- a/resources/views/livewire/tasks/task-list.blade.php
+++ b/resources/views/livewire/tasks/task-list.blade.php
@@ -1,4 +1,4 @@
-<div wire:poll.15s>
+<div wire:poll.15s x-data="{ newTaskOpen: false }">
     {{-- Getting started card (shown when the install is bare and the user hasn't dismissed it) --}}
     @if($this->showSetupCard)
         <div class="mb-5 rounded-[20px] border border-yak-orange/30 bg-gradient-to-br from-yak-orange/5 to-yak-cream p-5" data-testid="setup-card">
@@ -117,6 +117,16 @@
         @if($status !== '' || $source !== '' || $repo !== '')
             <flux:button size="sm" variant="ghost" icon="x-mark" wire:click="clearFilters" data-testid="clear-filters">Clear</flux:button>
         @endif
+
+        <div class="ml-auto">
+            <flux:button
+                size="sm"
+                variant="primary"
+                icon="plus"
+                @click="newTaskOpen = true"
+                data-testid="new-task-trigger"
+            >New task</flux:button>
+        </div>
     </div>
 
     <div class="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
@@ -201,4 +211,38 @@
             {{ $this->tasks->links() }}
         </div>
     @endif
+
+    {{-- New task slideover --}}
+    <div x-show="newTaskOpen" x-cloak class="fixed inset-0 z-50" style="display:none">
+        {{-- Backdrop --}}
+        <div
+            class="fixed inset-0 bg-black/30"
+            @click="newTaskOpen = false"
+            x-transition.opacity
+        ></div>
+        {{-- Panel --}}
+        <div
+            class="fixed inset-y-0 right-0 flex w-full max-w-md flex-col overflow-y-auto bg-white p-6 shadow-2xl dark:bg-zinc-900"
+            x-transition:enter="transition ease-out duration-200"
+            x-transition:enter-start="translate-x-full"
+            x-transition:enter-end="translate-x-0"
+            x-transition:leave="transition ease-in duration-150"
+            x-transition:leave-start="translate-x-0"
+            x-transition:leave-end="translate-x-full"
+            @keydown.escape.window="newTaskOpen = false"
+        >
+            <div class="mb-4 flex items-center justify-between">
+                <h2 class="text-lg font-medium text-yak-slate dark:text-zinc-100">New task</h2>
+                <button
+                    type="button"
+                    @click="newTaskOpen = false"
+                    aria-label="Close"
+                    class="text-zinc-400 hover:text-zinc-600 transition-colors"
+                >
+                    <flux:icon.x-mark class="size-5" />
+                </button>
+            </div>
+            <livewire:tasks.create-task />
+        </div>
+    </div>
 </div>

--- a/resources/views/livewire/tasks/task-list.blade.php
+++ b/resources/views/livewire/tasks/task-list.blade.php
@@ -184,9 +184,10 @@
                             @endif
                         </td>
                         <td class="max-w-xs truncate px-3 py-2 text-zinc-700 sm:px-5 dark:text-zinc-300">
+                            @php($children = $task->branch_name ? ($this->descendantsByBranch[$task->branch_name] ?? collect()) : collect())
                             {{ \Illuminate\Support\Str::limit($task->description, 60) }}
-                            @if($task->followUps->isNotEmpty())
-                                <span class="ml-2 rounded-full bg-[rgba(212,145,94,0.12)] px-2 py-0.5 text-[10px] font-semibold text-[#d4915e]">{{ $task->followUps->count() }} follow-ups</span>
+                            @if($children->isNotEmpty())
+                                <span class="ml-2 rounded-full bg-[rgba(212,145,94,0.12)] px-2 py-0.5 text-[10px] font-semibold text-[#d4915e]">{{ $children->count() }} follow-ups</span>
                             @endif
                         </td>
                         <td class="px-3 py-2 text-zinc-500 sm:px-5 dark:text-zinc-400">{{ \App\Livewire\Tasks\TaskList::formatDuration($task->duration_ms) }}</td>
@@ -198,7 +199,7 @@
                             @endif
                         </td>
                     </tr>
-                    @foreach($task->followUps as $child)
+                    @foreach($children as $child)
                         <tr wire:key="child-{{ $child->id }}" class="relative h-12 bg-zinc-50/60 transition-colors hover:bg-zinc-100/60 dark:bg-zinc-800/30 dark:hover:bg-zinc-800/60" style="transform: translateZ(0)">
                             <td class="border-l-[3px] border-[#e3cba9] py-2 pl-8 pr-3 sm:pr-5">
                                 <a href="{{ route('tasks.show', $child) }}" wire:navigate class="absolute inset-0" aria-label="Open task {{ $child->external_id ?? $child->id }}"></a>

--- a/resources/views/livewire/tasks/task-list.blade.php
+++ b/resources/views/livewire/tasks/task-list.blade.php
@@ -183,7 +183,12 @@
                                 <span class="text-zinc-700 dark:text-zinc-300">{{ $task->external_id ?? '—' }}</span>
                             @endif
                         </td>
-                        <td class="max-w-xs truncate px-3 py-2 text-zinc-700 sm:px-5 dark:text-zinc-300">{{ \Illuminate\Support\Str::limit($task->description, 60) }}</td>
+                        <td class="max-w-xs truncate px-3 py-2 text-zinc-700 sm:px-5 dark:text-zinc-300">
+                            {{ \Illuminate\Support\Str::limit($task->description, 60) }}
+                            @if($task->followUps->isNotEmpty())
+                                <span class="ml-2 rounded-full bg-[rgba(212,145,94,0.12)] px-2 py-0.5 text-[10px] font-semibold text-[#d4915e]">{{ $task->followUps->count() }} follow-ups</span>
+                            @endif
+                        </td>
                         <td class="px-3 py-2 text-zinc-500 sm:px-5 dark:text-zinc-400">{{ \App\Livewire\Tasks\TaskList::formatDuration($task->duration_ms) }}</td>
                         <td class="px-3 py-2 sm:px-5">
                             @if($task->pr_url)
@@ -193,6 +198,24 @@
                             @endif
                         </td>
                     </tr>
+                    @foreach($task->followUps as $child)
+                        <tr wire:key="child-{{ $child->id }}" class="relative h-12 bg-zinc-50/60 transition-colors hover:bg-zinc-100/60 dark:bg-zinc-800/30 dark:hover:bg-zinc-800/60" style="transform: translateZ(0)">
+                            <td class="border-l-[3px] border-[#e3cba9] py-2 pl-8 pr-3 sm:pr-5">
+                                <a href="{{ route('tasks.show', $child) }}" wire:navigate class="absolute inset-0" aria-label="Open task {{ $child->external_id ?? $child->id }}"></a>
+                                <span class="inline-block rounded-lg px-3 py-1 text-xs font-medium {{ \App\Livewire\Tasks\TaskList::statusBadgeClasses($child->status) }}">
+                                    {{ str_replace('_', ' ', $child->status->value) }}
+                                </span>
+                            </td>
+                            <td class="px-3 py-2 text-zinc-400 sm:px-5 dark:text-zinc-600">—</td>
+                            <td class="px-3 py-2 text-zinc-400 sm:px-5 dark:text-zinc-600">—</td>
+                            <td class="px-3 py-2 sm:px-5">
+                                <span class="text-zinc-500 dark:text-zinc-400">{{ $child->external_id ?? '—' }}</span>
+                            </td>
+                            <td class="max-w-xs truncate px-3 py-2 text-zinc-500 sm:px-5 dark:text-zinc-400">{{ \Illuminate\Support\Str::limit($child->description, 60) }}</td>
+                            <td class="px-3 py-2 text-zinc-400 sm:px-5 dark:text-zinc-600">{{ \App\Livewire\Tasks\TaskList::formatDuration($child->duration_ms) }}</td>
+                            <td class="px-3 py-2 text-zinc-400 sm:px-5 dark:text-zinc-600">—</td>
+                        </tr>
+                    @endforeach
                 @empty
                     <tr>
                         <td colspan="7" class="px-3 py-16 text-center text-zinc-500 sm:px-5 dark:text-zinc-400">

--- a/resources/views/livewire/tasks/task-list.blade.php
+++ b/resources/views/livewire/tasks/task-list.blade.php
@@ -1,5 +1,6 @@
-<div wire:poll.15s x-data="{ newTaskOpen: false }">
-    {{-- Getting started card (shown when the install is bare and the user hasn't dismissed it) --}}
+<div wire:poll.15s>
+    <div x-data="{ newTaskOpen: false }">
+        {{-- Getting started card (shown when the install is bare and the user hasn't dismissed it) --}}
     @if($this->showSetupCard)
         <div class="mb-5 rounded-[20px] border border-yak-orange/30 bg-gradient-to-br from-yak-orange/5 to-yak-cream p-5" data-testid="setup-card">
             <div class="flex items-start gap-4">
@@ -244,5 +245,6 @@
             </div>
             <livewire:tasks.create-task />
         </div>
+    </div>
     </div>
 </div>

--- a/resources/views/prompts/tasks/follow-up.blade.php
+++ b/resources/views/prompts/tasks/follow-up.blade.php
@@ -1,0 +1,4 @@
+The pull request for this task is already open. The user has reviewed it and is giving you feedback to refine it. Apply the following changes and push to the same branch. Do not ask for clarification; use your best judgment.
+
+**Feedback:**
+{{ $instructions }}

--- a/tests/Feature/Channels/GitHub/FollowUpCommentWebhookTest.php
+++ b/tests/Feature/Channels/GitHub/FollowUpCommentWebhookTest.php
@@ -1,0 +1,336 @@
+<?php
+
+use App\Jobs\FlushFollowUpBatchJob;
+use App\Models\FollowUpPendingComment;
+use App\Models\GitHubInstallationToken;
+use App\Models\YakTask;
+use App\Providers\ChannelServiceProvider;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config()->set('yak.channels.github', [
+        'app_id' => '123',
+        'private_key' => 'key',
+        'webhook_secret' => 'secret',
+        'app_bot_login' => 'yak-bot[bot]',
+        'installation_id' => 99,
+    ]);
+    config()->set('yak.followup.github_prefixes', '/yak,@yak-bot[bot],yak:');
+    config()->set('yak.followup.github_batch_window_seconds', 60);
+
+    GitHubInstallationToken::create([
+        'installation_id' => 99,
+        'token' => 'test-token',
+        'expires_at' => now()->addHour(),
+    ]);
+
+    (new ChannelServiceProvider(app()))->boot();
+});
+
+function signGhFollowUpPayload(string $payload): string
+{
+    return 'sha256=' . hash_hmac('sha256', $payload, 'secret');
+}
+
+// ─── issue_comment ────────────────────────────────────────────────────────────
+
+it('buffers a /yak issue_comment on a Yak task PR and dispatches FlushFollowUpBatchJob', function () {
+    Bus::fake();
+    Http::fake(['api.github.com/*' => Http::response([], 201)]);
+
+    $task = YakTask::factory()->success()->create([
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'repo' => 'acme/web',
+        'branch_name' => 'yak/x',
+    ]);
+
+    $payload = [
+        'action' => 'created',
+        'issue' => [
+            'number' => 9,
+            'pull_request' => [
+                'html_url' => 'https://github.com/acme/web/pull/9',
+            ],
+        ],
+        'comment' => [
+            'id' => 42,
+            'user' => ['login' => 'mathias'],
+            'body' => '/yak please add tests',
+        ],
+        'repository' => ['full_name' => 'acme/web'],
+        'installation' => ['id' => 99],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'issue_comment',
+        'X-Hub-Signature-256' => signGhFollowUpPayload($body),
+    ])->assertOk()->assertJsonPath('ok', true);
+
+    expect(FollowUpPendingComment::where('pr_url', 'https://github.com/acme/web/pull/9')->count())->toBe(1);
+
+    $comment = FollowUpPendingComment::first();
+    expect($comment->yak_task_id)->toBe($task->id)
+        ->and($comment->body)->toBe('please add tests')
+        ->and($comment->file)->toBeNull()
+        ->and($comment->github_comment_id)->toBe(42);
+
+    Bus::assertDispatched(FlushFollowUpBatchJob::class, fn ($job) => $job->prUrl === 'https://github.com/acme/web/pull/9');
+});
+
+it('skips a comment with no /yak prefix', function () {
+    Bus::fake();
+    Http::fake(['api.github.com/*' => Http::response([], 201)]);
+
+    YakTask::factory()->success()->create([
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'repo' => 'acme/web',
+        'branch_name' => 'yak/x',
+    ]);
+
+    $payload = [
+        'action' => 'created',
+        'issue' => [
+            'number' => 9,
+            'pull_request' => ['html_url' => 'https://github.com/acme/web/pull/9'],
+        ],
+        'comment' => [
+            'id' => 43,
+            'user' => ['login' => 'mathias'],
+            'body' => 'looks good to me',
+        ],
+        'repository' => ['full_name' => 'acme/web'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'issue_comment',
+        'X-Hub-Signature-256' => signGhFollowUpPayload($body),
+    ])->assertOk();
+
+    expect(FollowUpPendingComment::count())->toBe(0);
+    Bus::assertNotDispatched(FlushFollowUpBatchJob::class);
+});
+
+it('skips a bot-authored issue_comment', function () {
+    Bus::fake();
+    Http::fake(['api.github.com/*' => Http::response([], 201)]);
+
+    YakTask::factory()->success()->create([
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'repo' => 'acme/web',
+        'branch_name' => 'yak/x',
+    ]);
+
+    $payload = [
+        'action' => 'created',
+        'issue' => [
+            'number' => 9,
+            'pull_request' => ['html_url' => 'https://github.com/acme/web/pull/9'],
+        ],
+        'comment' => [
+            'id' => 44,
+            'user' => ['login' => 'yak-bot[bot]'],
+            'body' => '/yak do something',
+        ],
+        'repository' => ['full_name' => 'acme/web'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'issue_comment',
+        'X-Hub-Signature-256' => signGhFollowUpPayload($body),
+    ])->assertOk();
+
+    expect(FollowUpPendingComment::count())->toBe(0);
+    Bus::assertNotDispatched(FlushFollowUpBatchJob::class);
+});
+
+it('skips an issue_comment on a PR with no matching YakTask', function () {
+    Bus::fake();
+    Http::fake(['api.github.com/*' => Http::response([], 201)]);
+
+    $payload = [
+        'action' => 'created',
+        'issue' => [
+            'number' => 99,
+            'pull_request' => ['html_url' => 'https://github.com/acme/web/pull/99'],
+        ],
+        'comment' => [
+            'id' => 45,
+            'user' => ['login' => 'mathias'],
+            'body' => '/yak please do this',
+        ],
+        'repository' => ['full_name' => 'acme/web'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'issue_comment',
+        'X-Hub-Signature-256' => signGhFollowUpPayload($body),
+    ])->assertOk();
+
+    expect(FollowUpPendingComment::count())->toBe(0);
+    Bus::assertNotDispatched(FlushFollowUpBatchJob::class);
+});
+
+it('skips an issue_comment on a plain issue (no pull_request key)', function () {
+    Bus::fake();
+    Http::fake(['api.github.com/*' => Http::response([], 201)]);
+
+    $payload = [
+        'action' => 'created',
+        'issue' => [
+            'number' => 5,
+            // No pull_request key — this is a plain issue comment
+        ],
+        'comment' => [
+            'id' => 46,
+            'user' => ['login' => 'mathias'],
+            'body' => '/yak do something',
+        ],
+        'repository' => ['full_name' => 'acme/web'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'issue_comment',
+        'X-Hub-Signature-256' => signGhFollowUpPayload($body),
+    ])->assertOk();
+
+    expect(FollowUpPendingComment::count())->toBe(0);
+    Bus::assertNotDispatched(FlushFollowUpBatchJob::class);
+});
+
+// ─── pull_request_review_comment ─────────────────────────────────────────────
+
+it('buffers a /yak pull_request_review_comment capturing file, line, and diff_hunk', function () {
+    Bus::fake();
+    Http::fake(['api.github.com/*' => Http::response([], 201)]);
+
+    $task = YakTask::factory()->success()->create([
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'repo' => 'acme/web',
+        'branch_name' => 'yak/x',
+    ]);
+
+    $payload = [
+        'action' => 'created',
+        'pull_request' => [
+            'html_url' => 'https://github.com/acme/web/pull/9',
+            'number' => 9,
+        ],
+        'comment' => [
+            'id' => 77,
+            'user' => ['login' => 'mathias'],
+            'body' => '/yak rename this variable',
+            'path' => 'app/Foo.php',
+            'line' => 42,
+            'diff_hunk' => '@@ -1,3 +1,4 @@',
+        ],
+        'repository' => ['full_name' => 'acme/web'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request_review_comment',
+        'X-Hub-Signature-256' => signGhFollowUpPayload($body),
+    ])->assertOk()->assertJsonPath('ok', true);
+
+    expect(FollowUpPendingComment::count())->toBe(1);
+
+    $comment = FollowUpPendingComment::first();
+    expect($comment->yak_task_id)->toBe($task->id)
+        ->and($comment->body)->toBe('rename this variable')
+        ->and($comment->file)->toBe('app/Foo.php')
+        ->and($comment->line)->toBe(42)
+        ->and($comment->diff_hunk)->toBe('@@ -1,3 +1,4 @@')
+        ->and($comment->github_comment_id)->toBe(77);
+
+    Bus::assertDispatched(FlushFollowUpBatchJob::class, fn ($job) => $job->prUrl === 'https://github.com/acme/web/pull/9');
+});
+
+// ─── merged PR ───────────────────────────────────────────────────────────────
+
+it('declines a /yak comment on a merged PR and does not buffer', function () {
+    Bus::fake();
+    Http::fake(['api.github.com/*' => Http::response([], 201)]);
+
+    YakTask::factory()->merged()->create([
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'repo' => 'acme/web',
+        'branch_name' => 'yak/x',
+        'pr_number' => 9,
+    ]);
+
+    $payload = [
+        'action' => 'created',
+        'issue' => [
+            'number' => 9,
+            'pull_request' => ['html_url' => 'https://github.com/acme/web/pull/9'],
+        ],
+        'comment' => [
+            'id' => 50,
+            'user' => ['login' => 'mathias'],
+            'body' => '/yak please add more tests',
+        ],
+        'repository' => ['full_name' => 'acme/web'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'issue_comment',
+        'X-Hub-Signature-256' => signGhFollowUpPayload($body),
+    ])->assertOk();
+
+    expect(FollowUpPendingComment::count())->toBe(0);
+    Bus::assertNotDispatched(FlushFollowUpBatchJob::class);
+
+    // A decline comment should have been posted to the PR's issues comments endpoint.
+    Http::assertSent(fn ($r) => str_contains($r->url(), '/repos/acme/web/issues/9/comments'));
+});
+
+// ─── dedup: second comment on same PR does not re-dispatch the job ────────────
+
+it('does not dispatch a second FlushFollowUpBatchJob when there is already a pending comment', function () {
+    Bus::fake();
+    Http::fake(['api.github.com/*' => Http::response([], 201)]);
+
+    $task = YakTask::factory()->success()->create([
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'repo' => 'acme/web',
+        'branch_name' => 'yak/x',
+    ]);
+
+    // Seed an existing pending comment to simulate a previously batched item.
+    FollowUpPendingComment::create([
+        'yak_task_id' => $task->id,
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'body' => 'earlier comment',
+        'github_comment_id' => 40,
+    ]);
+
+    $payload = [
+        'action' => 'created',
+        'issue' => [
+            'number' => 9,
+            'pull_request' => ['html_url' => 'https://github.com/acme/web/pull/9'],
+        ],
+        'comment' => [
+            'id' => 41,
+            'user' => ['login' => 'mathias'],
+            'body' => '/yak one more thing',
+        ],
+        'repository' => ['full_name' => 'acme/web'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'issue_comment',
+        'X-Hub-Signature-256' => signGhFollowUpPayload($body),
+    ])->assertOk();
+
+    expect(FollowUpPendingComment::count())->toBe(2);
+    Bus::assertNotDispatched(FlushFollowUpBatchJob::class);
+});

--- a/tests/Feature/Channels/GitHub/FollowUpCommentWebhookTest.php
+++ b/tests/Feature/Channels/GitHub/FollowUpCommentWebhookTest.php
@@ -334,3 +334,79 @@ it('does not dispatch a second FlushFollowUpBatchJob when there is already a pen
     expect(FollowUpPendingComment::count())->toBe(2);
     Bus::assertNotDispatched(FlushFollowUpBatchJob::class);
 });
+
+it('uses original_line when line is null in a pull_request_review_comment', function () {
+    Bus::fake();
+    Http::fake(['api.github.com/*' => Http::response([], 201)]);
+
+    $task = YakTask::factory()->success()->create([
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'repo' => 'acme/web',
+        'branch_name' => 'yak/x',
+    ]);
+
+    $payload = [
+        'action' => 'created',
+        'pull_request' => [
+            'html_url' => 'https://github.com/acme/web/pull/9',
+            'number' => 9,
+        ],
+        'comment' => [
+            'id' => 88,
+            'user' => ['login' => 'mathias'],
+            'body' => '/yak consider refactoring',
+            'path' => 'src/core.php',
+            'line' => null,
+            'original_line' => 7,
+            'diff_hunk' => '@@ -5,3 +5,4 @@',
+        ],
+        'repository' => ['full_name' => 'acme/web'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request_review_comment',
+        'X-Hub-Signature-256' => signGhFollowUpPayload($body),
+    ])->assertOk()->assertJsonPath('ok', true);
+
+    expect(FollowUpPendingComment::count())->toBe(1);
+
+    $comment = FollowUpPendingComment::first();
+    expect($comment->yak_task_id)->toBe($task->id)
+        ->and($comment->body)->toBe('consider refactoring')
+        ->and($comment->file)->toBe('src/core.php')
+        ->and($comment->line)->toBe(7)
+        ->and($comment->diff_hunk)->toBe('@@ -5,3 +5,4 @@')
+        ->and($comment->github_comment_id)->toBe(88);
+
+    Bus::assertDispatched(FlushFollowUpBatchJob::class, fn ($job) => $job->prUrl === 'https://github.com/acme/web/pull/9');
+});
+
+it('makes no external call when the comment is not for a Yak task', function () {
+    Bus::fake();
+    Http::fake(['api.github.com/*' => Http::response([], 201)]);
+
+    $payload = [
+        'action' => 'created',
+        'issue' => [
+            'number' => 99,
+            'pull_request' => ['html_url' => 'https://github.com/acme/web/pull/99'],
+        ],
+        'comment' => [
+            'id' => 51,
+            'user' => ['login' => 'mathias'],
+            'body' => '/yak please implement feature',
+        ],
+        'repository' => ['full_name' => 'acme/web'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'issue_comment',
+        'X-Hub-Signature-256' => signGhFollowUpPayload($body),
+    ])->assertOk();
+
+    expect(FollowUpPendingComment::count())->toBe(0);
+    Bus::assertNotDispatched(FlushFollowUpBatchJob::class);
+    Http::assertNothingSent();
+});

--- a/tests/Feature/Channels/Linear/ActionActivityTest.php
+++ b/tests/Feature/Channels/Linear/ActionActivityTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Channels\Linear\NotificationDriver as LinearNotificationDriver;
+use App\Models\LinearOauthConnection;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    config()->set('yak.channels.linear', ['webhook_secret' => 'secret']);
+});
+
+it('postAction emits an agentActivityCreate mutation with action content type', function (): void {
+    Http::fake(['*' => Http::response(['data' => ['agentActivityCreate' => ['success' => true]]])]);
+    LinearOauthConnection::factory()->create();
+
+    app(LinearNotificationDriver::class)
+        ->postAction('session-action-123', 'Opened pull request', 'https://github.com/org/repo/pull/42');
+
+    Http::assertSent(function ($request): bool {
+        $vars = $request->data()['variables'] ?? [];
+        $content = $vars['input']['content'] ?? [];
+
+        return str_contains($request->url(), 'api.linear.app/graphql')
+            && ($vars['input']['agentSessionId'] ?? null) === 'session-action-123'
+            && ($content['type'] ?? null) === 'action'
+            && ($content['action'] ?? null) === 'Opened pull request'
+            && ($content['result'] ?? null) === 'https://github.com/org/repo/pull/42';
+    });
+});
+
+it('postAction emits an action mutation without a result when result is null', function (): void {
+    Http::fake(['*' => Http::response(['data' => ['agentActivityCreate' => ['success' => true]]])]);
+    LinearOauthConnection::factory()->create();
+
+    app(LinearNotificationDriver::class)
+        ->postAction('session-no-result', 'Started analysis');
+
+    Http::assertSent(function ($request): bool {
+        $vars = $request->data()['variables'] ?? [];
+        $content = $vars['input']['content'] ?? [];
+
+        return str_contains($request->url(), 'api.linear.app/graphql')
+            && ($vars['input']['agentSessionId'] ?? null) === 'session-no-result'
+            && ($content['type'] ?? null) === 'action'
+            && ($content['action'] ?? null) === 'Started analysis'
+            && array_key_exists('result', $content)
+            && $content['result'] === null;
+    });
+});
+
+it('postAction is a no-op when there is no active OAuth connection', function (): void {
+    Http::fake(['*' => Http::response(['data' => ['success' => true]])]);
+
+    app(LinearNotificationDriver::class)
+        ->postAction('session-no-token', 'Some action');
+
+    Http::assertNothingSent();
+});
+
+it('postAction is a no-op when the session id is empty', function (): void {
+    Http::fake(['*' => Http::response(['data' => ['success' => true]])]);
+    LinearOauthConnection::factory()->create();
+
+    app(LinearNotificationDriver::class)
+        ->postAction('', 'Some action');
+
+    Http::assertNothingSent();
+});

--- a/tests/Feature/Channels/Linear/InboxNotificationTest.php
+++ b/tests/Feature/Channels/Linear/InboxNotificationTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use App\Enums\TaskStatus;
+use App\Models\YakTask;
+use Illuminate\Support\Facades\Http;
+
+// Helpers shared with WebhookTest are loaded via the test file itself;
+// enableLinearChannel(), linearConnection(), signLinearPayload(), and
+// postLinearWebhook() are all available because Pest autoloads sibling
+// test files in the same directory.
+
+function inboxNotificationPayload(array $overrides = []): string
+{
+    return (string) json_encode([
+        'action' => $overrides['action'] ?? 'create',
+        'organizationId' => $overrides['organizationId'] ?? TEST_WORKSPACE_ID,
+        'notification' => array_merge([
+            'type' => $overrides['type'] ?? 'issueUnassignedFromYou',
+            'issue' => [
+                'id' => $overrides['issueId'] ?? 'issue-abc',
+                'identifier' => $overrides['identifier'] ?? 'ENG-10',
+            ],
+        ], $overrides['notification'] ?? []),
+    ]);
+}
+
+// --- Unassignment cancels in-flight work ---
+
+it('cancels a running linear task when unassigned from the issue', function () {
+    $secret = enableLinearChannel();
+    linearConnection();
+    Http::fake(['*' => Http::response(['data' => ['agentActivityCreate' => ['success' => true]]])]);
+
+    $task = YakTask::factory()->running()->create([
+        'source' => 'linear',
+        'linear_agent_session_id' => 'session-unassign-001',
+        'context' => json_encode([
+            'linear_issue_id' => 'issue-abc',
+            'linear_issue_identifier' => 'ENG-10',
+        ]),
+    ]);
+
+    $body = inboxNotificationPayload(['issueId' => 'issue-abc', 'type' => 'issueUnassignedFromYou']);
+
+    postLinearWebhook($body, $secret, 'InboxNotificationEvent')->assertSuccessful();
+
+    expect($task->fresh()->status)->toBe(TaskStatus::Cancelled);
+});
+
+it('does not cancel a terminal (success) task on unassignment', function () {
+    $secret = enableLinearChannel();
+    linearConnection();
+    Http::fake(['*' => Http::response(['data' => ['agentActivityCreate' => ['success' => true]]])]);
+
+    $task = YakTask::factory()->success()->create([
+        'source' => 'linear',
+        'context' => json_encode(['linear_issue_id' => 'issue-done']),
+    ]);
+
+    $body = inboxNotificationPayload(['issueId' => 'issue-done', 'type' => 'issueUnassignedFromYou']);
+
+    postLinearWebhook($body, $secret, 'InboxNotificationEvent')->assertSuccessful();
+
+    expect($task->fresh()->status)->toBe(TaskStatus::Success);
+});
+
+it('returns 200 ok on unassignment when no matching task exists', function () {
+    $secret = enableLinearChannel();
+    linearConnection();
+    Http::fake();
+
+    $body = inboxNotificationPayload(['issueId' => 'issue-no-task', 'type' => 'issueUnassignedFromYou']);
+
+    postLinearWebhook($body, $secret, 'InboxNotificationEvent')->assertSuccessful();
+
+    expect(YakTask::count())->toBe(0);
+    Http::assertNothingSent();
+});
+
+// --- Reactions are acknowledged without error ---
+
+it('returns 200 ok for a reaction inbox notification without touching tasks', function () {
+    $secret = enableLinearChannel();
+    linearConnection();
+    Http::fake();
+
+    $task = YakTask::factory()->running()->create([
+        'source' => 'linear',
+        'context' => json_encode(['linear_issue_id' => 'issue-reacted']),
+    ]);
+
+    $body = inboxNotificationPayload(['issueId' => 'issue-reacted', 'type' => 'issueEmojiReaction']);
+
+    postLinearWebhook($body, $secret, 'InboxNotificationEvent')->assertSuccessful();
+
+    expect($task->fresh()->status)->toBe(TaskStatus::Running);
+});
+
+// --- Unrelated inbox types are ignored ---
+
+it('ignores unrelated inbox notification types without changing tasks', function () {
+    $secret = enableLinearChannel();
+    linearConnection();
+    Http::fake();
+
+    $task = YakTask::factory()->running()->create([
+        'source' => 'linear',
+        'context' => json_encode(['linear_issue_id' => 'issue-other']),
+    ]);
+
+    $body = inboxNotificationPayload(['issueId' => 'issue-other', 'type' => 'issueAssignedToYou']);
+
+    postLinearWebhook($body, $secret, 'InboxNotificationEvent')->assertSuccessful();
+
+    expect($task->fresh()->status)->toBe(TaskStatus::Running);
+    Http::assertNothingSent();
+});
+
+// --- Connection guard ---
+
+it('returns 200 ok for an inbox notification from an unknown workspace', function () {
+    $secret = enableLinearChannel();
+    linearConnection();
+    Http::fake();
+
+    $body = inboxNotificationPayload([
+        'organizationId' => 'unknown-workspace',
+        'type' => 'issueUnassignedFromYou',
+        'issueId' => 'issue-abc',
+    ]);
+
+    postLinearWebhook($body, $secret, 'InboxNotificationEvent')->assertSuccessful();
+
+    Http::assertNothingSent();
+});
+
+// --- Robustness: payload with missing fields ---
+
+it('handles inbox notifications with a missing notification.issue gracefully', function () {
+    $secret = enableLinearChannel();
+    linearConnection();
+    Http::fake();
+
+    $body = (string) json_encode([
+        'action' => 'create',
+        'organizationId' => TEST_WORKSPACE_ID,
+        'notification' => [
+            'type' => 'issueUnassignedFromYou',
+            // 'issue' intentionally missing
+        ],
+    ]);
+
+    postLinearWebhook($body, $secret, 'InboxNotificationEvent')->assertSuccessful();
+});

--- a/tests/Feature/Channels/Linear/InboxNotificationTest.php
+++ b/tests/Feature/Channels/Linear/InboxNotificationTest.php
@@ -134,6 +134,35 @@ it('returns 200 ok for an inbox notification from an unknown workspace', functio
     Http::assertNothingSent();
 });
 
+// --- Security: LIKE wildcard injection ---
+
+test('an unassignment with a wildcard issue id cancels nothing (LIKE injection blocked)', function () {
+    $secret = enableLinearChannel();
+    linearConnection();
+    Http::fake();
+
+    // A legitimate in-flight task with a real issue id in context.
+    $task = YakTask::factory()->running()->create([
+        'source' => 'linear',
+        'linear_agent_session_id' => 'sess-wildcard-test',
+        'context' => json_encode([
+            'linear_issue_id' => 'issue-legit-123',
+            'linear_issue_identifier' => 'ENG-99',
+        ]),
+    ]);
+
+    // Attacker sends issueId='%' — a LIKE wildcard that would match everything.
+    $body = inboxNotificationPayload(['issueId' => '%', 'type' => 'issueUnassignedFromYou']);
+
+    postLinearWebhook($body, $secret, 'InboxNotificationEvent')->assertSuccessful();
+
+    // The wildcard must NOT cancel the legitimate task.
+    expect($task->fresh()->status)->toBe(TaskStatus::Running);
+
+    // No Linear API calls should have been made.
+    Http::assertNothingSent();
+});
+
 // --- Robustness: payload with missing fields ---
 
 it('handles inbox notifications with a missing notification.issue gracefully', function () {

--- a/tests/Feature/Channels/Linear/PromptedFollowUpTest.php
+++ b/tests/Feature/Channels/Linear/PromptedFollowUpTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use App\Jobs\ClarificationReplyJob;
+use App\Jobs\RunFollowUpJob;
+use App\Models\LinearOauthConnection;
+use App\Models\YakTask;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Testing\TestResponse;
+
+// Reuse helpers defined in WebhookTest.php (same test suite, loaded by Pest autoloader)
+
+function postLinearPrompted(array $payload, string $secret): TestResponse
+{
+    $body = (string) json_encode($payload);
+
+    return test()->call('POST', '/webhooks/linear', content: $body, server: [
+        'HTTP_Linear-Event' => 'AgentSessionEvent',
+        'HTTP_Linear-Signature' => signLinearPayload($body, $secret),
+        'CONTENT_TYPE' => 'application/json',
+    ]);
+}
+
+beforeEach(function (): void {
+    $this->secret = enableLinearChannel();
+
+    // Create the OAuth connection so resolveConnection() succeeds.
+    LinearOauthConnection::factory()->create([
+        'workspace_id' => TEST_WORKSPACE_ID,
+        'installer_user_id' => TEST_YAK_ACTOR_ID,
+    ]);
+
+    Http::fake(['*' => Http::response(['data' => ['agentActivityCreate' => ['success' => true]]])]);
+});
+
+// --- Follow-up on an open-PR task ---
+
+it('creates a follow-up task and dispatches RunFollowUpJob when prompted on an open-PR task', function (): void {
+    Bus::fake();
+
+    $task = YakTask::factory()->create([
+        'source' => 'linear',
+        'linear_agent_session_id' => 'sess-1',
+        'pr_url' => 'https://github.com/org/repo/pull/10',
+        'pr_merged_at' => null,
+        'pr_closed_at' => null,
+    ]);
+
+    postLinearPrompted([
+        'type' => 'AgentSessionEvent',
+        'action' => 'prompted',
+        'organizationId' => TEST_WORKSPACE_ID,
+        'agentSession' => ['id' => 'sess-1'],
+        'agentActivity' => ['content' => ['body' => 'also handle empty state']],
+    ], $this->secret)->assertSuccessful();
+
+    expect(YakTask::where('parent_task_id', $task->id)->exists())->toBeTrue();
+    Bus::assertDispatched(RunFollowUpJob::class);
+});
+
+// --- Stop signal cancels the task ---
+
+it('cancels the task when prompted with a stop signal', function (): void {
+    Bus::fake();
+
+    $task = YakTask::factory()->create([
+        'source' => 'linear',
+        'linear_agent_session_id' => 'sess-1',
+        'pr_url' => 'https://github.com/org/repo/pull/10',
+        'pr_merged_at' => null,
+        'pr_closed_at' => null,
+    ]);
+
+    postLinearPrompted([
+        'type' => 'AgentSessionEvent',
+        'action' => 'prompted',
+        'organizationId' => TEST_WORKSPACE_ID,
+        'agentSession' => ['id' => 'sess-1'],
+        'agentActivity' => ['signal' => 'stop'],
+    ], $this->secret)->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status->value)->toBe('cancelled');
+    expect($task->completed_at)->not->toBeNull();
+
+    Bus::assertNotDispatched(RunFollowUpJob::class);
+    expect(YakTask::where('parent_task_id', $task->id)->exists())->toBeFalse();
+});
+
+// --- Clarification reply ---
+
+it('dispatches ClarificationReplyJob when prompted on an AwaitingClarification task', function (): void {
+    Bus::fake();
+
+    YakTask::factory()->awaitingClarification()->create([
+        'source' => 'linear',
+        'linear_agent_session_id' => 'sess-2',
+    ]);
+
+    postLinearPrompted([
+        'type' => 'AgentSessionEvent',
+        'action' => 'prompted',
+        'organizationId' => TEST_WORKSPACE_ID,
+        'agentSession' => ['id' => 'sess-2'],
+        'agentActivity' => ['content' => ['body' => 'Here is my clarification']],
+    ], $this->secret)->assertSuccessful();
+
+    Bus::assertDispatched(ClarificationReplyJob::class);
+    Bus::assertNotDispatched(RunFollowUpJob::class);
+});
+
+// --- Merged/closed PR decline ---
+
+it('does not create a follow-up and dispatches nothing when the PR is already merged', function (): void {
+    Bus::fake();
+
+    YakTask::factory()->merged()->create([
+        'source' => 'linear',
+        'linear_agent_session_id' => 'sess-3',
+    ]);
+
+    postLinearPrompted([
+        'type' => 'AgentSessionEvent',
+        'action' => 'prompted',
+        'organizationId' => TEST_WORKSPACE_ID,
+        'agentSession' => ['id' => 'sess-3'],
+        'agentActivity' => ['content' => ['body' => 'can you also fix the footer']],
+    ], $this->secret)->assertSuccessful();
+
+    Bus::assertNotDispatched(RunFollowUpJob::class);
+    Bus::assertNotDispatched(ClarificationReplyJob::class);
+    expect(YakTask::whereNotNull('parent_task_id')->exists())->toBeFalse();
+});
+
+// --- Unknown session ---
+
+it('returns 200 and dispatches nothing when the session id matches no task', function (): void {
+    Bus::fake();
+
+    postLinearPrompted([
+        'type' => 'AgentSessionEvent',
+        'action' => 'prompted',
+        'organizationId' => TEST_WORKSPACE_ID,
+        'agentSession' => ['id' => 'unknown-session-id'],
+        'agentActivity' => ['content' => ['body' => 'hello?']],
+    ], $this->secret)->assertSuccessful();
+
+    Bus::assertNotDispatched(RunFollowUpJob::class);
+    Bus::assertNotDispatched(ClarificationReplyJob::class);
+});

--- a/tests/Feature/Channels/Linear/StartedStateTest.php
+++ b/tests/Feature/Channels/Linear/StartedStateTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\Repository;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+
+it('moves the Linear issue to the started state when started_state_id is configured', function () {
+    $secret = enableLinearChannel();
+    config()->set('yak.channels.linear.started_state_id', 'started-state-uuid');
+    linearConnection();
+    Queue::fake();
+    Http::fake(['*' => Http::response(['data' => ['agentActivityCreate' => ['success' => true], 'issueUpdate' => ['success' => true]]])]);
+    Repository::factory()->default()->create();
+
+    postLinearWebhook(agentSessionCreatedPayload(['issueId' => 'issue-started-uuid']), $secret)
+        ->assertSuccessful();
+
+    Http::assertSent(function ($request): bool {
+        if (! str_contains($request->url(), 'api.linear.app/graphql')) {
+            return false;
+        }
+
+        if (! str_contains($request['query'], 'issueUpdate')) {
+            return false;
+        }
+
+        return ($request['variables']['stateId'] ?? null) === 'started-state-uuid'
+            && ($request['variables']['issueId'] ?? null) === 'issue-started-uuid';
+    });
+});
+
+it('does not send a started-state issueUpdate when started_state_id is not configured', function () {
+    $secret = enableLinearChannel();
+    // started_state_id is intentionally absent from enableLinearChannel()
+    linearConnection();
+    Queue::fake();
+    Http::fake(['*' => Http::response(['data' => ['agentActivityCreate' => ['success' => true]]])]);
+    Repository::factory()->default()->create();
+
+    postLinearWebhook(agentSessionCreatedPayload(), $secret)->assertSuccessful();
+
+    Http::assertNotSent(function ($request): bool {
+        if (! str_contains($request->url(), 'api.linear.app/graphql')) {
+            return false;
+        }
+
+        return str_contains($request['query'], 'issueUpdate');
+    });
+});

--- a/tests/Feature/Channels/Linear/WebhookHardeningTest.php
+++ b/tests/Feature/Channels/Linear/WebhookHardeningTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Jobs\RunYakJob;
+use App\Models\YakTask;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+
+// --- Replay protection: stale webhookTimestamp ---
+
+test('rejects a created event with a stale webhookTimestamp', function () {
+    $secret = enableLinearChannel();
+    linearConnection();
+    Bus::fake();
+    Http::fake(['*' => Http::response(['data' => ['agentActivityCreate' => ['success' => true]]])]);
+
+    $payload = (string) json_encode(array_merge(
+        json_decode(agentSessionCreatedPayload(), true),
+        ['webhookTimestamp' => now()->subMinutes(5)->getTimestampMs()],
+    ));
+
+    $response = test()->call('POST', '/webhooks/linear', content: $payload, server: [
+        'HTTP_Linear-Signature' => signLinearPayload($payload, $secret),
+        'HTTP_Linear-Event' => 'AgentSessionEvent',
+        'CONTENT_TYPE' => 'application/json',
+    ]);
+
+    $response->assertSuccessful();
+    expect(YakTask::count())->toBe(0);
+    Bus::assertNotDispatched(RunYakJob::class);
+});
+
+// --- Delivery idempotency: duplicate Linear-Delivery header ---
+
+test('processes a delivery id only once', function () {
+    $secret = enableLinearChannel();
+    linearConnection();
+    Bus::fake();
+    Http::fake(['*' => Http::response(['data' => ['agentActivityCreate' => ['success' => true]]])]);
+
+    $payload = agentSessionCreatedPayload();
+    $signature = signLinearPayload($payload, $secret);
+
+    $post = fn () => test()->call('POST', '/webhooks/linear', content: $payload, server: [
+        'HTTP_Linear-Signature' => $signature,
+        'HTTP_Linear-Event' => 'AgentSessionEvent',
+        'HTTP_Linear-Delivery' => 'delivery-uuid-1',
+        'CONTENT_TYPE' => 'application/json',
+    ]);
+
+    $post()->assertSuccessful();
+    expect(YakTask::count())->toBe(1);
+
+    $post()->assertSuccessful();
+    expect(YakTask::count())->toBe(1);
+    Bus::assertDispatchedTimes(RunYakJob::class, 1);
+});
+
+// --- Back-compat: no timestamp, no delivery header still works ---
+
+test('still processes events with no timestamp and no delivery header', function () {
+    $secret = enableLinearChannel();
+    linearConnection();
+    Bus::fake();
+    Http::fake(['*' => Http::response(['data' => ['agentActivityCreate' => ['success' => true]]])]);
+
+    $payload = agentSessionCreatedPayload();
+
+    $response = test()->call('POST', '/webhooks/linear', content: $payload, server: [
+        'HTTP_Linear-Signature' => signLinearPayload($payload, $secret),
+        'HTTP_Linear-Event' => 'AgentSessionEvent',
+        'CONTENT_TYPE' => 'application/json',
+    ]);
+
+    $response->assertSuccessful();
+    expect(YakTask::count())->toBe(1);
+});

--- a/tests/Feature/Channels/Linear/WebhookTest.php
+++ b/tests/Feature/Channels/Linear/WebhookTest.php
@@ -369,18 +369,14 @@ it('ignores unrelated webhook event headers', function () {
     Queue::assertNotPushed(RunYakJob::class);
 });
 
-// --- AgentSessionEvent.prompted responds with a polite error ---
+// --- AgentSessionEvent.prompted posts an immediate thought ack ---
 
-it('responds to prompted events with an error activity pointing to the dashboard', function () {
+it('responds to prompted events with an immediate thought acknowledgment', function () {
     $secret = enableLinearChannel();
     linearConnection();
-    LinearOauthConnection::query()->delete(); // recreate with known token
-    LinearOauthConnection::factory()->create([
-        'workspace_id' => TEST_WORKSPACE_ID,
-        'installer_user_id' => TEST_YAK_ACTOR_ID,
-    ]);
     Http::fake(['*' => Http::response(['data' => ['agentActivityCreate' => ['success' => true]]])]);
 
+    // No matching task — unknown session gets a thought ack only.
     postLinearWebhook(agentSessionPromptedPayload(['sessionId' => 'session-xyz']), $secret)
         ->assertSuccessful();
 
@@ -391,7 +387,7 @@ it('responds to prompted events with an error activity pointing to the dashboard
         $vars = $request->data()['variables'] ?? [];
 
         return ($vars['input']['agentSessionId'] ?? null) === 'session-xyz'
-            && ($vars['input']['content']['type'] ?? null) === 'error';
+            && ($vars['input']['content']['type'] ?? null) === 'thought';
     });
 });
 

--- a/tests/Feature/Channels/Slack/FollowUpThreadReplyTest.php
+++ b/tests/Feature/Channels/Slack/FollowUpThreadReplyTest.php
@@ -1,0 +1,185 @@
+<?php
+
+use App\Jobs\ClarificationReplyJob;
+use App\Jobs\RunFollowUpJob;
+use App\Jobs\SendNotificationJob;
+use App\Models\YakTask;
+use App\Providers\ChannelServiceProvider;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    config()->set('yak.channels.slack', [
+        'driver' => 'slack',
+        'bot_token' => 'xoxb-test-token',
+        'signing_secret' => 'test-slack-signing-secret',
+    ]);
+
+    (new ChannelServiceProvider(app()))->boot();
+});
+
+/*
+|--------------------------------------------------------------------------
+| Follow-up thread reply on open-PR task
+|--------------------------------------------------------------------------
+*/
+
+it('creates a follow-up when a thread reply arrives on a task with an open PR', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->success()->create([
+        'source' => 'slack',
+        'slack_channel' => 'C123',
+        'slack_thread_ts' => '111.222',
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'branch_name' => 'yak/x',
+    ]);
+
+    $body = slackThreadReplyPayload('Please also add a test', 'C123', '111.222');
+    $headers = signSlackPayload($body, 'test-slack-signing-secret');
+
+    $this->call('POST', '/webhooks/slack', content: $body, server: [
+        'HTTP_X-Slack-Request-Timestamp' => $headers['X-Slack-Request-Timestamp'],
+        'HTTP_X-Slack-Signature' => $headers['X-Slack-Signature'],
+        'CONTENT_TYPE' => 'application/json',
+    ])->assertSuccessful();
+
+    Queue::assertPushed(RunFollowUpJob::class, function (RunFollowUpJob $job) use ($task) {
+        return $job->task->parent_task_id === $task->id;
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| Bot message in an open-PR thread is ignored
+|--------------------------------------------------------------------------
+*/
+
+it('ignores bot messages in an open-PR thread', function () {
+    Queue::fake();
+
+    YakTask::factory()->success()->create([
+        'source' => 'slack',
+        'slack_channel' => 'C123',
+        'slack_thread_ts' => '111.222',
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'branch_name' => 'yak/x',
+    ]);
+
+    $body = slackThreadReplyPayload('bot reply text', 'C123', '111.222', [
+        'event' => ['bot_id' => 'B_BOT'],
+    ]);
+    $headers = signSlackPayload($body, 'test-slack-signing-secret');
+
+    $this->call('POST', '/webhooks/slack', content: $body, server: [
+        'HTTP_X-Slack-Request-Timestamp' => $headers['X-Slack-Request-Timestamp'],
+        'HTTP_X-Slack-Signature' => $headers['X-Slack-Signature'],
+        'CONTENT_TYPE' => 'application/json',
+    ])->assertSuccessful();
+
+    Queue::assertNotPushed(RunFollowUpJob::class);
+});
+
+it('ignores bot_message subtype in an open-PR thread', function () {
+    Queue::fake();
+
+    YakTask::factory()->success()->create([
+        'source' => 'slack',
+        'slack_channel' => 'C123',
+        'slack_thread_ts' => '111.222',
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'branch_name' => 'yak/x',
+    ]);
+
+    $body = slackThreadReplyPayload('bot reply text', 'C123', '111.222', [
+        'event' => ['subtype' => 'bot_message'],
+    ]);
+    $headers = signSlackPayload($body, 'test-slack-signing-secret');
+
+    $this->call('POST', '/webhooks/slack', content: $body, server: [
+        'HTTP_X-Slack-Request-Timestamp' => $headers['X-Slack-Request-Timestamp'],
+        'HTTP_X-Slack-Signature' => $headers['X-Slack-Signature'],
+        'CONTENT_TYPE' => 'application/json',
+    ])->assertSuccessful();
+
+    Queue::assertNotPushed(RunFollowUpJob::class);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Thread reply with no matching task → ignored
+|--------------------------------------------------------------------------
+*/
+
+it('ignores a thread reply in a thread with no matching Yak task', function () {
+    Queue::fake();
+
+    $body = slackThreadReplyPayload('some reply', 'C_UNKNOWN', '999.999');
+    $headers = signSlackPayload($body, 'test-slack-signing-secret');
+
+    $this->call('POST', '/webhooks/slack', content: $body, server: [
+        'HTTP_X-Slack-Request-Timestamp' => $headers['X-Slack-Request-Timestamp'],
+        'HTTP_X-Slack-Signature' => $headers['X-Slack-Signature'],
+        'CONTENT_TYPE' => 'application/json',
+    ])->assertSuccessful();
+
+    Queue::assertNotPushed(RunFollowUpJob::class);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Thread reply on a merged-PR task → decline
+|--------------------------------------------------------------------------
+*/
+
+it('posts a decline notification and dispatches no follow-up when the PR is already merged', function () {
+    Queue::fake();
+
+    YakTask::factory()->merged()->create([
+        'source' => 'slack',
+        'slack_channel' => 'C123',
+        'slack_thread_ts' => '111.222',
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'branch_name' => 'yak/x',
+    ]);
+
+    $body = slackThreadReplyPayload('Can you add something?', 'C123', '111.222');
+    $headers = signSlackPayload($body, 'test-slack-signing-secret');
+
+    $this->call('POST', '/webhooks/slack', content: $body, server: [
+        'HTTP_X-Slack-Request-Timestamp' => $headers['X-Slack-Request-Timestamp'],
+        'HTTP_X-Slack-Signature' => $headers['X-Slack-Signature'],
+        'CONTENT_TYPE' => 'application/json',
+    ])->assertSuccessful();
+
+    Queue::assertNotPushed(RunFollowUpJob::class);
+    Queue::assertPushed(SendNotificationJob::class);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Regression: awaiting_clarification still dispatches ClarificationReplyJob
+|--------------------------------------------------------------------------
+*/
+
+it('still dispatches ClarificationReplyJob for awaiting-clarification tasks (regression)', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->awaitingClarification()->create([
+        'slack_channel' => 'C_CLAR',
+        'slack_thread_ts' => '777.888',
+    ]);
+
+    $body = slackThreadReplyPayload('Option A', 'C_CLAR', '777.888');
+    $headers = signSlackPayload($body, 'test-slack-signing-secret');
+
+    $this->call('POST', '/webhooks/slack', content: $body, server: [
+        'HTTP_X-Slack-Request-Timestamp' => $headers['X-Slack-Request-Timestamp'],
+        'HTTP_X-Slack-Signature' => $headers['X-Slack-Signature'],
+        'CONTENT_TYPE' => 'application/json',
+    ])->assertSuccessful();
+
+    Queue::assertPushed(ClarificationReplyJob::class, function (ClarificationReplyJob $job) use ($task) {
+        return $job->task->id === $task->id;
+    });
+    Queue::assertNotPushed(RunFollowUpJob::class);
+});

--- a/tests/Feature/CreatePullRequestJobTest.php
+++ b/tests/Feature/CreatePullRequestJobTest.php
@@ -30,6 +30,7 @@ test('creates PR via GitHub API with installation token', function () {
             'token' => 'ghs_test_installation_token',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 42,
             'html_url' => 'https://github.com/org/my-repo/pull/42',
@@ -78,6 +79,7 @@ test('uses cached installation token when not expired', function () {
     ]);
 
     Http::fake([
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -127,6 +129,7 @@ test('requests new installation token when cached token is expired', function ()
             'token' => 'ghs_fresh_token',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -166,6 +169,7 @@ test('caches installation token in database after request', function () {
             'token' => 'ghs_new_cached',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -211,6 +215,7 @@ test('PR title uses Yak Fix prefix for fix mode tasks', function () {
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -241,7 +246,8 @@ test('PR title uses Yak Fix prefix for fix mode tasks', function () {
     app()->call([$job, 'handle']);
 
     Http::assertSent(function ($request) {
-        return str_contains($request->url(), '/pulls')
+        return $request->method() === 'POST'
+            && str_contains($request->url(), '/pulls')
             && $request['title'] === 'Yak Fix: Fix broken auth';
     });
 });
@@ -252,6 +258,7 @@ test('PR title uses Yak Research prefix for research mode tasks', function () {
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -282,7 +289,8 @@ test('PR title uses Yak Research prefix for research mode tasks', function () {
     app()->call([$job, 'handle']);
 
     Http::assertSent(function ($request) {
-        return str_contains($request->url(), '/pulls')
+        return $request->method() === 'POST'
+            && str_contains($request->url(), '/pulls')
             && $request['title'] === 'Yak Research: Investigate memory leak';
     });
 });
@@ -293,6 +301,7 @@ test('PR title truncation preserves multi-byte characters at the boundary', func
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -327,7 +336,7 @@ test('PR title truncation preserves multi-byte characters at the boundary', func
     app()->call([$job, 'handle']);
 
     Http::assertSent(function ($request) {
-        if (! str_contains($request->url(), '/pulls')) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
             return false;
         }
 
@@ -346,6 +355,7 @@ test('PR title truncates long descriptions', function () {
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -377,7 +387,8 @@ test('PR title truncates long descriptions', function () {
     app()->call([$job, 'handle']);
 
     Http::assertSent(function ($request) {
-        return str_contains($request->url(), '/pulls')
+        return $request->method() === 'POST'
+            && str_contains($request->url(), '/pulls')
             && str_starts_with($request['title'], 'Yak Fix: ')
             && str_ends_with($request['title'], '...');
     });
@@ -395,6 +406,7 @@ test('PR body includes source, repo, attempts, and result summary', function () 
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/test-repo/pull/1',
@@ -426,7 +438,7 @@ test('PR body includes source, repo, attempts, and result summary', function () 
     app()->call([$job, 'handle']);
 
     Http::assertSent(function ($request) {
-        if (! str_contains($request->url(), '/pulls')) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
             return false;
         }
 
@@ -446,6 +458,7 @@ test('PR body does not wrap the agent summary in a "What changed" heading', func
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -473,7 +486,7 @@ test('PR body does not wrap the agent summary in a "What changed" heading', func
     app()->call([$job, 'handle']);
 
     Http::assertSent(function ($request) use ($agentSummary) {
-        if (! str_contains($request->url(), '/pulls')) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
             return false;
         }
 
@@ -491,6 +504,7 @@ test('PR body omits the Files changed section and Yak warning footer', function 
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -516,7 +530,7 @@ test('PR body omits the Files changed section and Yak warning footer', function 
     app()->call([$job, 'handle']);
 
     Http::assertSent(function ($request) {
-        if (! str_contains($request->url(), '/pulls')) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
             return false;
         }
 
@@ -544,6 +558,7 @@ test('PR body includes screenshot signed URLs', function () {
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -583,7 +598,7 @@ test('PR body includes screenshot signed URLs', function () {
     app()->call([$job, 'handle']);
 
     Http::assertSent(function ($request) {
-        if (! str_contains($request->url(), '/pulls')) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
             return false;
         }
 
@@ -602,6 +617,7 @@ test('PR body prefers reviewer cut over raw webm when both exist', function () {
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -641,7 +657,7 @@ test('PR body prefers reviewer cut over raw webm when both exist', function () {
     app()->call([$job, 'handle']);
 
     Http::assertSent(function ($request) {
-        if (! str_contains($request->url(), '/pulls')) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
             return false;
         }
 
@@ -659,6 +675,7 @@ test('PR body falls back to raw webm when no reviewer cut exists', function () {
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -694,7 +711,7 @@ test('PR body falls back to raw webm when no reviewer cut exists', function () {
     app()->call([$job, 'handle']);
 
     Http::assertSent(function ($request) {
-        if (! str_contains($request->url(), '/pulls')) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
             return false;
         }
 
@@ -711,6 +728,7 @@ test('PR body includes video walkthrough signed URLs', function () {
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 1,
             'html_url' => 'https://github.com/org/my-repo/pull/1',
@@ -745,7 +763,7 @@ test('PR body includes video walkthrough signed URLs', function () {
     app()->call([$job, 'handle']);
 
     Http::assertSent(function ($request) {
-        if (! str_contains($request->url(), '/pulls')) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
             return false;
         }
 
@@ -769,6 +787,7 @@ test('applies yak label to every PR', function () {
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 5,
             'html_url' => 'https://github.com/org/my-repo/pull/5',
@@ -809,6 +828,7 @@ test('applies yak-large-change label when LOC exceeds threshold', function () {
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 7,
             'html_url' => 'https://github.com/org/my-repo/pull/7',
@@ -850,6 +870,7 @@ test('does not apply yak-large-change label for small changes', function () {
             'token' => 'ghs_test',
             'expires_at' => now()->addHour()->toIso8601String(),
         ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
         'api.github.com/repos/*/pulls' => Http::response([
             'number' => 8,
             'html_url' => 'https://github.com/org/my-repo/pull/8',

--- a/tests/Feature/HealthCheck/RegistryTest.php
+++ b/tests/Feature/HealthCheck/RegistryTest.php
@@ -43,7 +43,7 @@ it('channel section includes only enabled channels', function () {
     $checks = app(Registry::class)->forSection(HealthSection::Channels);
     $ids = array_map(fn ($c) => $c->id(), $checks);
 
-    expect($ids)->toBe(['slack']);
+    expect($ids)->toBe(['slack', 'slack-interactivity']);
     expect($checks[0])->toBeInstanceOf(SlackChannelCheck::class);
 });
 
@@ -56,6 +56,8 @@ it('throws when asked for an unknown id', function () {
 })->throws(InvalidArgumentException::class);
 
 it('returns name for a given id without instantiating a run', function () {
+    config(['yak.channels.linear.webhook_secret' => 'sec']);
+
     expect(app(Registry::class)->nameFor('queue-worker'))->toBe('Queue Worker');
     expect(app(Registry::class)->nameFor('linear'))->toBe('Linear');
 });

--- a/tests/Feature/Jobs/RunYakReviewJobPriorFindingsTest.php
+++ b/tests/Feature/Jobs/RunYakReviewJobPriorFindingsTest.php
@@ -6,6 +6,7 @@ use App\DataTransferObjects\AgentRunResult;
 use App\DataTransferObjects\ParsedPriorFinding;
 use App\DataTransferObjects\ParsedReview;
 use App\Enums\TaskMode;
+use App\Enums\TaskStatus;
 use App\Jobs\RunYakReviewJob;
 use App\Models\PrReview;
 use App\Models\PrReviewComment;
@@ -214,12 +215,12 @@ it('falls back to today\'s incremental flow when GraphQL fetch fails', function 
     $github = mock(GitHubAppService::class);
     $github->shouldReceive('getInstallationToken')->andReturn('tok');
     $github->shouldReceive('listPullRequestFiles')->andReturn([]);
-    $github->shouldReceive('listReviewThreads')->andThrow(new \RuntimeException('graphql exploded'));
+    $github->shouldReceive('listReviewThreads')->andThrow(new RuntimeException('graphql exploded'));
     $github->shouldReceive('createPullRequestReview')->andReturn(['id' => 9, 'comments' => []]);
     $github->shouldNotReceive('replyToReviewComment');
     app()->instance(GitHubAppService::class, $github);
 
     (new RunYakReviewJob($task))->handle(app(AgentRunner::class));
 
-    expect($task->fresh()->status)->toBe(\App\Enums\TaskStatus::Success);
+    expect($task->fresh()->status)->toBe(TaskStatus::Success);
 });

--- a/tests/Feature/Livewire/Tasks/CreateTaskTest.php
+++ b/tests/Feature/Livewire/Tasks/CreateTaskTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Enums\TaskMode;
+use App\Jobs\ResearchYakJob;
+use App\Jobs\RunYakJob;
+use App\Livewire\Tasks\CreateTask;
+use App\Models\Repository;
+use App\Models\YakTask;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+
+test('save creates a dashboard fix task and dispatches RunYakJob', function () {
+    Queue::fake();
+    Repository::factory()->create(['slug' => 'web', 'is_active' => true]);
+
+    Livewire::test(CreateTask::class)
+        ->set('repo', 'web')
+        ->set('taskMode', 'fix')
+        ->set('description', 'Add a CSV export to the reports page')
+        ->call('save');
+
+    $task = YakTask::where('source', 'dashboard')->first();
+    expect($task)->not->toBeNull()
+        ->and($task->repo)->toBe('web')
+        ->and($task->mode)->toBe(TaskMode::Fix)
+        ->and($task->description)->toBe('Add a CSV export to the reports page');
+
+    Queue::assertPushed(RunYakJob::class, fn (RunYakJob $j) => $j->task->is($task));
+    Queue::assertNotPushed(ResearchYakJob::class);
+});
+
+test('save with research mode dispatches ResearchYakJob', function () {
+    Queue::fake();
+    Repository::factory()->create(['slug' => 'api', 'is_active' => true]);
+
+    Livewire::test(CreateTask::class)
+        ->set('repo', 'api')
+        ->set('taskMode', 'research')
+        ->set('description', 'Investigate the slow dashboard query')
+        ->call('save');
+
+    $task = YakTask::where('source', 'dashboard')->first();
+    expect($task->mode)->toBe(TaskMode::Research);
+    Queue::assertPushed(ResearchYakJob::class);
+    Queue::assertNotPushed(RunYakJob::class);
+});
+
+test('save validates required fields and an active repo', function () {
+    Queue::fake();
+    Repository::factory()->create(['slug' => 'web', 'is_active' => true]);
+
+    // blank description
+    Livewire::test(CreateTask::class)
+        ->set('repo', 'web')->set('taskMode', 'fix')->set('description', '')
+        ->call('save')
+        ->assertHasErrors('description');
+
+    // missing/inactive repo
+    Livewire::test(CreateTask::class)
+        ->set('repo', 'does-not-exist')->set('taskMode', 'fix')->set('description', 'something valid here')
+        ->call('save')
+        ->assertHasErrors('repo');
+
+    expect(YakTask::where('source', 'dashboard')->count())->toBe(0);
+    Queue::assertNothingPushed();
+});
+
+test('repos computed returns only active repos', function () {
+    Repository::factory()->create(['slug' => 'active-one', 'is_active' => true]);
+    Repository::factory()->create(['slug' => 'inactive-one', 'is_active' => false]);
+
+    $repos = Livewire::test(CreateTask::class)->instance()->repos();
+
+    expect($repos->pluck('slug')->all())->toContain('active-one')
+        ->and($repos->pluck('slug')->all())->not->toContain('inactive-one');
+});

--- a/tests/Feature/Livewire/Tasks/TaskDetailFollowUpTest.php
+++ b/tests/Feature/Livewire/Tasks/TaskDetailFollowUpTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Jobs\RunFollowUpJob;
+use App\Livewire\Tasks\TaskDetail;
+use App\Models\User;
+use App\Models\YakTask;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->create());
+});
+
+test('sendFollowUp on an open-PR task creates a chained follow-up and dispatches RunFollowUpJob', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->success()->create([
+        'source' => 'dashboard',
+        'repo' => 'web',
+        'branch_name' => 'yak/CSV-1',
+        'session_id' => 'sess_parent',
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'pr_number' => 9,
+    ]);
+
+    Livewire::test(TaskDetail::class, ['task' => $task])
+        ->set('followUpText', 'Also handle the empty-state')
+        ->call('sendFollowUp')
+        ->assertSet('followUpText', '');
+
+    expect(YakTask::where('parent_task_id', $task->id)->count())->toBe(1);
+    Queue::assertPushed(RunFollowUpJob::class);
+});
+
+test('sendFollowUp on a merged PR creates nothing and dispatches nothing', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->merged()->create(['source' => 'dashboard', 'branch_name' => 'yak/M-1']);
+
+    Livewire::test(TaskDetail::class, ['task' => $task])
+        ->set('followUpText', 'too late')
+        ->call('sendFollowUp');
+
+    expect(YakTask::where('parent_task_id', $task->id)->count())->toBe(0);
+    Queue::assertNothingPushed();
+});
+
+test('composer is shown for an open PR and hidden when no open PR', function () {
+    $open = YakTask::factory()->success()->create(['source' => 'dashboard', 'branch_name' => 'yak/O-1']);
+    $merged = YakTask::factory()->merged()->create(['source' => 'dashboard', 'branch_name' => 'yak/X-1']);
+
+    Livewire::test(TaskDetail::class, ['task' => $open])
+        ->assertSeeHtml('data-testid="follow-up-input"');
+
+    Livewire::test(TaskDetail::class, ['task' => $merged])
+        ->assertDontSeeHtml('data-testid="follow-up-input"');
+});

--- a/tests/Feature/Livewire/Tasks/TaskListNestingTest.php
+++ b/tests/Feature/Livewire/Tasks/TaskListNestingTest.php
@@ -61,3 +61,33 @@ test('top-level list excludes follow-up children even across tabs/filters', func
     $ids = Livewire::test(TaskList::class)->set('status', 'running')->instance()->tasks->pluck('id')->all();
     expect($ids)->not->toContain($root->followUps()->first()->id);
 });
+
+test('a multi-level follow-up chain shows grandchildren nested under the root', function () {
+    $root = YakTask::factory()->success()->create(['repo' => 'web', 'external_id' => 'GC-1', 'branch_name' => 'yak/GC-1']);
+    $child = YakTask::factory()->create([
+        'parent_task_id' => $root->id, 'repo' => 'web',
+        'external_id' => 'GC-1-followup-1', 'branch_name' => 'yak/GC-1',
+    ]);
+    $grandchild = YakTask::factory()->create([
+        'parent_task_id' => $child->id, 'repo' => 'web',  // parent is the CHILD, not the root
+        'external_id' => 'GC-1-followup-2', 'branch_name' => 'yak/GC-1',
+    ]);
+
+    Livewire::test(TaskList::class)
+        ->assertSee('GC-1-followup-1')
+        ->assertSee('GC-1-followup-2')   // grandchild must still render
+        ->assertSee('2 follow-ups');     // count includes the whole chain
+
+    $topLevel = Livewire::test(TaskList::class)->instance()->tasks->pluck('id')->all();
+    expect($topLevel)->toContain($root->id)
+        ->and($topLevel)->not->toContain($child->id)
+        ->and($topLevel)->not->toContain($grandchild->id);
+});
+
+test('tab count excludes follow-up children', function () {
+    $root = YakTask::factory()->success()->create(['repo' => 'web', 'external_id' => 'TC-1', 'branch_name' => 'yak/TC-1']);
+    YakTask::factory()->create(['parent_task_id' => $root->id, 'repo' => 'web', 'external_id' => 'TC-1-followup-1', 'branch_name' => 'yak/TC-1']);
+
+    // Only the root counts toward the Tasks tab badge.
+    expect(Livewire::test(TaskList::class)->instance()->tasksCount)->toBe(1);
+});

--- a/tests/Feature/Livewire/Tasks/TaskListNestingTest.php
+++ b/tests/Feature/Livewire/Tasks/TaskListNestingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Enums\TaskStatus;
+use App\Livewire\Tasks\TaskList;
+use App\Models\YakTask;
+use Livewire\Livewire;
+
+test('a root task with follow-ups nests its children and is the only top-level row', function () {
+    $root = YakTask::factory()->success()->create([
+        'repo' => 'web',
+        'external_id' => 'ROOT-1',
+        'branch_name' => 'yak/R-1',
+    ]);
+    $childA = YakTask::factory()->create([
+        'parent_task_id' => $root->id,
+        'repo' => 'web',
+        'external_id' => 'ROOT-1-followup-1',
+        'branch_name' => 'yak/R-1',
+        'description' => 'first follow up change',
+    ]);
+    $childB = YakTask::factory()->create([
+        'parent_task_id' => $root->id,
+        'repo' => 'web',
+        'external_id' => 'ROOT-1-followup-2',
+        'branch_name' => 'yak/R-1',
+        'description' => 'second follow up change',
+    ]);
+
+    Livewire::test(TaskList::class)
+        ->assertSee('ROOT-1')
+        ->assertSee('ROOT-1-followup-1')   // child rendered nested
+        ->assertSee('ROOT-1-followup-2')
+        ->assertSee('2 follow-ups');        // badge on the root
+
+    // The computed query returns only the root at the top level (children are not separate paginated rows)
+    $topLevelIds = Livewire::test(TaskList::class)->instance()->tasks->pluck('id')->all();
+    expect($topLevelIds)->toContain($root->id)
+        ->and($topLevelIds)->not->toContain($childA->id)
+        ->and($topLevelIds)->not->toContain($childB->id);
+});
+
+test('a standalone task renders normally with no follow-ups badge', function () {
+    YakTask::factory()->success()->create(['external_id' => 'SOLO-1', 'repo' => 'web']);
+
+    Livewire::test(TaskList::class)
+        ->assertSee('SOLO-1')
+        ->assertDontSee('follow-ups');
+});
+
+test('top-level list excludes follow-up children even across tabs/filters', function () {
+    $root = YakTask::factory()->success()->create(['repo' => 'web', 'external_id' => 'FR-1', 'branch_name' => 'yak/F-1']);
+    YakTask::factory()->create([
+        'parent_task_id' => $root->id,
+        'repo' => 'web',
+        'external_id' => 'FR-1-followup-1',
+        'branch_name' => 'yak/F-1',
+        'status' => TaskStatus::Running,
+    ]);
+
+    // Even filtering by a status the child has, children never appear as their own top-level row.
+    $ids = Livewire::test(TaskList::class)->set('status', 'running')->instance()->tasks->pluck('id')->all();
+    expect($ids)->not->toContain($root->followUps()->first()->id);
+});

--- a/tests/Feature/Livewire/Tasks/TaskListNewTaskTest.php
+++ b/tests/Feature/Livewire/Tasks/TaskListNewTaskTest.php
@@ -1,0 +1,10 @@
+<?php
+
+use App\Livewire\Tasks\TaskList;
+use Livewire\Livewire;
+
+test('task list shows the New task trigger and embeds the CreateTask component', function () {
+    Livewire::test(TaskList::class)
+        ->assertSeeHtml('data-testid="new-task-trigger"')
+        ->assertSeeHtml('data-testid="create-task-form"');
+});

--- a/tests/Feature/PRMergeTrackingTest.php
+++ b/tests/Feature/PRMergeTrackingTest.php
@@ -165,9 +165,9 @@ test('webhook skips unsupported events', function () {
 
     $payload = ['action' => 'created'];
 
-    $response = postGitHubWebhook($this, $payload, $secret, 'issue_comment');
+    $response = postGitHubWebhook($this, $payload, $secret, 'label');
 
-    $response->assertOk()->assertJson(['skipped' => 'unhandled event: issue_comment']);
+    $response->assertOk()->assertJson(['skipped' => 'unhandled event: label']);
 });
 
 test('webhook skips when no task matches PR URL', function () {

--- a/tests/Feature/ProcessCIResultJobTest.php
+++ b/tests/Feature/ProcessCIResultJobTest.php
@@ -780,3 +780,113 @@ test('ProcessCIResultJob dispatches to default queue', function () {
 
     expect($job->queue)->toBe('default');
 });
+
+/*
+|--------------------------------------------------------------------------
+| Green Path — Linear Action Activity Label
+|--------------------------------------------------------------------------
+*/
+
+test('Linear initial run posts "Opened pull request" action', function () {
+    Http::fake([
+        'api.github.com/*' => Http::response([
+            'number' => 11,
+            'html_url' => 'https://github.com/org/lin-repo/pull/11',
+        ]),
+        'api.linear.app/*' => Http::response(['data' => ['success' => true]]),
+    ]);
+
+    Process::fake([
+        '*git diff --name-only *' => Process::result(''),
+        '*git diff --stat *' => Process::result(' 1 file changed, 5 insertions(+)'),
+        '*git checkout *' => Process::result(''),
+        '*git branch -D *' => Process::result(''),
+    ]);
+
+    LinearOauthConnection::factory()->create();
+
+    Repository::factory()->create([
+        'slug' => 'org/lin-repo',
+        'path' => '/home/yak/repos/lin-repo',
+    ]);
+
+    $task = YakTask::factory()->awaitingCi()->create([
+        'repo' => 'org/lin-repo',
+        'branch_name' => 'yak/LIN-INIT',
+        'source' => 'linear',
+        'linear_agent_session_id' => 'session-init',
+        'parent_task_id' => null,
+        'attempts' => 1,
+    ]);
+
+    (new ProcessCIResultJob($task, true))->handle();
+
+    Http::assertSent(function ($request) {
+        if (! str_contains($request->url(), 'api.linear.app/graphql')) {
+            return false;
+        }
+        $content = $request->data()['variables']['input']['content'] ?? [];
+
+        return ($content['type'] ?? null) === 'action'
+            && ($content['action'] ?? null) === 'Opened pull request';
+    });
+});
+
+test('Linear follow-up run posts "Pushed changes" action instead of "Opened pull request"', function () {
+    Http::fake([
+        'api.github.com/*' => Http::response([
+            'number' => 12,
+            'html_url' => 'https://github.com/org/lin-repo/pull/12',
+        ]),
+        'api.linear.app/*' => Http::response(['data' => ['success' => true]]),
+    ]);
+
+    Process::fake([
+        '*git diff --name-only *' => Process::result(''),
+        '*git diff --stat *' => Process::result(' 1 file changed, 3 insertions(+)'),
+        '*git checkout *' => Process::result(''),
+        '*git branch -D *' => Process::result(''),
+    ]);
+
+    LinearOauthConnection::factory()->create();
+
+    Repository::factory()->create([
+        'slug' => 'org/lin-repo',
+        'path' => '/home/yak/repos/lin-repo',
+    ]);
+
+    $parent = YakTask::factory()->success()->create([
+        'repo' => 'org/lin-repo',
+        'source' => 'linear',
+    ]);
+
+    $task = YakTask::factory()->awaitingCi()->create([
+        'repo' => 'org/lin-repo',
+        'branch_name' => 'yak/LIN-FUP',
+        'source' => 'linear',
+        'linear_agent_session_id' => 'session-followup',
+        'parent_task_id' => $parent->id,
+        'attempts' => 1,
+    ]);
+
+    (new ProcessCIResultJob($task, true))->handle();
+
+    Http::assertSent(function ($request) {
+        if (! str_contains($request->url(), 'api.linear.app/graphql')) {
+            return false;
+        }
+        $content = $request->data()['variables']['input']['content'] ?? [];
+
+        return ($content['type'] ?? null) === 'action'
+            && ($content['action'] ?? null) === 'Pushed changes';
+    });
+
+    Http::assertNotSent(function ($request) {
+        if (! str_contains($request->url(), 'api.linear.app/graphql')) {
+            return false;
+        }
+        $content = $request->data()['variables']['input']['content'] ?? [];
+
+        return ($content['action'] ?? null) === 'Opened pull request';
+    });
+});

--- a/tests/Feature/ProcessCIResultJobTest.php
+++ b/tests/Feature/ProcessCIResultJobTest.php
@@ -128,8 +128,11 @@ test('green path creates PR via GitHub API with correct payload', function () {
     $job->handle();
 
     Http::assertSent(function ($request) {
-        return str_contains($request->url(), 'api.github.com/repos/org/my-repo/pulls')
-            && $request['head'] === 'yak/FIX-99'
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), 'api.github.com/repos/org/my-repo/pulls')) {
+            return false;
+        }
+
+        return $request['head'] === 'yak/FIX-99'
             && $request['base'] === 'main'
             && str_contains($request['title'], 'Yak Fix:');
     });
@@ -174,7 +177,7 @@ test('PR body contains source, repo, and result summary', function () {
     $job->handle();
 
     Http::assertSent(function ($request) {
-        if (! str_contains($request->url(), '/pulls')) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
             return false;
         }
 
@@ -394,7 +397,7 @@ test('green path generates signed URLs with HMAC-SHA256 for artifacts', function
 
     // Verify artifact was created with signed URL in PR body
     Http::assertSent(function ($request) {
-        if (! str_contains($request->url(), '/pulls')) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
             return false;
         }
 

--- a/tests/Feature/TwoWayFeedback/AddReactionTest.php
+++ b/tests/Feature/TwoWayFeedback/AddReactionTest.php
@@ -26,6 +26,13 @@ test('addReaction posts the reaction content to the issue comment reactions endp
         && $request['content'] === 'eyes');
 });
 
+test('addReaction targets the pulls endpoint for review comments', function () {
+    config()->set('yak.channels.github.installation_id', 4242);
+    Http::fake(['api.github.com/*' => Http::response([], 201)]);
+    app(AppService::class)->addReaction(4242, 'acme/web', 77, 'eyes', isReviewComment: true);
+    Http::assertSent(fn ($r) => str_contains($r->url(), '/repos/acme/web/pulls/comments/77/reactions'));
+});
+
 test('followup config exposes github prefixes and batch window', function () {
     expect(config('yak.followup.github_prefixes'))->not->toBeNull()
         ->and((int) config('yak.followup.github_batch_window_seconds'))->toBeGreaterThan(0);

--- a/tests/Feature/TwoWayFeedback/AddReactionTest.php
+++ b/tests/Feature/TwoWayFeedback/AddReactionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Channels\GitHub\AppService;
+use App\Models\GitHubInstallationToken;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    GitHubInstallationToken::create([
+        'installation_id' => 4242,
+        'token' => 't',
+        'expires_at' => now()->addHour(),
+    ]);
+});
+
+test('addReaction posts the reaction content to the issue comment reactions endpoint', function () {
+    config()->set('yak.channels.github.installation_id', 4242);
+
+    Http::fake([
+        'api.github.com/repos/acme/web/issues/comments/555/reactions' => Http::response(['id' => 1, 'content' => 'eyes'], 201),
+    ]);
+
+    app(AppService::class)->addReaction(4242, 'acme/web', 555, 'eyes');
+
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_contains($request->url(), '/repos/acme/web/issues/comments/555/reactions')
+        && $request['content'] === 'eyes');
+});
+
+test('followup config exposes github prefixes and batch window', function () {
+    expect(config('yak.followup.github_prefixes'))->not->toBeNull()
+        ->and((int) config('yak.followup.github_batch_window_seconds'))->toBeGreaterThan(0);
+});

--- a/tests/Feature/TwoWayFeedback/ChainCloseStampTest.php
+++ b/tests/Feature/TwoWayFeedback/ChainCloseStampTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Models\YakTask;
+use App\Providers\ChannelServiceProvider;
+
+beforeEach(function () {
+    config()->set('yak.channels.github', [
+        'app_id' => '123',
+        'private_key' => 'key',
+        'webhook_secret' => 'secret',
+        'app_bot_login' => 'yak-bot[bot]',
+    ]);
+
+    (new ChannelServiceProvider(app()))->boot();
+});
+
+function signChainClosePayload(string $payload): string
+{
+    return 'sha256=' . hash_hmac('sha256', $payload, 'secret');
+}
+
+test('merging a PR stamps pr_merged_at across the whole follow-up chain', function () {
+    $prUrl = 'https://github.com/acme/web/pull/9';
+
+    $root = YakTask::factory()->success()->create(['repo' => 'acme/web', 'pr_url' => $prUrl, 'branch_name' => 'yak/CH-1', 'external_id' => 'CH-1']);
+    $child = YakTask::factory()->create(['parent_task_id' => $root->id, 'repo' => 'acme/web', 'pr_url' => $prUrl, 'branch_name' => 'yak/CH-1', 'external_id' => 'CH-1-followup-1']);
+    $grandchild = YakTask::factory()->create(['parent_task_id' => $child->id, 'repo' => 'acme/web', 'pr_url' => $prUrl, 'branch_name' => 'yak/CH-1', 'external_id' => 'CH-1-followup-2']);
+
+    $payload = [
+        'action' => 'closed',
+        'pull_request' => [
+            'html_url' => $prUrl,
+            'number' => 9,
+            'merged' => true,
+            'user' => ['login' => 'yak-bot[bot]'],
+            'head' => ['ref' => 'yak/CH-1', 'sha' => 'aaa'],
+            'base' => ['ref' => 'main', 'sha' => 'bbb'],
+        ],
+        'repository' => ['full_name' => 'acme/web'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, [
+        'X-GitHub-Event' => 'pull_request',
+        'X-Hub-Signature-256' => signChainClosePayload($body),
+    ])->assertOk();
+
+    expect($root->fresh()->pr_merged_at)->not->toBeNull()
+        ->and($child->fresh()->pr_merged_at)->not->toBeNull()
+        ->and($grandchild->fresh()->pr_merged_at)->not->toBeNull();
+
+    // The guard now correctly reports the chain head as not open.
+    expect($grandchild->fresh()->prIsOpen())->toBeFalse();
+});
+
+test('closing a PR without merge stamps pr_closed_at across the chain', function () {
+    $prUrl = 'https://github.com/acme/web/pull/10';
+    $root = YakTask::factory()->success()->create(['repo' => 'acme/web', 'pr_url' => $prUrl, 'branch_name' => 'yak/CL-1', 'external_id' => 'CL-1']);
+    $child = YakTask::factory()->create(['parent_task_id' => $root->id, 'repo' => 'acme/web', 'pr_url' => $prUrl, 'branch_name' => 'yak/CL-1', 'external_id' => 'CL-1-followup-1']);
+
+    $payload = [
+        'action' => 'closed',
+        'pull_request' => ['html_url' => $prUrl, 'number' => 10, 'merged' => false, 'user' => ['login' => 'yak-bot[bot]'], 'head' => ['ref' => 'yak/CL-1', 'sha' => 'a'], 'base' => ['ref' => 'main', 'sha' => 'b']],
+        'repository' => ['full_name' => 'acme/web'],
+    ];
+    $body = json_encode($payload);
+
+    $this->postJson('/webhooks/github', $payload, ['X-GitHub-Event' => 'pull_request', 'X-Hub-Signature-256' => signChainClosePayload($body)])->assertOk();
+
+    expect($root->fresh()->pr_closed_at)->not->toBeNull()
+        ->and($child->fresh()->pr_closed_at)->not->toBeNull();
+});

--- a/tests/Feature/TwoWayFeedback/CreatePullRequestIdempotencyTest.php
+++ b/tests/Feature/TwoWayFeedback/CreatePullRequestIdempotencyTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Channels\GitHub\AppService as GitHubAppService;
+use App\Jobs\CreatePullRequestJob;
+use App\Models\Repository;
+use App\Models\YakTask;
+
+beforeEach(function () {
+    config()->set('yak.channels.github.installation_id', 4242);
+});
+
+test('skips PR creation and comments when an open PR already exists for the branch', function () {
+    $github = $this->mock(GitHubAppService::class);
+    $github->shouldReceive('findOpenPullRequestForBranch')
+        ->once()
+        ->andReturn(['number' => 9, 'html_url' => 'https://github.com/acme/web/pull/9']);
+    $github->shouldNotReceive('createPullRequest');
+    $github->shouldReceive('commentOnPullRequest')->once()
+        ->withArgs(fn ($inst, $slug, $num, $body) => $num === 9 && str_contains($body, 'feedback'));
+
+    Repository::factory()->create(['slug' => 'acme/web', 'path' => '/home/yak/repos/web']);
+    $task = YakTask::factory()->success()->create([
+        'repo' => 'acme/web',
+        'branch_name' => 'yak/CSV-1',
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'pr_number' => 9,
+        'result_summary' => 'Handled the empty state',
+    ]);
+
+    (new CreatePullRequestJob($task))->handle($github);
+
+    $task->refresh();
+    expect($task->pr_number)->toBe(9)
+        ->and($task->pr_url)->toBe('https://github.com/acme/web/pull/9');
+});
+
+test('creates a PR and stores pr_number when none exists', function () {
+    $github = $this->mock(GitHubAppService::class);
+    $github->shouldReceive('findOpenPullRequestForBranch')->once()->andReturn(null);
+    $github->shouldReceive('createPullRequest')->once()
+        ->andReturn(['number' => 12, 'html_url' => 'https://github.com/acme/web/pull/12']);
+    $github->shouldReceive('addLabels')->once();
+
+    Repository::factory()->create(['slug' => 'acme/web', 'path' => '/home/yak/repos/web']);
+    $task = YakTask::factory()->awaitingCi()->create([
+        'repo' => 'acme/web',
+        'branch_name' => 'yak/NEW-1',
+        'pr_url' => null,
+        'description' => 'Add a thing',
+    ]);
+
+    (new CreatePullRequestJob($task))->handle($github);
+
+    $task->refresh();
+    expect($task->pr_url)->toBe('https://github.com/acme/web/pull/12')
+        ->and($task->pr_number)->toBe(12);
+});

--- a/tests/Feature/TwoWayFeedback/CreatePullRequestIdempotencyTest.php
+++ b/tests/Feature/TwoWayFeedback/CreatePullRequestIdempotencyTest.php
@@ -55,3 +55,19 @@ test('creates a PR and stores pr_number when none exists', function () {
     expect($task->pr_url)->toBe('https://github.com/acme/web/pull/12')
         ->and($task->pr_number)->toBe(12);
 });
+
+test('throws when an existing PR is returned without expected fields', function () {
+    $github = $this->mock(GitHubAppService::class);
+    $github->shouldReceive('findOpenPullRequestForBranch')->once()->andReturn(['html_url' => 'https://github.com/acme/web/pull/9']); // missing 'number'
+    $github->shouldNotReceive('createPullRequest');
+    $github->shouldNotReceive('commentOnPullRequest');
+
+    Repository::factory()->create(['slug' => 'acme/web', 'path' => '/home/yak/repos/web']);
+    $task = YakTask::factory()->success()->create([
+        'repo' => 'acme/web',
+        'branch_name' => 'yak/CSV-1',
+    ]);
+
+    expect(fn () => (new CreatePullRequestJob($task))->handle($github))
+        ->toThrow(RuntimeException::class);
+});

--- a/tests/Feature/TwoWayFeedback/DashboardNotificationTest.php
+++ b/tests/Feature/TwoWayFeedback/DashboardNotificationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Channels\ChannelRegistry;
+use App\Enums\NotificationType;
+use App\Jobs\SendNotificationJob;
+use App\Models\GitHubInstallationToken;
+use App\Models\YakTask;
+use Illuminate\Support\Facades\Http;
+
+test('dashboard-sourced task with an open PR does not post to GitHub', function () {
+    Http::fake(); // any github API call would be recorded
+    config()->set('yak.channels.github.installation_id', 4242);
+
+    GitHubInstallationToken::factory()->create([
+        'installation_id' => 4242,
+        'token' => 'ghs_test_token',
+        'expires_at' => now()->addHour(),
+    ]);
+
+    $task = YakTask::factory()->success()->create([
+        'source' => 'dashboard',
+        'repo' => 'acme/web',
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+    ]);
+
+    (new SendNotificationJob($task, NotificationType::Progress, 'pushed, waiting for CI'))->handle(app(ChannelRegistry::class));
+
+    Http::assertNothingSent();
+});
+
+test('non-dashboard source with PR still falls back to GitHub', function () {
+    Http::fake(['api.github.com/*' => Http::response(['id' => 1])]);
+
+    config()->set('yak.channels.github.installation_id', 4242);
+
+    GitHubInstallationToken::factory()->create([
+        'installation_id' => 4242,
+        'token' => 'ghs_test_token',
+        'expires_at' => now()->addHour(),
+    ]);
+
+    $task = YakTask::factory()->success()->create([
+        'source' => 'sentry',
+        'repo' => 'acme/web',
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+    ]);
+
+    (new SendNotificationJob($task, NotificationType::Progress, 'pushed, waiting for CI'))->handle(app(ChannelRegistry::class));
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'acme/web/issues/9/comments'));
+});

--- a/tests/Feature/TwoWayFeedback/FlushFollowUpBatchJobTest.php
+++ b/tests/Feature/TwoWayFeedback/FlushFollowUpBatchJobTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Channels\GitHub\AppService;
+use App\Jobs\FlushFollowUpBatchJob;
+use App\Jobs\RunFollowUpJob;
+use App\Models\FollowUpPendingComment;
+use App\Models\YakTask;
+use App\Services\FollowUpTaskFactory;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(fn () => config()->set('yak.channels.github.installation_id', 4242));
+
+test('flushes buffered comments into one follow-up and clears the buffer', function () {
+    Queue::fake();
+
+    $root = YakTask::factory()->success()->create([
+        'repo' => 'acme/web',
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'pr_number' => 9,
+        'branch_name' => 'yak/CSV-1',
+        'session_id' => 'sess',
+    ]);
+
+    foreach (['handle empty state', 'rename the column', 'add a test'] as $i => $body) {
+        FollowUpPendingComment::create([
+            'yak_task_id' => $root->id,
+            'pr_url' => $root->pr_url,
+            'body' => $body,
+            'file' => $i === 1 ? 'app/Report.php' : null,
+            'line' => $i === 1 ? 42 : null,
+            'diff_hunk' => $i === 1 ? '@@ -1 +1 @@' : null,
+        ]);
+    }
+
+    (new FlushFollowUpBatchJob($root->pr_url))->handle(
+        app(FollowUpTaskFactory::class),
+        app(AppService::class),
+    );
+
+    // one chained follow-up created, carrying all three instructions
+    $child = YakTask::where('parent_task_id', $root->id)->first();
+    expect($child)->not->toBeNull()
+        ->and($child->description)->toContain('handle empty state')
+        ->and($child->description)->toContain('rename the column')
+        ->and($child->description)->toContain('add a test')
+        ->and($child->description)->toContain('app/Report.php');
+
+    // buffer cleared
+    expect(FollowUpPendingComment::where('pr_url', $root->pr_url)->count())->toBe(0);
+    Queue::assertPushed(RunFollowUpJob::class);
+});
+
+test('empty buffer is a no-op', function () {
+    Queue::fake();
+
+    (new FlushFollowUpBatchJob('https://github.com/acme/web/pull/404'))->handle(
+        app(FollowUpTaskFactory::class),
+        app(AppService::class),
+    );
+
+    expect(YakTask::count())->toBe(0);
+    Queue::assertNothingPushed();
+});
+
+test('merged PR posts a decline comment and creates no follow-up', function () {
+    Queue::fake();
+    $github = $this->mock(AppService::class);
+    $github->shouldReceive('commentOnPullRequest')->once()
+        ->withArgs(fn ($inst, $slug, $num, $body) => $num === 9);
+
+    $root = YakTask::factory()->merged()->create([
+        'repo' => 'acme/web',
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'pr_number' => 9,
+        'branch_name' => 'yak/CSV-1',
+    ]);
+    FollowUpPendingComment::create(['yak_task_id' => $root->id, 'pr_url' => $root->pr_url, 'body' => 'too late']);
+
+    (new FlushFollowUpBatchJob($root->pr_url))->handle(
+        app(FollowUpTaskFactory::class),
+        $github,
+    );
+
+    expect(YakTask::where('parent_task_id', $root->id)->count())->toBe(0)
+        ->and(FollowUpPendingComment::where('pr_url', $root->pr_url)->count())->toBe(0); // buffer still cleared
+    Queue::assertNothingPushed();
+});

--- a/tests/Feature/TwoWayFeedback/FollowUpCommentParserTest.php
+++ b/tests/Feature/TwoWayFeedback/FollowUpCommentParserTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Channels\GitHub\FollowUpCommentParser;
+
+beforeEach(function () {
+    config()->set('yak.followup.github_prefixes', '/yak,@yak-bot[bot],yak:');
+});
+
+function parse(string $body): ?string
+{
+    return app(FollowUpCommentParser::class)->parse($body);
+}
+
+test('parses each configured prefix and strips it', function () {
+    expect(parse('/yak handle the empty-state'))->toBe('handle the empty-state')
+        ->and(parse('@yak-bot[bot] rename this method'))->toBe('rename this method')
+        ->and(parse('yak: add a test for the 401 case'))->toBe('add a test for the 401 case');
+});
+
+test('prefix match is case-insensitive', function () {
+    expect(parse('/YAK fix the thing'))->toBe('fix the thing')
+        ->and(parse('Yak: do the thing'))->toBe('do the thing');
+});
+
+test('captures multi-line instructions after the prefix', function () {
+    expect(parse("/yak do A\nand also B"))->toBe("do A\nand also B");
+});
+
+test('ignores leading blank lines before the prefix line', function () {
+    expect(parse("\n\n/yak after blanks"))->toBe('after blanks');
+});
+
+test('returns null when no prefix matches', function () {
+    expect(parse('looks good to me'))->toBeNull()
+        ->and(parse('the /yak tool is great'))->toBeNull()   // prefix not at line start
+        ->and(parse(''))->toBeNull()
+        ->and(parse('   '))->toBeNull();
+});
+
+test('returns null when the prefix has no instructions after it', function () {
+    expect(parse('/yak'))->toBeNull()
+        ->and(parse('/yak    '))->toBeNull()
+        ->and(parse('yak:'))->toBeNull();
+});

--- a/tests/Feature/TwoWayFeedback/FollowUpPendingCommentTest.php
+++ b/tests/Feature/TwoWayFeedback/FollowUpPendingCommentTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\FollowUpPendingComment;
+use App\Models\YakTask;
+use Illuminate\Support\Facades\Schema;
+
+test('follow_up_pending_comments table has the expected columns', function () {
+    foreach (['id', 'yak_task_id', 'pr_url', 'body', 'file', 'line', 'diff_hunk', 'github_comment_id', 'created_at'] as $col) {
+        expect(Schema::hasColumn('follow_up_pending_comments', $col))->toBeTrue("missing column {$col}");
+    }
+});
+
+test('a pending comment round-trips and belongs to a task', function () {
+    $task = YakTask::factory()->create();
+
+    $row = FollowUpPendingComment::create([
+        'yak_task_id' => $task->id,
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'body' => 'handle the empty state',
+        'file' => 'app/Foo.php',
+        'line' => 42,
+        'diff_hunk' => '@@ -1 +1 @@',
+        'github_comment_id' => 555,
+    ]);
+
+    expect($row->fresh()->body)->toBe('handle the empty state')
+        ->and($row->task->id)->toBe($task->id);
+});

--- a/tests/Feature/TwoWayFeedback/FollowUpPromptTest.php
+++ b/tests/Feature/TwoWayFeedback/FollowUpPromptTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\YakPromptBuilder;
+
+test('followUpPrompt embeds the instructions and frames the PR as already open', function () {
+    $prompt = YakPromptBuilder::followUpPrompt('Handle the empty-state when there are no rows');
+
+    expect($prompt)->toContain('Handle the empty-state when there are no rows')
+        ->and($prompt)->toContain('already open')
+        ->and($prompt)->toContain('same branch');
+});

--- a/tests/Feature/TwoWayFeedback/FollowUpTaskFactoryTest.php
+++ b/tests/Feature/TwoWayFeedback/FollowUpTaskFactoryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Jobs\RunFollowUpJob;
+use App\Models\YakTask;
+use App\Services\FollowUpTaskFactory;
+use Illuminate\Support\Facades\Queue;
+
+test('creates a chained task copying branch/session/PR and dispatches RunFollowUpJob', function () {
+    Queue::fake();
+
+    $parent = YakTask::factory()->success()->create([
+        'source' => 'linear',
+        'repo' => 'web',
+        'branch_name' => 'yak/CSV-1',
+        'session_id' => 'sess_parent',
+        'pr_url' => 'https://github.com/acme/web/pull/9',
+        'pr_number' => 9,
+        'linear_agent_session_id' => 'agent-sess-1',
+        'external_id' => 'LINEAR-ENG-42',
+    ]);
+
+    $child = app(FollowUpTaskFactory::class)->create($parent, 'Handle the empty-state', 'dashboard');
+
+    expect($child)->not->toBeNull()
+        ->and($child->parent_task_id)->toBe($parent->id)
+        ->and($child->branch_name)->toBe('yak/CSV-1')
+        ->and($child->session_id)->toBe('sess_parent')
+        ->and($child->pr_url)->toBe('https://github.com/acme/web/pull/9')
+        ->and($child->pr_number)->toBe(9)
+        ->and($child->repo)->toBe('web')
+        ->and($child->source)->toBe('dashboard')
+        ->and($child->linear_agent_session_id)->toBe('agent-sess-1')
+        ->and($child->description)->toBe('Handle the empty-state')
+        ->and($child->status->value)->toBe('pending');
+
+    Queue::assertPushed(RunFollowUpJob::class, fn (RunFollowUpJob $job) => $job->task->id === $child->id);
+});
+
+test('returns null and dispatches nothing when the PR is merged or closed', function () {
+    Queue::fake();
+
+    $merged = YakTask::factory()->merged()->create(['branch_name' => 'yak/M-1']);
+    $closed = YakTask::factory()->closedWithoutMerge()->create(['branch_name' => 'yak/C-1']);
+
+    expect(app(FollowUpTaskFactory::class)->create($merged, 'too late', 'dashboard'))->toBeNull()
+        ->and(app(FollowUpTaskFactory::class)->create($closed, 'too late', 'dashboard'))->toBeNull();
+
+    Queue::assertNothingPushed();
+});
+
+test('chains onto the newest task in the conversation', function () {
+    Queue::fake();
+
+    $root = YakTask::factory()->success()->create(['branch_name' => 'yak/CHAIN-9', 'session_id' => 's0']);
+    $head = YakTask::factory()->create([
+        'parent_task_id' => $root->id,
+        'branch_name' => 'yak/CHAIN-9',
+        'session_id' => 's1',
+        'pr_url' => $root->pr_url,
+        'created_at' => now()->addMinute(),
+    ]);
+
+    $child = app(FollowUpTaskFactory::class)->create($root, 'next', 'dashboard');
+
+    expect($child->parent_task_id)->toBe($head->id);
+});

--- a/tests/Feature/TwoWayFeedback/FollowUpTaskFactoryTest.php
+++ b/tests/Feature/TwoWayFeedback/FollowUpTaskFactoryTest.php
@@ -64,3 +64,28 @@ test('chains onto the newest task in the conversation', function () {
 
     expect($child->parent_task_id)->toBe($head->id);
 });
+
+test('first follow-up external_id is rooted and not compounding', function () {
+    Queue::fake();
+
+    $root = YakTask::factory()->success()->create(['external_id' => 'LINEAR-ENG-42', 'branch_name' => 'yak/E-1']);
+
+    $child = app(FollowUpTaskFactory::class)->create($root, 'do it', 'dashboard');
+
+    expect($child->external_id)->toStartWith('LINEAR-ENG-42-followup-')
+        ->and(substr_count($child->external_id, '-followup-'))->toBe(1);
+});
+
+test('chaining off an existing follow-up does not compound the external_id', function () {
+    Queue::fake();
+
+    $root = YakTask::factory()->success()->create(['external_id' => 'LINEAR-ENG-42', 'branch_name' => 'yak/E-2']);
+    $followUp = app(FollowUpTaskFactory::class)->create($root, 'first', 'dashboard');
+
+    // Now chain off the follow-up itself (passing the follow-up, not the root).
+    $second = app(FollowUpTaskFactory::class)->create($followUp, 'second', 'dashboard');
+
+    expect($second->external_id)->toStartWith('LINEAR-ENG-42-followup-')
+        ->and(substr_count($second->external_id, '-followup-'))->toBe(1)
+        ->and($second->parent_task_id)->toBe($followUp->id);
+});

--- a/tests/Feature/TwoWayFeedback/MigrationColumnsTest.php
+++ b/tests/Feature/TwoWayFeedback/MigrationColumnsTest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+
+test('tasks table has parent_task_id and pr_number columns', function () {
+    expect(Schema::hasColumn('tasks', 'parent_task_id'))->toBeTrue()
+        ->and(Schema::hasColumn('tasks', 'pr_number'))->toBeTrue();
+});

--- a/tests/Feature/TwoWayFeedback/PreventBranchOverlapTest.php
+++ b/tests/Feature/TwoWayFeedback/PreventBranchOverlapTest.php
@@ -19,3 +19,12 @@ test('RunFollowUpJob is guarded by PreventBranchOverlap', function () {
 
     expect($classes)->toContain(PreventBranchOverlap::class);
 });
+
+test('PreventBranchOverlap falls back to task id when branch is null and configures TTLs', function () {
+    $task = YakTask::factory()->create(['repo' => 'web', 'branch_name' => null]);
+    $mw = new PreventBranchOverlap($task);
+
+    expect($mw->key)->toBe('web:task-' . $task->id)
+        ->and($mw->releaseAfter)->toBe(30)
+        ->and($mw->expiresAfter)->toBe(4200);
+});

--- a/tests/Feature/TwoWayFeedback/PreventBranchOverlapTest.php
+++ b/tests/Feature/TwoWayFeedback/PreventBranchOverlapTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Jobs\Middleware\PreventBranchOverlap;
+use App\Jobs\RunFollowUpJob;
+use App\Models\YakTask;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+
+test('PreventBranchOverlap keys on repo and branch', function () {
+    $task = YakTask::factory()->make(['repo' => 'web', 'branch_name' => 'yak/CSV-1']);
+    $mw = new PreventBranchOverlap($task);
+
+    expect($mw)->toBeInstanceOf(WithoutOverlapping::class)
+        ->and($mw->key)->toBe('web:yak/CSV-1');
+});
+
+test('RunFollowUpJob is guarded by PreventBranchOverlap', function () {
+    $task = YakTask::factory()->make(['repo' => 'web', 'branch_name' => 'yak/CSV-1']);
+    $classes = array_map(fn ($m) => $m::class, (new RunFollowUpJob($task))->middleware());
+
+    expect($classes)->toContain(PreventBranchOverlap::class);
+});

--- a/tests/Feature/TwoWayFeedback/PreventBranchOverlapTest.php
+++ b/tests/Feature/TwoWayFeedback/PreventBranchOverlapTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Jobs\ClarificationReplyJob;
 use App\Jobs\Middleware\PreventBranchOverlap;
+use App\Jobs\RetryYakJob;
 use App\Jobs\RunFollowUpJob;
 use App\Models\YakTask;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
@@ -27,4 +29,36 @@ test('PreventBranchOverlap falls back to task id when branch is null and configu
     expect($mw->key)->toBe('web:task-' . $task->id)
         ->and($mw->releaseAfter)->toBe(30)
         ->and($mw->expiresAfter)->toBe(4200);
+});
+
+test('ClarificationReplyJob is guarded by PreventBranchOverlap', function () {
+    $task = YakTask::factory()->make(['repo' => 'web', 'branch_name' => 'yak/CSV-1']);
+    $classes = array_map(fn ($m) => $m::class, (new ClarificationReplyJob($task, 'go with option 1'))->middleware());
+
+    expect($classes)->toContain(PreventBranchOverlap::class);
+});
+
+test('RetryYakJob is guarded by PreventBranchOverlap', function () {
+    $task = YakTask::factory()->make(['repo' => 'web', 'branch_name' => 'yak/CSV-1']);
+    $classes = array_map(fn ($m) => $m::class, (new RetryYakJob($task))->middleware());
+
+    expect($classes)->toContain(PreventBranchOverlap::class);
+});
+
+test('ClarificationReplyJob PreventBranchOverlap keys on the branch name', function () {
+    $task = YakTask::factory()->make(['repo' => 'acme/app', 'branch_name' => 'yak/ISSUE-42']);
+    $middleware = (new ClarificationReplyJob($task, 'use approach A'))->middleware();
+    $overlap = collect($middleware)->first(fn ($m) => $m instanceof PreventBranchOverlap);
+
+    expect($overlap)->not->toBeNull()
+        ->and($overlap->key)->toBe('acme/app:yak/ISSUE-42');
+});
+
+test('RetryYakJob PreventBranchOverlap keys on the branch name', function () {
+    $task = YakTask::factory()->make(['repo' => 'acme/app', 'branch_name' => 'yak/ISSUE-42']);
+    $middleware = (new RetryYakJob($task))->middleware();
+    $overlap = collect($middleware)->first(fn ($m) => $m instanceof PreventBranchOverlap);
+
+    expect($overlap)->not->toBeNull()
+        ->and($overlap->key)->toBe('acme/app:yak/ISSUE-42');
 });

--- a/tests/Feature/TwoWayFeedback/RunFollowUpJobTest.php
+++ b/tests/Feature/TwoWayFeedback/RunFollowUpJobTest.php
@@ -3,12 +3,15 @@
 use App\Contracts\AgentRunner;
 use App\DataTransferObjects\AgentRunResult;
 use App\Enums\TaskStatus;
+use App\Jobs\ProcessCIResultJob;
 use App\Jobs\RunFollowUpJob;
+use App\Jobs\SendNotificationJob;
 use App\Models\Repository;
 use App\Models\YakTask;
 use App\Services\IncusSandboxManager;
 use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Queue;
 use Tests\Support\FakeAgentRunner;
 use Tests\Support\FakeSandboxManager;
 
@@ -117,4 +120,48 @@ test('RunFollowUpJob dispatches to the yak-claude queue', function () {
     $task = YakTask::factory()->make(['branch_name' => 'yak/Q-1']);
 
     expect((new RunFollowUpJob($task))->queue)->toBe('yak-claude');
+});
+
+test('RunFollowUpJob with ci_system=none dispatches ProcessCIResultJob instead of waiting for CI', function () {
+    Queue::fake();
+
+    $fake = (new FakeAgentRunner)->queueResult(fakeFollowUpResult());
+    $this->app->instance(AgentRunner::class, $fake);
+    $this->app->instance(IncusSandboxManager::class, new FakeSandboxManager);
+    Process::fake(['*git rev-parse *' => Process::result(output: 'yak/NOCI-1'), '*' => Process::result('')]);
+
+    Repository::factory()->create(['slug' => 'noci-repo', 'path' => '/home/yak/repos/noci-repo', 'ci_system' => 'none']);
+    $task = YakTask::factory()->create([
+        'status' => TaskStatus::Pending,
+        'repo' => 'noci-repo',
+        'session_id' => 'sess_parent',
+        'branch_name' => 'yak/NOCI-1',
+        'pr_url' => 'https://github.com/acme/noci-repo/pull/5',
+        'description' => 'tweak',
+    ]);
+
+    (new RunFollowUpJob($task))->handle($fake);
+
+    Queue::assertPushed(ProcessCIResultJob::class, fn (ProcessCIResultJob $job) => $job->task->id === $task->id);
+    Queue::assertNotPushed(SendNotificationJob::class, fn ($job) => str_contains((string) ($job->message ?? ''), 'waiting for CI'));
+});
+
+test('RunFollowUpJob fails when the task has no branch', function () {
+    $fake = (new FakeAgentRunner)->queueResult(fakeFollowUpResult());
+    $this->app->instance(AgentRunner::class, $fake);
+    $this->app->instance(IncusSandboxManager::class, new FakeSandboxManager);
+    Process::fake(['*' => Process::result('')]);
+
+    Repository::factory()->create(['slug' => 'nobranch-repo', 'path' => '/home/yak/repos/nobranch-repo']);
+    $task = YakTask::factory()->create([
+        'status' => TaskStatus::Pending,
+        'repo' => 'nobranch-repo',
+        'branch_name' => null,
+        'pr_url' => 'https://github.com/acme/nobranch-repo/pull/1',
+        'description' => 'tweak',
+    ]);
+
+    (new RunFollowUpJob($task))->handle($fake);
+
+    expect($task->fresh()->status)->toBe(TaskStatus::Failed);
 });

--- a/tests/Feature/TwoWayFeedback/RunFollowUpJobTest.php
+++ b/tests/Feature/TwoWayFeedback/RunFollowUpJobTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Contracts\AgentRunner;
+use App\DataTransferObjects\AgentRunResult;
+use App\Enums\TaskStatus;
+use App\Jobs\RunFollowUpJob;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\IncusSandboxManager;
+use Illuminate\Contracts\Process\ProcessResult;
+use Illuminate\Support\Facades\Process;
+use Tests\Support\FakeAgentRunner;
+use Tests\Support\FakeSandboxManager;
+
+function fakeFollowUpResult(string $sessionId = 'sess_followup'): AgentRunResult
+{
+    return new AgentRunResult(
+        sessionId: $sessionId,
+        resultSummary: 'Addressed the feedback',
+        costUsd: 0.50,
+        numTurns: 4,
+        durationMs: 20000,
+        isError: false,
+        clarificationNeeded: false,
+        clarificationOptions: [],
+        rawOutput: '{}',
+    );
+}
+
+test('RunFollowUpJob resumes the session, force-pushes the existing branch, and parks at awaiting_ci', function () {
+    $fake = (new FakeAgentRunner)->queueResult(fakeFollowUpResult());
+    $this->app->instance(AgentRunner::class, $fake);
+
+    $pushed = false;
+    $recorder = new class($pushed) extends FakeSandboxManager
+    {
+        public function __construct(public bool &$pushed) {}
+
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null, ?callable $output = null): ProcessResult
+        {
+            if (str_contains($command, 'git rev-parse --abbrev-ref HEAD')) {
+                return Process::result('yak/CSV-1');
+            }
+
+            if (str_contains($command, 'git push --force-with-lease')) {
+                $this->pushed = true;
+
+                return Process::result('');
+            }
+
+            return parent::run($containerName, $command, $timeout, $asRoot);
+        }
+    };
+    $this->app->instance(IncusSandboxManager::class, $recorder);
+
+    Process::fake(['*' => Process::result('')]);
+
+    Repository::factory()->create(['slug' => 'fu-repo', 'path' => '/home/yak/repos/fu-repo']);
+    $task = YakTask::factory()->create([
+        'status' => TaskStatus::Pending,
+        'repo' => 'fu-repo',
+        'session_id' => 'sess_parent',
+        'branch_name' => 'yak/CSV-1',
+        'pr_url' => 'https://github.com/acme/fu-repo/pull/9',
+        'pr_number' => 9,
+        'description' => 'Also handle the empty-state',
+    ]);
+
+    (new RunFollowUpJob($task))->handle($fake);
+
+    $task->refresh();
+
+    expect($task->status)->toBe(TaskStatus::AwaitingCi)
+        ->and($task->session_id)->toBe('sess_followup')
+        ->and($task->result_summary)->toBe('Addressed the feedback')
+        ->and($pushed)->toBeTrue()
+        ->and($fake->lastCall()->resumeSessionId)->toBe('sess_parent')
+        ->and($fake->lastCall()->prompt)->toContain('Also handle the empty-state');
+});
+
+test('RunFollowUpJob never creates a new branch', function () {
+    $fake = (new FakeAgentRunner)->queueResult(fakeFollowUpResult());
+    $this->app->instance(AgentRunner::class, $fake);
+
+    $recorder = new class extends FakeSandboxManager
+    {
+        /** @var array<int, string> */
+        public array $commands = [];
+
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null, ?callable $output = null): ProcessResult
+        {
+            $this->commands[] = $command;
+
+            return parent::run($containerName, $command, $timeout, $asRoot);
+        }
+    };
+    $this->app->instance(IncusSandboxManager::class, $recorder);
+    Process::fake(['*git rev-parse *' => Process::result(output: 'yak/CSV-2'), '*' => Process::result('')]);
+
+    Repository::factory()->create(['slug' => 'nb-repo', 'path' => '/home/yak/repos/nb-repo']);
+    $task = YakTask::factory()->create([
+        'status' => TaskStatus::Pending,
+        'repo' => 'nb-repo',
+        'session_id' => 'sess_parent',
+        'branch_name' => 'yak/CSV-2',
+        'pr_url' => 'https://github.com/acme/nb-repo/pull/3',
+        'description' => 'tweak',
+    ]);
+
+    (new RunFollowUpJob($task))->handle($fake);
+
+    $createdBranch = array_filter($recorder->commands, fn (string $c) => str_contains($c, 'checkout -b'));
+    expect($createdBranch)->toBeEmpty();
+});
+
+test('RunFollowUpJob dispatches to the yak-claude queue', function () {
+    $task = YakTask::factory()->make(['branch_name' => 'yak/Q-1']);
+
+    expect((new RunFollowUpJob($task))->queue)->toBe('yak-claude');
+});

--- a/tests/Feature/TwoWayFeedback/YakTaskConversationTest.php
+++ b/tests/Feature/TwoWayFeedback/YakTaskConversationTest.php
@@ -28,3 +28,9 @@ test('conversation returns the full chain ordered by created_at', function () {
         ->and($root->followUps()->pluck('id')->all())->toBe([$child->id])
         ->and($child->parent->id)->toBe($root->id);
 });
+
+test('conversation on a lone task returns just itself', function () {
+    $solo = YakTask::factory()->success()->create(['branch_name' => 'yak/SOLO-1']);
+
+    expect($solo->conversation()->pluck('id')->all())->toBe([$solo->id]);
+});

--- a/tests/Feature/TwoWayFeedback/YakTaskConversationTest.php
+++ b/tests/Feature/TwoWayFeedback/YakTaskConversationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\YakTask;
+
+test('prIsOpen reflects PR lifecycle', function () {
+    expect(YakTask::factory()->success()->create()->prIsOpen())->toBeTrue()
+        ->and(YakTask::factory()->merged()->create()->prIsOpen())->toBeFalse()
+        ->and(YakTask::factory()->closedWithoutMerge()->create()->prIsOpen())->toBeFalse()
+        ->and(YakTask::factory()->pending()->create(['pr_url' => null])->prIsOpen())->toBeFalse();
+});
+
+test('conversation returns the full chain ordered by created_at', function () {
+    $root = YakTask::factory()->success()->create(['branch_name' => 'yak/CHAIN-1']);
+    $child = YakTask::factory()->create([
+        'parent_task_id' => $root->id,
+        'branch_name' => 'yak/CHAIN-1',
+        'created_at' => now()->addMinute(),
+    ]);
+    $grandchild = YakTask::factory()->create([
+        'parent_task_id' => $child->id,
+        'branch_name' => 'yak/CHAIN-1',
+        'created_at' => now()->addMinutes(2),
+    ]);
+
+    $ids = $child->conversation()->pluck('id')->all();
+
+    expect($ids)->toBe([$root->id, $child->id, $grandchild->id])
+        ->and($root->followUps()->pluck('id')->all())->toBe([$child->id])
+        ->and($child->parent->id)->toBe($root->id);
+});

--- a/tests/Unit/GitOperationsHasUncommittedChangesTest.php
+++ b/tests/Unit/GitOperationsHasUncommittedChangesTest.php
@@ -13,7 +13,7 @@ function fakeSandboxReturningPorcelain(string $stdout, int $exit = 0): IncusSand
 
         public function __construct(private string $stdout, private int $exit) {}
 
-        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null): ProcessResult
+        public function run(string $containerName, string $command, ?int $timeout = null, bool $asRoot = false, ?string $input = null, ?callable $output = null): ProcessResult
         {
             $this->lastCommand = $command;
 


### PR DESCRIPTION
## Summary

Two-way communication so a human can keep talking to Yak and have it push more commits to the **same open PR** until the work is done — on every surface (dashboard, GitHub, Slack, Linear) — without checking out the branch. Built as 5 sequenced plans; all on this branch.

### Plan 1 — Follow-up engine (foundation)
- `parent_task_id` + `pr_number` on `tasks`; `YakTask` relations + `prIsOpen()` + `conversation()`.
- `FollowUpTaskFactory` (chained task, guards merged/closed, root-based collision-free `external_id`, transaction + `afterCommit`).
- `RunFollowUpJob` (resumes the Claude session, reuses the branch, force-pushes) via an extracted `ResumesAgentOnExistingBranch` trait (shared with `ClarificationReplyJob`, behavior preserved).
- `PreventBranchOverlap` middleware (lock TTL outlasts job timeout).
- `CreatePullRequestJob` made idempotent (detects an existing PR → comments instead of 422) + stores `pr_number`.

### Plan 2 — Dashboard
- Conversation panel + follow-up composer on the task detail page (activity-style rows).
- Nested task list (follow-up chains under their root, full descendant chain, tab counts exclude children).
- Right-side slideover (custom Alpine; Flux free has no modal) to start brand-new `source = dashboard` tasks (Fix/Research).

### Plan 3 — GitHub
- `issue_comment` + `pull_request_review_comment` handlers; a `/yak …` comment (prefix-gated) is 👀-reacted, buffered, and debounced (60s) into one follow-up via `FlushFollowUpBatchJob`.
- `FollowUpCommentParser`, `follow_up_pending_comments` buffer, `AppService::addReaction`.
- Chain-wide PR lifecycle fix: merge/close stamps the whole follow-up chain.

### Plan 4 — Slack
- Thread replies on a PR-bearing task become follow-ups (bot messages skipped; merged/closed declines in-thread).

### Plan 5 — Linear (rock-solid agent coverage)
- State-aware `prompted` routing: `stop` → cancel; `AwaitingClarification` → clarification reply (finally activates elicitation on Linear); open PR → follow-up; else decline; + 10s `thought` ack.
- Webhook hardening: `webhookTimestamp` freshness + `Linear-Delivery` idempotency.
- Move issue to a configured **started** state on pickup; emit `action` activities for milestones; `InboxNotificationEvent` (unassignment cancels in-flight work; reactions handled).

## Notes for reviewers
- A background security review flagged a LIKE-wildcard-injection in the Linear inbox handler; fixed (id validation + escaping). Workspace-scoping (IDOR) is mitigated by globally-unique issue UUIDs + the connection gate; a column-scoped filter is noted as a future hardening.
- **Manual prerequisites** before this goes live: subscribe the GitHub App to `issue_comment` + `pull_request_review_comment`, and the Linear app to `InboxNotificationEvent`; optionally set `YAK_LINEAR_STARTED_STATE_ID`.
- Open item: confirm the Linear `prompted` + `InboxNotificationEvent` payload field shapes against real deliveries (handlers are defensive; tests encode best-understanding).

## Test plan
- [x] 835 passing across all touched areas (Linear, GitHub, Slack, dashboard/Livewire, follow-up engine, CI/PR) — `php -d memory_limit=1536M vendor/bin/pest --filter="Linear|TwoWayFeedback|GitHub|Slack|...|Deployment"`.
- [x] Each task built TDD-first with spec + code-quality review; regressions from the idempotency GET caught and fixed in `CreatePullRequestJobTest`, `ProcessCIResultJobTest`, `PRMergeTrackingTest`.
- [x] Pint clean.
- [ ] Note: the full unfiltered suite OOMs at PHP's 128M default (pre-existing, reproduces on main) — run filtered or raise `memory_limit`.