### PR TITLE
Install yak-claude-login on a standard deploy, not just a local one

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -115,5 +115,10 @@
     - role: yak-container
       tags: [yak-container, yak-app, secrets]
 
+    # yak-container is included deliberately: the standard deploy runs
+    # `--tags yak-container`, and this role installs /usr/local/bin/yak-claude-login,
+    # which the Claude health check and every Slack auth alert instruct the
+    # operator to run. Without this tag a clean-checkout deploy ships those
+    # instructions without the command they name.
     - role: claude-code-config
-      tags: [claude-code-config, yak-app]
+      tags: [claude-code-config, yak-app, yak-container]


### PR DESCRIPTION
## Summary

The `claude-code-config` role installs `/usr/local/bin/yak-claude-login`, which the Claude auth health check and every Slack auth alert instruct the operator to run. The role was tagged `[claude-code-config, yak-app]`, but the standard deploy invocation is `--tags yak-container` — so a deploy from a clean checkout ships those instructions without installing the command they name. The first person to follow the runbook mid-incident would get `command not found`.

It happened to install on the current production host only because the local, gitignored `deploy.sh` passes `--tags yak-container,claude-code-config`. That is not reproducible from a fresh checkout.

## Changes

- Add `yak-container` to the role's tag list in `ansible/playbook.yml`, with a comment explaining why the tag is load-bearing rather than cosmetic.

Verified with `ansible-playbook --syntax-check`.