### PR TITLE
Store the Claude probe timestamp as a string so the health row survives cache serialization

### DIFF
--- a/app/Livewire/HealthRow.php
+++ b/app/Livewire/HealthRow.php
@@ -85,7 +85,7 @@ class HealthRow extends Component
 
     private function claudeAuthResult(): HealthResult
     {
-        /** @var array{result: HealthResult, checked_at: Carbon}|null $stored */
+        /** @var array{result: HealthResult, checked_at: string}|null $stored */
         $stored = Cache::get(ClaudeAuthCheck::LAST_RESULT_CACHE_KEY);
 
         if ($stored === null) {

--- a/app/Services/HealthCheck/ClaudeAuthCheck.php
+++ b/app/Services/HealthCheck/ClaudeAuthCheck.php
@@ -204,9 +204,15 @@ class ClaudeAuthCheck implements HealthCheck
 
     private function recordResult(HealthResult $result): HealthResult
     {
+        // Store the timestamp as an ISO-8601 string, not a Carbon instance.
+        // The cache store serializes this payload, and a Carbon object does not
+        // reliably survive the round-trip across process boundaries — it comes
+        // back as __PHP_Incomplete_Class, which then makes HealthRow's
+        // Carbon::parse() throw a TypeError and take out the health row. A
+        // string round-trips through every cache driver unchanged.
         Cache::put(self::LAST_RESULT_CACHE_KEY, [
             'result' => $result,
-            'checked_at' => now(),
+            'checked_at' => now()->toIso8601String(),
         ], now()->addDay());
 
         return $result;

--- a/tests/Feature/HealthCheck/SystemChecksTest.php
+++ b/tests/Feature/HealthCheck/SystemChecksTest.php
@@ -239,3 +239,24 @@ it('webhook signatures check reports rejected webhooks', function () {
     expect($result->detail)->toContain('Linear (3)');
     expect($result->detail)->toContain('Slack (1)');
 });
+
+it('stores the probe timestamp as a string that survives cache serialization', function () {
+    // Regression: `checked_at` was stored as a Carbon instance. The database
+    // cache store serializes the payload, and the object came back as
+    // __PHP_Incomplete_Class across a process boundary, so HealthRow's
+    // Carbon::parse() threw a TypeError and took out the health row. The
+    // array cache driver used by the rest of these tests never serializes,
+    // which is exactly why this slipped through.
+    Process::fake(['*' => Process::result(output: 'ok', exitCode: 0)]);
+
+    (new ClaudeAuthCheck)->run();
+
+    $stored = Cache::get(ClaudeAuthCheck::LAST_RESULT_CACHE_KEY);
+
+    expect($stored['checked_at'])->toBeString();
+
+    $roundTripped = unserialize(serialize($stored));
+
+    expect($roundTripped['checked_at'])->toBe($stored['checked_at']);
+    expect(Carbon\Carbon::parse($roundTripped['checked_at']))->toBeInstanceOf(Carbon\Carbon::class);
+});


### PR DESCRIPTION
## Summary

Follow-up to #20. `ClaudeAuthCheck` recorded `checked_at` as a Carbon instance. The cache store serializes that payload and the object does not survive the round-trip across a process boundary — it reads back as `__PHP_Incomplete_Class`, so `HealthRow`'s `Carbon::parse()` throws a `TypeError` and takes out the Claude row on the Health dashboard.

Confirmed against the deployed host rather than inferred:

```
checked_at type: object / class: __PHP_Incomplete_Class
PARSE FAILED: TypeError: Carbon\Carbon::parse(): Argument #1 ($time) must be of type
  DateTimeInterface|...|string|int|float|null, __PHP_Incomplete_Class given
```

Blast radius is the Health dashboard row only. Task execution, the queue gate, the credential mount and Slack alerting are unaffected — the gate flag reads clear and the liveness probe passes on the deployed host.

## Changes

- `ClaudeAuthCheck::recordResult()` stores `now()->toIso8601String()` instead of `now()`. A string round-trips through every cache driver unchanged.
- `HealthRow`'s docblock corrected to `checked_at: string`. `Carbon::parse()` already accepted a string, so no logic change was needed there.

## Why the existing tests missed it

They run on the `array` cache driver, which never serializes; production runs `database`, which does. The regression test added here asserts the stored value is a string **and** survives an explicit `serialize`/`unserialize` cycle, so it fails on the pre-fix code regardless of driver. Verified RED before GREEN.