### PR TITLE
fix(setup): survive heavy repos that need more than an hour

### DIFF
--- a/app/Jobs/RunYakJob.php
+++ b/app/Jobs/RunYakJob.php
@@ -37,7 +37,8 @@ class RunYakJob implements ShouldQueue
     // or long tool calls regularly exceed 10 minutes. Laravel enforces
     // this via pcntl_alarm → posix_kill(getmypid(), SIGKILL), so setting
     // it too low silently murders the worker mid-stream and leaves the
-    // sandbox + reserved job orphaned. 3600s matches SetupYakJob's budget.
+    // sandbox + reserved job orphaned. (SetupYakJob gets a higher budget
+    // because heavy repos can take over an hour to build from scratch.)
     public int $timeout = 3600;
 
     /** @var array<int, int> */

--- a/app/Jobs/SetupYakJob.php
+++ b/app/Jobs/SetupYakJob.php
@@ -26,10 +26,21 @@ use Illuminate\Support\Facades\Log;
 
 class SetupYakJob implements ShouldQueue
 {
-    use HandlesAgentJobFailure;
+    use HandlesAgentJobFailure {
+        failed as handleAgentJobFailure;
+    }
     use Queueable;
 
-    public int $timeout = 3600;
+    // Setup on heavy repos legitimately exceeds an hour: local docker image
+    // builds, composer/npm installs, migrations, and verification. Task 5431
+    // (Geocodio/geocodio) finished the setup twice and was hard-killed during
+    // final wrap-up at exactly 3600s both times.
+    public int $timeout = 7200;
+
+    // Seconds reserved between the agent's own deadline and the worker's
+    // pcntl hard kill, so the agent can wind down and report a result
+    // instead of being SIGKILLed mid-stream.
+    private const AGENT_SHUTDOWN_BUFFER_SECONDS = 180;
 
     // A failed setup rarely succeeds on retry without manual intervention,
     // and each retry burns another agent budget. Fail fast; users can
@@ -51,6 +62,22 @@ class SetupYakJob implements ShouldQueue
             new PausesDuringDrain,
             new EnsureDailyBudget,
         ];
+    }
+
+    /**
+     * The worker's hard kill (timeout, crash) lands here without ever
+     * reaching handleError(), which normally resets setup_status — so the
+     * repo would show 'running' forever. Only downgrade when the task
+     * actually failed: failed() can also fire after a successful run if a
+     * post-success cleanup step blew up, and a promoted template is ready.
+     */
+    public function failed(?\Throwable $e): void
+    {
+        $this->handleAgentJobFailure($e);
+
+        if ($this->task->fresh()?->status === TaskStatus::Failed) {
+            Repository::where('slug', $this->task->repo)->first()?->update(['setup_status' => 'failed']);
+        }
     }
 
     public function handle(AgentRunner $agent): void
@@ -106,7 +133,7 @@ class SetupYakJob implements ShouldQueue
                 prompt: YakPromptBuilder::setupPrompt($repository->name),
                 systemPrompt: YakPromptBuilder::systemPrompt($this->task),
                 containerName: $containerName,
-                timeoutSeconds: $this->timeout - 30,
+                timeoutSeconds: $this->agentTimeoutSeconds(),
                 maxBudgetUsd: (float) config('yak.max_budget_per_task'),
                 maxTurns: (int) config('yak.max_turns'),
                 model: (string) config('yak.default_model'),
@@ -147,6 +174,21 @@ class SetupYakJob implements ShouldQueue
                 $sandbox->destroy($containerName);
             }
         }
+    }
+
+    /**
+     * Agent budget = job timeout minus time already spent (template
+     * invalidation, sandbox create, clone) minus a shutdown buffer.
+     * A fixed "$timeout - 30" ignored the pre-agent work, so the agent's
+     * graceful deadline landed at the same instant as the worker's pcntl
+     * hard kill — and the hard kill won, discarding the whole run.
+     */
+    private function agentTimeoutSeconds(): int
+    {
+        $startedAt = $this->task->started_at ?? now();
+        $elapsed = (int) $startedAt->diffInSeconds(now());
+
+        return max(60, $this->timeout - $elapsed - self::AGENT_SHUTDOWN_BUFFER_SECONDS);
     }
 
     private function cloneRepoInSandbox(IncusSandboxManager $sandbox, string $containerName, Repository $repository): void

--- a/config/queue.php
+++ b/config/queue.php
@@ -40,11 +40,11 @@ return [
             'connection' => env('DB_QUEUE_CONNECTION'),
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
-            // Must exceed every job's `$timeout` (longest is SetupYakJob at 3600s).
+            // Must exceed every job's `$timeout` (longest is SetupYakJob at 7200s).
             // Otherwise the queue re-reserves a still-running job, records it in
             // failed_jobs via MaxAttemptsExceededException, then the original
             // worker's timeout handler hits a duplicate UUID on insert.
-            'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 4200),
+            'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 7800),
             'after_commit' => false,
         ],
 

--- a/tests/Feature/Jobs/HandlesAgentJobFailureTest.php
+++ b/tests/Feature/Jobs/HandlesAgentJobFailureTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\NotificationType;
+use App\Enums\TaskMode;
 use App\Enums\TaskStatus;
 use App\Jobs\SendNotificationJob;
 use App\Jobs\SetupYakJob;
@@ -81,6 +82,46 @@ it('does not dispatch a failure notification for system-source tasks', function 
     $job->failed(new RuntimeException('boom'));
 
     Queue::assertNotPushed(SendNotificationJob::class);
+});
+
+it('marks the repository setup_status failed when a setup job dies on timeout', function () {
+    // The worker's hard kill lands in failed(), which never went through
+    // handleError() — without this, setup_status stays 'running' forever
+    // (repo Geocodio/geocodio got stuck this way after task 5431 timed out).
+    $repository = Repository::factory()->create([
+        'slug' => 'acme/widgets',
+        'setup_status' => 'running',
+    ]);
+    $task = YakTask::factory()->create([
+        'repo' => 'acme/widgets',
+        'mode' => TaskMode::Setup,
+        'status' => TaskStatus::Running,
+    ]);
+
+    $job = new SetupYakJob($task);
+    $job->failed(new RuntimeException('App\Jobs\SetupYakJob has timed out.'));
+
+    expect($repository->refresh()->setup_status)->toBe('failed');
+});
+
+it('does not downgrade repository setup_status when the task already succeeded', function () {
+    // failed() can fire after a successful run if only post-success cleanup
+    // blew up; a promoted, ready template must not be re-marked failed.
+    $repository = Repository::factory()->create([
+        'slug' => 'acme/widgets',
+        'setup_status' => 'ready',
+    ]);
+    $task = YakTask::factory()->create([
+        'repo' => 'acme/widgets',
+        'mode' => TaskMode::Setup,
+        'status' => TaskStatus::Success,
+        'completed_at' => now()->subMinute(),
+    ]);
+
+    $job = new SetupYakJob($task);
+    $job->failed(new RuntimeException('late cleanup failure'));
+
+    expect($repository->refresh()->setup_status)->toBe('ready');
 });
 
 it('does not clobber a task that is already in a terminal state', function () {

--- a/tests/Feature/QueueConfigurationTest.php
+++ b/tests/Feature/QueueConfigurationTest.php
@@ -20,7 +20,7 @@ use App\Models\YakTask;
 */
 
 test('database queue retry_after defaults above the longest job timeout', function () {
-    expect(config('queue.connections.database.retry_after'))->toBe(4200);
+    expect(config('queue.connections.database.retry_after'))->toBe(7800);
 });
 
 /*
@@ -43,7 +43,7 @@ test('yak-claude jobs dispatch to yak-claude queue', function () {
     }
 });
 
-test('per-task yak-claude jobs share SetupYakJob\'s 3600 second timeout', function () {
+test('per-task yak-claude jobs share a 3600 second timeout', function () {
     // Laravel enforces $timeout via pcntl_alarm → posix_kill(getmypid(), SIGKILL).
     // Agent sessions with browser capture regularly exceed 10 minutes; a lower
     // cap silently murders the worker mid-stream (tasks 4406/4407/4408 hit this).
@@ -52,12 +52,21 @@ test('per-task yak-claude jobs share SetupYakJob\'s 3600 second timeout', functi
         new RetryYakJob(YakTask::factory()->retrying()->make()),
         new ResearchYakJob(YakTask::factory()->pending()->make()),
         new ClarificationReplyJob(YakTask::factory()->awaitingClarification()->make(), 'test reply'),
-        new SetupYakJob(YakTask::factory()->pending()->make()),
     ];
 
     foreach ($jobs as $job) {
         expect($job->timeout)->toBe(3600);
     }
+});
+
+test('setup job gets a 7200 second timeout', function () {
+    // Setup on heavy repos (local docker image builds, npm/composer installs,
+    // migrations, verification) legitimately exceeds an hour: task 5431 for
+    // Geocodio/geocodio finished the setup twice and was killed during final
+    // wrap-up at exactly 3600s both times.
+    $job = new SetupYakJob(YakTask::factory()->pending()->make());
+
+    expect($job->timeout)->toBe(7200);
 });
 
 test('per-task yak-claude jobs have exponential backoff', function () {

--- a/tests/Feature/SetupYakJobTest.php
+++ b/tests/Feature/SetupYakJobTest.php
@@ -13,6 +13,7 @@ use App\Models\User;
 use App\Models\YakTask;
 use App\Services\IncusSandboxManager;
 use App\YakPromptBuilder;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Queue;
 use Tests\Support\FakeAgentRunner;
@@ -251,6 +252,49 @@ test('setup increments attempts', function () {
 
     $task->refresh();
     expect($task->attempts)->toBe(1);
+});
+
+test('agent budget is job timeout minus elapsed pre-agent time minus shutdown buffer', function () {
+    // A fixed "$timeout - 30" ignores time spent on sandbox create + clone
+    // before the agent starts, so the agent's graceful deadline lands at the
+    // same instant as the worker's pcntl hard kill — and the hard kill wins,
+    // discarding an otherwise-complete setup.
+    $this->travelTo(now());
+
+    $fake = (new FakeAgentRunner)->queueResult(new AgentRunResult(
+        sessionId: 'sess_budget',
+        resultSummary: 'Done',
+        costUsd: 0.0,
+        numTurns: 1,
+        durationMs: 1000,
+        isError: false,
+        clarificationNeeded: false,
+        clarificationOptions: [],
+        rawOutput: '{}',
+    ));
+    $this->app->instance(AgentRunner::class, $fake);
+
+    // Sandbox creation burns 600s of the job budget before the agent starts.
+    $fakeSandbox = new class extends FakeSandboxManager
+    {
+        public function create(YakTask $task, Repository $repository): string
+        {
+            Carbon::setTestNow(now()->addSeconds(600));
+
+            return parent::create($task, $repository);
+        }
+    };
+    $this->app->instance(IncusSandboxManager::class, $fakeSandbox);
+
+    Process::fake(['*' => Process::result('')]);
+
+    Repository::factory()->create(['slug' => 'slow-repo', 'path' => '/home/yak/repos/slow-repo']);
+    $task = YakTask::factory()->pending()->create(['repo' => 'slow-repo', 'mode' => TaskMode::Setup]);
+
+    (new SetupYakJob($task))->handle($fake);
+
+    // 7200 (job timeout) - 600 (elapsed) - 180 (shutdown buffer)
+    expect($fake->lastCall()->timeoutSeconds)->toBe(6420);
 });
 
 /*


### PR DESCRIPTION
## Summary

Setup for Geocodio/geocodio (task 5431) finished its work twice and was SIGKILLed during final wrap-up at exactly 3600s both times. Heavy repos -- local docker image builds (~15 min alone), composer/npm installs, migrations, verification -- legitimately need more than an hour, so the run was thrown away seconds before completion on every attempt, and the repo was left stuck showing setup as "running".

## Changes

- **`SetupYakJob` timeout 3600s -> 7200s.** Setup runs rarely and `tries = 1`, so the unused ceiling costs nothing, while each timed-out run burns up to an hour of agent budget and discards all work.
- **`DB_QUEUE_RETRY_AFTER` default 4200 -> 7800.** Required companion: `retry_after` must exceed the longest job timeout on the connection, or the database queue re-serves a still-running setup job to a second worker mid-run.
- **Agent budget computed from remaining job time** (`timeout - elapsed - 180s shutdown buffer`) instead of the fixed `timeout - 30`. The old offset ignored pre-agent sandbox create/clone time, so the agent's graceful deadline landed at the same instant as the worker's pcntl hard kill -- and the hard kill won. Now the agent gets to wind down, report a result, and promote the snapshot even when it runs long.
- **`SetupYakJob::failed()` resets the repository's `setup_status` to `failed`.** The hard-kill path bypasses `handleError()`, which previously left the repo stuck on "running" forever. Guarded so a post-success cleanup failure never downgrades a `ready` repo.

Tests cover the new agent-budget computation, both `setup_status` behaviors of `failed()`, and the updated timeout/retry_after invariants.