### PR TITLE
fix(docker): run scheduler and workers as www-data, not root

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -38,6 +38,7 @@ stopwaitsecs=3610
 [program:default-worker]
 process_name=%(program_name)s_%(process_num)02d
 command=php /app/artisan queue:work database --queue=default --timeout=30 --memory=256 --tries=3 --sleep=3
+user=www-data
 autostart=true
 autorestart=true
 stopasgroup=true
@@ -49,6 +50,7 @@ stopwaitsecs=40
 [program:yak-render-worker]
 process_name=%(program_name)s_%(process_num)02d
 command=php /app/artisan queue:work database --queue=yak-render --timeout=900 --memory=2048 --tries=2 --sleep=3
+user=www-data
 autostart=true
 autorestart=true
 stopasgroup=true
@@ -72,7 +74,15 @@ stderr_logfile=/app/storage/logs/yak-deployments-worker-error.log
 stopwaitsecs=910
 
 [program:scheduler]
+# Must run as www-data, not root. `yak:healthcheck` drives the Claude CLI
+# (ClaudeAuthCheck) against the shared CLAUDE_CONFIG_DIR that the workers use
+# as www-data. A root-run CLI leaves root-owned artifacts in that directory —
+# notably `.oauth_refresh.lock`, the mkdir-based mutex guarding OAuth token
+# refresh. A stale root-owned lock blocks every subsequent www-data refresh,
+# so the ~8h access token simply expires and every task 401s until someone
+# logs in interactively (Aug 2026).
 command=bash -c "while true; do php /app/artisan schedule:run --no-interaction >> /app/storage/logs/scheduler.log 2>&1; sleep 60; done"
+user=www-data
 autostart=true
 autorestart=true
 stdout_logfile=/app/storage/logs/scheduler.log

--- a/tests/Feature/QueueConfigurationTest.php
+++ b/tests/Feature/QueueConfigurationTest.php
@@ -181,3 +181,90 @@ test('supervisord config has default worker with correct settings', function () 
         ->toContain('--timeout=30')
         ->toContain('numprocs=3');
 });
+
+/*
+|--------------------------------------------------------------------------
+| Production Supervisord Configuration
+|--------------------------------------------------------------------------
+|
+| docker/supervisord.conf is the file that actually ships — Dockerfile
+| copies it to /etc/supervisor/conf.d/yak.conf and runs it as the CMD.
+| (base_path('supervisord.conf') above is a local-dev leftover.)
+|
+*/
+
+/**
+ * Parse docker/supervisord.conf into [program name => [directive => value]].
+ *
+ * @return array<string, array<string, string>>
+ */
+function productionSupervisordPrograms(): array
+{
+    $path = base_path('docker/supervisord.conf');
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+    if ($lines === false) {
+        throw new RuntimeException("Unable to read {$path}");
+    }
+
+    $programs = [];
+    $current = null;
+
+    foreach ($lines as $line) {
+        $line = trim($line);
+
+        if (str_starts_with($line, '#') || str_starts_with($line, ';')) {
+            continue;
+        }
+
+        if (preg_match('/^\[program:(.+)\]$/', $line, $matches) === 1) {
+            $current = $matches[1];
+            $programs[$current] = [];
+
+            continue;
+        }
+
+        if (str_starts_with($line, '[')) {
+            $current = null;
+
+            continue;
+        }
+
+        if ($current !== null && str_contains($line, '=')) {
+            [$key, $value] = explode('=', $line, 2);
+            $programs[$current][trim($key)] = trim($value);
+        }
+    }
+
+    return $programs;
+}
+
+test('every supervisord program that runs artisan runs as www-data', function () {
+    // supervisord itself runs as root, so a program with no `user=` inherits
+    // root. Any program that drives the Laravel app must drop to www-data:
+    // /data, /app/storage and the shared CLAUDE_CONFIG_DIR are all www-data
+    // owned, and root-owned files landing there lock www-data out.
+    $programs = productionSupervisordPrograms();
+
+    $artisanPrograms = array_filter(
+        $programs,
+        fn (array $directives): bool => str_contains($directives['command'] ?? '', 'artisan'),
+    );
+
+    expect($artisanPrograms)->not->toBeEmpty();
+
+    foreach ($artisanPrograms as $name => $directives) {
+        expect($directives['user'] ?? null)->toBe('www-data', "[program:{$name}] must declare user=www-data");
+    }
+});
+
+test('scheduler runs as www-data so healthchecks cannot leave root-owned claude state', function () {
+    // yak:healthcheck runs every 15 minutes and shells the Claude CLI out
+    // against /home/yak/.claude (ClaudeAuthCheck). As root it leaves a
+    // root-owned .oauth_refresh.lock behind, which blocks every subsequent
+    // www-data OAuth refresh until someone re-authenticates by hand.
+    $programs = productionSupervisordPrograms();
+
+    expect($programs)->toHaveKey('scheduler');
+    expect($programs['scheduler']['user'] ?? null)->toBe('www-data');
+});


### PR DESCRIPTION
## Summary

Three supervisord programs declared no `user=` and so inherited `user=root` from the `[supervisord]` section. For the scheduler this broke Claude authentication roughly every eight hours, requiring a manual `claude login` on the box to recover.

The scheduler runs `yak:healthcheck` every 15 minutes, which shells the Claude CLI out through `ClaudeAuthCheck` against the shared `CLAUDE_CONFIG_DIR` at `/home/yak/.claude` -- a directory every other process uses as www-data. Running the CLI as root leaves root-owned artifacts in it, most damagingly `.oauth_refresh.lock`, the mkdir-based mutex guarding OAuth token refresh. With a stale root-owned lock present, no www-data process can acquire it, the refresh never runs, and the ~8h access token expires. Tasks then fail with `401 OAuth access token has expired`.

Confirmed on the Geocodio instance: a root-owned `.oauth_refresh.lock` created at 06:45, a token that had expired at 02:30, and a `.credentials.json` untouched since the previous evening's manual login. Removing the lock let the refresh succeed immediately, with no re-authentication needed -- the credentials were never actually the problem.

## Changes

**`docker/supervisord.conf`**

- `user=www-data` on `[program:scheduler]`, with a comment recording why it must not run as root
- `user=www-data` on `[program:default-worker]` and `[program:yak-render-worker]`, which had the same latent defect and write into www-data-owned trees (`/data`, `/app/storage`)
- `php-fpm` and `nginx` deliberately stay as root; their masters need to bind and fork workers

**`tests/Feature/QueueConfigurationTest.php`**

- `every supervisord program that runs artisan runs as www-data` -- parses the shipped config, filters to programs whose `command` contains `artisan`, and asserts each declares `user=www-data`. Catches any future worker added without a `user=` line; the artisan filter is what correctly exempts php-fpm and nginx.
- `scheduler runs as www-data so healthchecks cannot leave root-owned claude state` -- names the specific regression so a failure points straight at the cause.

Both target `docker/supervisord.conf`, the file the Dockerfile actually copies to `/etc/supervisor/conf.d/yak.conf`. The pre-existing supervisord tests in this file read the root-level `supervisord.conf`, a local-dev leftover that never ships and whose assertions (`--timeout=600`, `numprocs=1`) contradict the shipped config. Left alone here as separate cleanup.

Verified by reverting the scheduler fix: both new tests fail, then pass on restore.