### PR TITLE
fix(auth): stop orphaned oauth refresh locks from breaking all Claude auth

### DIFF
--- a/app/Services/HealthCheck/ClaudeAuthCheck.php
+++ b/app/Services/HealthCheck/ClaudeAuthCheck.php
@@ -3,6 +3,8 @@
 namespace App\Services\HealthCheck;
 
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
 use Symfony\Component\Process\Exception\ProcessTimedOutException as SymfonyProcessTimedOutException;
 
@@ -17,6 +19,14 @@ use Symfony\Component\Process\Exception\ProcessTimedOutException as SymfonyProce
  */
 class ClaudeAuthCheck implements HealthCheck
 {
+    /**
+     * A .oauth_refresh.lock older than this is an orphan (a real refresh
+     * completes in seconds). Left in place it blocks every subsequent
+     * refresh — on the host and in every sandbox that gets a copy of the
+     * config dir — until someone deletes it by hand.
+     */
+    private const STALE_LOCK_SECONDS = 600;
+
     public function id(): string
     {
         return 'claude-auth';
@@ -41,6 +51,8 @@ class ClaudeAuthCheck implements HealthCheck
             return HealthResult::error("Session token missing at {$sessionFile} — run `docker exec -it yak claude login`");
         }
 
+        $this->sweepStaleOauthRefreshLock($configDir);
+
         $command = sprintf(
             'env HOME=%s CLAUDE_CONFIG_DIR=%s claude auth status',
             escapeshellarg(dirname($configDir)),
@@ -48,7 +60,10 @@ class ClaudeAuthCheck implements HealthCheck
         );
 
         try {
-            $result = Process::timeout(15)->run($command);
+            // 60s, not less: with an expired access token `claude auth status`
+            // performs an OAuth refresh, and killing the CLI mid-refresh
+            // orphans .oauth_refresh.lock (task 5434 got 401s from this).
+            $result = Process::timeout(60)->run($command);
         } catch (ProcessTimedOutException|SymfonyProcessTimedOutException) {
             return HealthResult::error('Timed out');
         }
@@ -58,5 +73,29 @@ class ClaudeAuthCheck implements HealthCheck
         }
 
         return HealthResult::error('Claude session expired — run `docker exec -it yak claude login` to re-authenticate');
+    }
+
+    private function sweepStaleOauthRefreshLock(string $configDir): void
+    {
+        $lockDir = $configDir . '/.oauth_refresh.lock';
+
+        if (! is_dir($lockDir)) {
+            return;
+        }
+
+        $age = time() - (int) filemtime($lockDir);
+
+        // A fresh lock likely belongs to an in-flight refresh; deleting it
+        // could corrupt a rotation about to be persisted.
+        if ($age < self::STALE_LOCK_SECONDS) {
+            return;
+        }
+
+        File::deleteDirectory($lockDir);
+
+        Log::channel('yak')->warning('Swept stale .oauth_refresh.lock', [
+            'lock_dir' => $lockDir,
+            'age_seconds' => $age,
+        ]);
     }
 }

--- a/app/Services/IncusSandboxManager.php
+++ b/app/Services/IncusSandboxManager.php
@@ -719,6 +719,11 @@ class IncusSandboxManager
             ));
         }
 
+        // The recursive push copies everything — including any host-side
+        // .oauth_refresh.lock orphaned by a killed refresh, which would block
+        // the sandbox CLI's own token refresh and 401 the whole run.
+        $this->run($containerName, 'rm -rf /home/yak/.claude/.oauth_refresh.lock', timeout: 10, asRoot: true);
+
         // Fix ownership inside container. `incus file push` lands files as
         // root; chown must run as root to change ownership to yak.
         $this->run($containerName, 'chown -R yak:yak /home/yak/.claude /home/yak/.claude.json 2>/dev/null', timeout: 10, asRoot: true);

--- a/tests/Feature/HealthCheck/SystemChecksTest.php
+++ b/tests/Feature/HealthCheck/SystemChecksTest.php
@@ -54,6 +54,20 @@ it('claude cli check fails when not installed', function () {
     expect($result->status)->toBe(HealthStatus::Error);
 });
 
+/**
+ * Create a throwaway Claude config dir (with the sibling .claude.json
+ * session file ClaudeAuthCheck requires) and return its path.
+ */
+function makeClaudeConfigDir(): string
+{
+    $base = sys_get_temp_dir() . '/yak-auth-' . uniqid();
+    $configDir = $base . '/claude';
+    mkdir($configDir, 0755, true);
+    file_put_contents($base . '/.claude.json', '{}');
+
+    return $configDir;
+}
+
 it('claude auth check fails when session file missing', function () {
     // Use a nested path so both the config dir and its parent (where the
     // .claude.json lookup happens) are guaranteed not to exist.
@@ -63,6 +77,51 @@ it('claude auth check fails when session file missing', function () {
 
     expect($result->status)->toBe(HealthStatus::Error);
     expect($result->detail)->toContain('Session token missing');
+});
+
+it('claude auth check gives the CLI enough time to complete a token refresh', function () {
+    // With an expired access token, `claude auth status` performs an OAuth
+    // refresh. The old 15s cap SIGKILLed the CLI mid-refresh, orphaning
+    // .oauth_refresh.lock and blocking every subsequent refresh (task 5434).
+    $configDir = makeClaudeConfigDir();
+    config()->set('yak.sandbox.claude_config_source', $configDir);
+
+    Process::fake(['*' => Process::result(output: '{"loggedIn":true}')]);
+
+    (new ClaudeAuthCheck)->run();
+
+    Process::assertRan(fn ($process) => str_contains($process->command, 'claude auth status')
+        && $process->timeout === 60);
+});
+
+it('claude auth check sweeps a stale oauth refresh lock before running', function () {
+    $configDir = makeClaudeConfigDir();
+    $lockDir = $configDir . '/.oauth_refresh.lock';
+    mkdir($lockDir);
+    touch($lockDir, time() - 3600);
+
+    config()->set('yak.sandbox.claude_config_source', $configDir);
+    Process::fake(['*' => Process::result(output: '{"loggedIn":true}')]);
+
+    $result = (new ClaudeAuthCheck)->run();
+
+    expect(is_dir($lockDir))->toBeFalse();
+    expect($result->status)->toBe(HealthStatus::Ok);
+});
+
+it('claude auth check leaves a fresh oauth refresh lock alone', function () {
+    // A recent lock likely belongs to an in-flight refresh; deleting it
+    // could corrupt a rotation that is about to be persisted.
+    $configDir = makeClaudeConfigDir();
+    $lockDir = $configDir . '/.oauth_refresh.lock';
+    mkdir($lockDir);
+
+    config()->set('yak.sandbox.claude_config_source', $configDir);
+    Process::fake(['*' => Process::result(output: '{"loggedIn":true}')]);
+
+    (new ClaudeAuthCheck)->run();
+
+    expect(is_dir($lockDir))->toBeTrue();
 });
 
 it('webhook signatures check passes when no failures', function () {

--- a/tests/Feature/Services/IncusSandboxManagerTest.php
+++ b/tests/Feature/Services/IncusSandboxManagerTest.php
@@ -53,6 +53,40 @@ it('reclaims a stale container before creating a new one', function () {
     Process::assertRan("incus delete {$container} --force 2>/dev/null");
 });
 
+it('removes any copied oauth refresh lock from the sandbox after pushing claude config', function () {
+    // The whole host .claude dir is pushed into the sandbox. If the host has
+    // a stale .oauth_refresh.lock (orphaned by a killed refresh), the copy
+    // would block the sandbox CLI's own token refresh and 401 the run.
+    $configDir = sys_get_temp_dir() . '/yak-claude-' . uniqid();
+    mkdir($configDir, 0755, true);
+    config()->set('yak.sandbox.claude_config_source', $configDir);
+
+    $repo = Repository::factory()->create([
+        'slug' => 'lock-repo',
+        'sandbox_snapshot' => 'yak-tpl-lock-repo/ready',
+        'sandbox_base_version' => 2,
+    ]);
+    $task = YakTask::factory()->create(['repo' => 'lock-repo']);
+    $container = "task-{$task->id}";
+
+    Process::fake([
+        "incus info *{$container}*" => Process::result(exitCode: 1),
+        'incus snapshot list *' => Process::result(output: 'ready,', exitCode: 0),
+        'incus copy *' => Process::result(exitCode: 0),
+        'incus config *' => Process::result(exitCode: 0),
+        'incus start *' => Process::result(exitCode: 0),
+        "incus exec {$container} -- systemctl is-system-running 2>/dev/null" => Process::result(output: 'running', exitCode: 0),
+        "incus exec {$container} -- docker info 2>/dev/null" => Process::result(exitCode: 0),
+        'incus exec *' => Process::result(exitCode: 0),
+        'incus file *' => Process::result(exitCode: 0),
+        '*' => Process::result(exitCode: 0),
+    ]);
+
+    app(IncusSandboxManager::class)->create($task, $repo);
+
+    Process::assertRan(fn ($process) => str_contains($process->command, 'rm -rf /home/yak/.claude/.oauth_refresh.lock'));
+});
+
 it('skips reclaim when no stale container is present', function () {
     $repo = Repository::factory()->create([
         'slug' => 'clean',


### PR DESCRIPTION
## Summary

Task 5434 failed with "401 OAuth access token has expired. Re-authenticate to continue." even though the refresh token was still valid and the operator had re-logged in the day before. The real culprit: an orphaned `.oauth_refresh.lock` in the shared `/home/yak/.claude` dir.

The chain: the access token expired at 14:32; the 14:45 `yak:healthcheck` ran `claude auth status`, which starts an OAuth refresh when the token is expired; the check's 15s process timeout SIGKILLed the CLI mid-refresh, orphaning the CLI's `.oauth_refresh.lock`; every later refresh was then blocked -- the host healthchecks, and every sandbox, because sandbox creation pushes the entire `.claude` dir, lock included. (Cousin of #13, which fixed the root-owned variant of the same lock; this is the killed-mid-refresh variant with correct ownership.)

## Changes

- **`ClaudeAuthCheck`: process timeout 15s -> 60s.** Root cause. An auth probe that can trigger a token refresh must not be killed mid-refresh.
- **`ClaudeAuthCheck`: sweep stale locks.** Before probing, delete `.oauth_refresh.lock` if it is older than 10 minutes -- a real refresh completes in seconds, so an old lock is always an orphan. Fresh locks are left alone since they may belong to an in-flight refresh. Runs every 15 minutes with the healthcheck, so a future orphan self-heals within minutes instead of requiring manual intervention.
- **`IncusSandboxManager`: never ship the lock to sandboxes.** After the recursive `.claude` push, remove any copied `.oauth_refresh.lock` inside the container, so a host-side orphan can never brick a sandbox's own refresh.