### PR TITLE
fix(sandbox): stop letting a 60s process cap kill finished setup runs

### DIFF
--- a/app/Jobs/Deployments/GarbageCollectTemplateSnapshotsJob.php
+++ b/app/Jobs/Deployments/GarbageCollectTemplateSnapshotsJob.php
@@ -16,6 +16,12 @@ class GarbageCollectTemplateSnapshotsJob implements ShouldQueue
 {
     use Queueable;
 
+    /** Deleting a snapshot unwinds a ZFS dataset; well past the Process facade's 60s default. */
+    private const DELETE_TIMEOUT = 300;
+
+    /** Cheap metadata read. */
+    private const LIST_TIMEOUT = 30;
+
     public function __construct()
     {
         $this->onQueue('yak-deployments');
@@ -31,7 +37,7 @@ class GarbageCollectTemplateSnapshotsJob implements ShouldQueue
                 continue;
             }
 
-            $result = Process::run("incus snapshot delete {$ref->name()}");
+            $result = Process::timeout(self::DELETE_TIMEOUT)->run("incus snapshot delete {$ref->name()}");
             if (! $result->successful()) {
                 Log::channel('yak')->warning('Failed to GC template snapshot', [
                     'snapshot' => $ref->name(),
@@ -44,7 +50,7 @@ class GarbageCollectTemplateSnapshotsJob implements ShouldQueue
     /** @return list<TemplateSnapshotRef> */
     private function listAllSnapshots(): array
     {
-        $result = Process::run('incus snapshot list --format plain');
+        $result = Process::timeout(self::LIST_TIMEOUT)->run('incus snapshot list --format plain');
         if (! $result->successful()) {
             return [];
         }

--- a/app/Services/DeploymentContainerManager.php
+++ b/app/Services/DeploymentContainerManager.php
@@ -14,6 +14,18 @@ use RuntimeException;
 
 class DeploymentContainerManager
 {
+    /** Ceiling for `incus copy`, which clones a full repo template. */
+    private const COPY_TIMEOUT = 600;
+
+    /** How long to let a preview container shut down cleanly before killing it. */
+    private const STOP_TIMEOUT = 60;
+
+    /** Ceiling for `incus start` and for `incus delete`, which unwinds ZFS datasets. */
+    private const LIFECYCLE_TIMEOUT = 300;
+
+    /** Ceiling for cheap metadata reads and config pokes. */
+    private const QUERY_TIMEOUT = 30;
+
     public function __construct(private IncusSandboxManager $sandbox) {}
 
     public function createFromTemplate(BranchDeployment $deployment): void
@@ -21,7 +33,7 @@ class DeploymentContainerManager
         $deployment->loadMissing('repository');
         $ref = new TemplateSnapshotRef($deployment->repository->slug, $deployment->template_version);
 
-        $result = Process::run("incus copy {$ref->name()} {$deployment->container_name}");
+        $result = Process::timeout(self::COPY_TIMEOUT)->run("incus copy {$ref->name()} {$deployment->container_name}");
 
         if ($result->exitCode() !== 0) {
             throw new RuntimeException("Failed to clone template snapshot: {$result->errorOutput()}");
@@ -34,8 +46,8 @@ class DeploymentContainerManager
         // live read/write mount of the host's ~/.claude, nor the idmap that
         // would let it, even if an earlier build of that fix poisoned a
         // template. Best-effort — never fail the deployment over this.
-        Process::run("incus config device remove {$deployment->container_name} claude 2>/dev/null");
-        Process::run("incus config unset {$deployment->container_name} raw.idmap 2>/dev/null");
+        Process::timeout(self::QUERY_TIMEOUT)->run("incus config device remove {$deployment->container_name} claude 2>/dev/null");
+        Process::timeout(self::QUERY_TIMEOUT)->run("incus config unset {$deployment->container_name} raw.idmap 2>/dev/null");
     }
 
     public function start(BranchDeployment $deployment): string
@@ -43,7 +55,7 @@ class DeploymentContainerManager
         $deployment->loadMissing('repository');
         $manifest = PreviewManifest::fromArray($deployment->repository->preview_manifest);
 
-        $result = Process::run("incus start {$deployment->container_name}");
+        $result = Process::timeout(self::LIFECYCLE_TIMEOUT)->run("incus start {$deployment->container_name}");
 
         // Idempotent: DeployBranchJob and WakeHibernatedDeploymentJob can
         // race in pathological scenarios (e.g. a wake dispatched before the
@@ -72,7 +84,7 @@ class DeploymentContainerManager
 
     public function resolveContainerIp(string $containerName): string
     {
-        $result = Process::run("incus list {$containerName} -c n,4 -f csv");
+        $result = Process::timeout(self::QUERY_TIMEOUT)->run("incus list {$containerName} -c n,4 -f csv");
 
         if ($result->exitCode() !== 0) {
             throw new DeploymentStartTimeoutException('ip_resolution', "Failed to list container {$containerName}");
@@ -116,7 +128,7 @@ class DeploymentContainerManager
         $this->exec($deployment, 'fetch', "cd {$workspace} && git fetch --all --prune", $manifest->checkoutRefreshTimeoutSeconds);
         $this->exec($deployment, 'checkout', "cd {$workspace} && git checkout --force {$commitSha}", $manifest->checkoutRefreshTimeoutSeconds);
 
-        $hasRepoHook = Process::run("incus exec {$deployment->container_name} -- test -f {$workspace}/.yak/preview.sh")
+        $hasRepoHook = Process::timeout(self::QUERY_TIMEOUT)->run("incus exec {$deployment->container_name} -- test -f {$workspace}/.yak/preview.sh")
             ->exitCode() === 0;
 
         if ($hasRepoHook) {
@@ -133,16 +145,29 @@ class DeploymentContainerManager
 
     public function stop(BranchDeployment $deployment): void
     {
-        $result = Process::run("incus stop {$deployment->container_name}");
+        // `incus stop` defaults to `--timeout -1`, i.e. wait forever for a
+        // clean shutdown. A preview container is by definition running an
+        // app server that may not exit promptly, so bound the graceful
+        // window and then kill it rather than hanging the hibernation.
+        $container = $deployment->container_name;
 
-        if ($result->exitCode() !== 0) {
-            throw new RuntimeException("Failed to stop container: {$result->errorOutput()}");
+        $result = Process::timeout(self::STOP_TIMEOUT + 30)
+            ->run("incus stop {$container} --timeout " . self::STOP_TIMEOUT);
+
+        if ($result->exitCode() === 0) {
+            return;
+        }
+
+        $forced = Process::timeout(self::STOP_TIMEOUT)->run("incus stop {$container} --force");
+
+        if ($forced->exitCode() !== 0) {
+            throw new RuntimeException("Failed to stop container: {$forced->errorOutput()}");
         }
     }
 
     public function destroy(BranchDeployment $deployment): void
     {
-        $result = Process::run("incus delete --force {$deployment->container_name}");
+        $result = Process::timeout(self::LIFECYCLE_TIMEOUT)->run("incus delete --force {$deployment->container_name}");
 
         if (! $result->successful() && ! str_contains(strtolower($result->errorOutput()), 'not found')) {
             throw new RuntimeException("Failed to destroy container: {$result->errorOutput()}");

--- a/app/Services/IncusSandboxManager.php
+++ b/app/Services/IncusSandboxManager.php
@@ -25,6 +25,31 @@ use RuntimeException;
 class IncusSandboxManager
 {
     /**
+     * Wall-clock ceiling for incus commands that move real data — `copy`,
+     * `snapshot create`, `config device add`. Cloning a fully provisioned
+     * repo template is fast on ZFS but not instant, and Laravel's Process
+     * facade defaults to a 60s timeout that these routinely blow past.
+     */
+    private const EXEC_TIMEOUT = 600;
+
+    /**
+     * How long to let a container shut down cleanly before killing it.
+     * `incus stop` defaults to `--timeout -1` (wait forever), so this has
+     * to be bounded on our side or the shutdown of a container holding a
+     * stuck dev server hangs until the Process facade throws.
+     */
+    private const STOP_TIMEOUT = 60;
+
+    /** Ceiling for `incus delete`, which unwinds ZFS datasets. */
+    private const DELETE_TIMEOUT = 300;
+
+    /** Ceiling for a single readiness probe inside a booting container. */
+    private const PROBE_TIMEOUT = 10;
+
+    /** Ceiling for cheap metadata reads — `list`, `info`, `config`, `file push`. */
+    private const QUERY_TIMEOUT = 30;
+
+    /**
      * Create a sandbox container for a task, cloned from the repo's snapshot.
      *
      * If the repo has a sandbox snapshot, clones from it (instant CoW).
@@ -291,10 +316,10 @@ class IncusSandboxManager
         ]);
 
         // Stop the container before snapshotting for a clean state
-        $this->exec("incus stop {$containerName}");
+        $this->stopBeforeCapture($containerName);
 
         // Delete existing snapshot if present (idempotent re-snapshot)
-        Process::run("incus snapshot delete {$containerName} {$snapshotName} 2>/dev/null");
+        Process::timeout(self::DELETE_TIMEOUT)->run("incus snapshot delete {$containerName} {$snapshotName} 2>/dev/null");
 
         $this->exec("incus snapshot create {$containerName} {$snapshotName}");
 
@@ -317,10 +342,10 @@ class IncusSandboxManager
         $snapshotName = "ready-v{$newVersion}";
 
         // Delete old template if it exists
-        Process::run("incus delete {$templateName} --force 2>/dev/null");
+        Process::timeout(self::DELETE_TIMEOUT)->run("incus delete {$templateName} --force 2>/dev/null");
 
         // Stop the task container
-        $this->exec("incus stop {$containerName}");
+        $this->stopBeforeCapture($containerName);
 
         // `incus copy` carries instance-local devices and config to the
         // copy. Strip the shared claude credential mount and its idmap
@@ -329,8 +354,8 @@ class IncusSandboxManager
         // ~/.claude. The container is stopped and about to be destroyed,
         // so this is safe; best-effort since a container that never had
         // the device/idmap must not fail the promotion.
-        Process::run("incus config device remove {$containerName} claude 2>/dev/null");
-        Process::run("incus config unset {$containerName} raw.idmap 2>/dev/null");
+        Process::timeout(self::QUERY_TIMEOUT)->run("incus config device remove {$containerName} claude 2>/dev/null");
+        Process::timeout(self::QUERY_TIMEOUT)->run("incus config unset {$containerName} raw.idmap 2>/dev/null");
 
         // Copy task container as the new template
         $this->exec("incus copy {$containerName} {$templateName}");
@@ -390,7 +415,7 @@ class IncusSandboxManager
         ]);
 
         // Force stop + delete in one shot (ignore errors for already-stopped containers)
-        Process::run("incus delete {$containerName} --force 2>/dev/null");
+        Process::timeout(self::DELETE_TIMEOUT)->run("incus delete {$containerName} --force 2>/dev/null");
     }
 
     /**
@@ -401,7 +426,7 @@ class IncusSandboxManager
         $templateName = $this->templateName($repository);
         $snapshotName = (string) config('yak.sandbox.snapshot_name', 'ready');
 
-        $result = Process::run("incus snapshot list {$templateName} --format csv 2>/dev/null");
+        $result = Process::timeout(self::QUERY_TIMEOUT)->run("incus snapshot list {$templateName} --format csv 2>/dev/null");
 
         if ($result->exitCode() !== 0) {
             return false;
@@ -449,7 +474,7 @@ class IncusSandboxManager
      */
     public function cleanupStale(): int
     {
-        $result = Process::run('incus list --format csv -c n,s 2>/dev/null');
+        $result = Process::timeout(self::QUERY_TIMEOUT)->run('incus list --format csv -c n,s 2>/dev/null');
 
         if ($result->exitCode() !== 0) {
             return 0;
@@ -468,7 +493,7 @@ class IncusSandboxManager
 
             if (str_starts_with($name, 'task-')) {
                 if ($status === 'STOPPED') {
-                    Process::run("incus delete {$name} --force");
+                    Process::timeout(self::DELETE_TIMEOUT)->run("incus delete {$name} --force");
                     $deleted++;
 
                     continue;
@@ -478,7 +503,7 @@ class IncusSandboxManager
                     Log::channel('yak')->warning('Cleaning up orphaned sandbox', [
                         'container' => $name,
                     ]);
-                    Process::run("incus delete {$name} --force");
+                    Process::timeout(self::DELETE_TIMEOUT)->run("incus delete {$name} --force");
                     $deleted++;
                 }
 
@@ -490,7 +515,7 @@ class IncusSandboxManager
                     'container' => $name,
                     'status' => $status,
                 ]);
-                Process::run("incus delete {$name} --force");
+                Process::timeout(self::DELETE_TIMEOUT)->run("incus delete {$name} --force");
                 $deleted++;
             }
         }
@@ -503,7 +528,7 @@ class IncusSandboxManager
      */
     public function containerExists(string $containerName): bool
     {
-        $result = Process::run('incus info ' . escapeshellarg($containerName));
+        $result = Process::timeout(self::QUERY_TIMEOUT)->run('incus info ' . escapeshellarg($containerName));
 
         return $result->exitCode() === 0;
     }
@@ -543,7 +568,7 @@ class IncusSandboxManager
             'current_version' => (int) config('yak.sandbox.base_version', 1),
         ]);
 
-        Process::run("incus delete {$templateName} --force 2>/dev/null");
+        Process::timeout(self::DELETE_TIMEOUT)->run("incus delete {$templateName} --force 2>/dev/null");
 
         $repository->update([
             'sandbox_snapshot' => null,
@@ -623,7 +648,7 @@ class IncusSandboxManager
 
         // Fall back to base template
         $baseTemplate = (string) config('yak.sandbox.base_template', 'yak-base');
-        $baseResult = Process::run("incus snapshot list {$baseTemplate} --format csv 2>/dev/null");
+        $baseResult = Process::timeout(self::QUERY_TIMEOUT)->run("incus snapshot list {$baseTemplate} --format csv 2>/dev/null");
 
         if ($baseResult->exitCode() === 0 && str_contains($baseResult->output(), $snapshotName)) {
             return "{$baseTemplate}/{$snapshotName}";
@@ -640,7 +665,7 @@ class IncusSandboxManager
         $disk = (string) config('yak.sandbox.disk_limit', '30GB');
 
         $this->exec("incus config set {$containerName} limits.cpu={$cpu} limits.memory={$memory}");
-        Process::run("incus config device set {$containerName} root size={$disk} 2>/dev/null");
+        Process::timeout(self::QUERY_TIMEOUT)->run("incus config device set {$containerName} root size={$disk} 2>/dev/null");
     }
 
     /**
@@ -677,26 +702,41 @@ class IncusSandboxManager
         }
     }
 
+    /**
+     * Run a short readiness probe inside a booting container.
+     *
+     * Returns false rather than throwing when the probe times out or errors,
+     * so the caller's polling loop gets another turn.
+     *
+     * @param  list<string>  $expectedOutput  when given, trimmed stdout must match one of these
+     */
+    private function probeSucceeds(string $command, array $expectedOutput = []): bool
+    {
+        try {
+            $result = Process::timeout(self::PROBE_TIMEOUT)->run($command);
+        } catch (\Throwable) {
+            return false;
+        }
+
+        if ($expectedOutput === []) {
+            return $result->exitCode() === 0;
+        }
+
+        return in_array(trim($result->output()), $expectedOutput, true);
+    }
+
     private function waitForReady(string $containerName, int $maxWaitSeconds = 60): void
     {
         $start = time();
 
         while (time() - $start < $maxWaitSeconds) {
-            $result = Process::run(
-                "incus exec {$containerName} -- systemctl is-system-running 2>/dev/null",
-            );
-
-            $status = trim($result->output());
-
-            if ($status === 'running' || $status === 'degraded') {
-                // Also check Docker is ready
-                $docker = Process::run(
-                    "incus exec {$containerName} -- docker info 2>/dev/null",
-                );
-
-                if ($docker->exitCode() === 0) {
-                    return;
-                }
+            // A probe that hangs is just a not-ready-yet signal, so cap each
+            // one well under $maxWaitSeconds and keep polling. Without the
+            // cap these inherit the Process facade's 60s default, and a
+            // single stuck probe outlives the whole wait window.
+            if ($this->probeSucceeds("incus exec {$containerName} -- systemctl is-system-running 2>/dev/null", ['running', 'degraded'])
+                && $this->probeSucceeds("incus exec {$containerName} -- docker info 2>/dev/null")) {
+                return;
             }
 
             usleep(500_000); // 500ms
@@ -747,7 +787,7 @@ class IncusSandboxManager
         // an earlier build of this feature (see promoteToTemplate()) may
         // already carry the device. Remove it first so the add below
         // doesn't fail with "Device already exists".
-        Process::run(sprintf(
+        Process::timeout(self::QUERY_TIMEOUT)->run(sprintf(
             'incus config device remove %s claude 2>/dev/null',
             escapeshellarg($containerName),
         ));
@@ -939,7 +979,7 @@ class IncusSandboxManager
             return;
         }
 
-        Process::run(sprintf(
+        Process::timeout(self::QUERY_TIMEOUT)->run(sprintf(
             'incus file push %s %s/home/yak/mcp-config.json',
             escapeshellarg($mcpConfigPath),
             escapeshellarg($containerName),
@@ -970,7 +1010,7 @@ class IncusSandboxManager
             asRoot: true,
         );
 
-        Process::run(sprintf(
+        Process::timeout(self::QUERY_TIMEOUT)->run(sprintf(
             'incus file push %s %s/home/yak/.docker/config.json',
             escapeshellarg($dockerConfigSource),
             escapeshellarg($containerName),
@@ -986,9 +1026,36 @@ class IncusSandboxManager
         );
     }
 
-    private function exec(string $command): void
+    /**
+     * Stop a container that is about to be snapshotted, copied, or destroyed.
+     *
+     * `incus stop` defaults to `--timeout -1`, i.e. wait forever for a clean
+     * shutdown. A sandbox that just finished a setup run is usually holding a
+     * dev server, a docker daemon, or a stray agent process that never exits,
+     * so the graceful path can outlast any wrapper timeout we set. Give it a
+     * bounded window and then kill it: the container's only remaining job is
+     * to be captured or deleted, so a hard stop costs nothing.
+     */
+    private function stopBeforeCapture(string $containerName): void
     {
-        $result = Process::run($command);
+        $graceful = Process::timeout(self::STOP_TIMEOUT + 30)
+            ->run("incus stop {$containerName} --timeout " . self::STOP_TIMEOUT);
+
+        if ($graceful->exitCode() === 0) {
+            return;
+        }
+
+        Log::channel('yak')->warning('Graceful sandbox stop failed, forcing', [
+            'container' => $containerName,
+            'error' => trim($graceful->errorOutput()),
+        ]);
+
+        $this->exec("incus stop {$containerName} --force", timeout: self::STOP_TIMEOUT);
+    }
+
+    private function exec(string $command, ?int $timeout = null): void
+    {
+        $result = Process::timeout($timeout ?? self::EXEC_TIMEOUT)->run($command);
 
         if ($result->exitCode() !== 0) {
             throw new RuntimeException("Incus command failed: {$command}\n{$result->errorOutput()}");

--- a/app/Services/Mp4ChapterWriter.php
+++ b/app/Services/Mp4ChapterWriter.php
@@ -33,7 +33,9 @@ class Mp4ChapterWriter
         try {
             File::put($ffmetaPath, $this->ffmeta($timeline));
 
-            $result = Process::run([
+            // Stream copy, but a long walkthrough mp4 still outruns the
+            // Process facade's 60s default on a busy host.
+            $result = Process::timeout(300)->run([
                 'ffmpeg', '-y',
                 '-i', $mp4Path,
                 '-i', $ffmetaPath,

--- a/tests/Feature/Services/IncusProcessTimeoutTest.php
+++ b/tests/Feature/Services/IncusProcessTimeoutTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Jobs\Deployments\GarbageCollectTemplateSnapshotsJob;
+use App\Models\BranchDeployment;
+use App\Models\Repository;
+use App\Services\DeploymentContainerManager;
+use App\Services\IncusSandboxManager;
+use Illuminate\Support\Facades\Process;
+
+/**
+ * Regression cover for task 5511, which burned a full setup run and then
+ * failed on `The process "incus stop task-5511" exceeded the timeout of 60
+ * seconds`. Two bugs stacked: incus stop waits forever for a clean shutdown
+ * (`--timeout` defaults to -1), and the Process facade caps every command at
+ * 60s unless told otherwise.
+ */
+it('bounds the graceful window when stopping a sandbox for promotion', function () {
+    Process::fake();
+
+    $repository = Repository::factory()->create(['current_template_version' => 1]);
+
+    app(IncusSandboxManager::class)->promoteToTemplate('task-5511', $repository);
+
+    Process::assertRan(fn ($process) => str_contains($process->command, 'incus stop task-5511 --timeout'));
+    Process::assertNotRan(fn ($process) => $process->command === 'incus stop task-5511');
+});
+
+it('force-kills a sandbox whose graceful stop fails', function () {
+    Process::fake([
+        'incus stop task-5511 --timeout*' => Process::result(errorOutput: 'shutdown timed out', exitCode: 1),
+        '*' => Process::result(),
+    ]);
+
+    $repository = Repository::factory()->create(['current_template_version' => 1]);
+
+    app(IncusSandboxManager::class)->promoteToTemplate('task-5511', $repository);
+
+    Process::assertRan(fn ($process) => str_contains($process->command, 'incus stop task-5511 --force'));
+    // The promotion still completes rather than aborting the setup run.
+    Process::assertRan(fn ($process) => str_contains($process->command, 'incus snapshot create'));
+});
+
+it('gives every incus command in a promotion more than the 60s default', function () {
+    Process::fake();
+
+    $repository = Repository::factory()->create(['current_template_version' => 1]);
+
+    app(IncusSandboxManager::class)->promoteToTemplate('task-5511', $repository);
+
+    Process::assertRan(function ($process) {
+        expect($process->timeout)
+            ->not->toBe(60, "`{$process->command}` is still on the Process facade's 60s default");
+
+        return true;
+    });
+});
+
+it('bounds the graceful window when hibernating a preview container', function () {
+    Process::fake();
+
+    $deployment = BranchDeployment::factory()->create(['container_name' => 'deploy-42']);
+
+    app(DeploymentContainerManager::class)->stop($deployment);
+
+    Process::assertRan(fn ($process) => str_contains($process->command, 'incus stop deploy-42 --timeout'));
+    Process::assertNotRan(fn ($process) => $process->command === 'incus stop deploy-42');
+});
+
+it('force-kills a preview container whose graceful stop fails', function () {
+    Process::fake([
+        'incus stop deploy-42 --timeout*' => Process::result(errorOutput: 'shutdown timed out', exitCode: 1),
+        '*' => Process::result(),
+    ]);
+
+    $deployment = BranchDeployment::factory()->create(['container_name' => 'deploy-42']);
+
+    app(DeploymentContainerManager::class)->stop($deployment);
+
+    Process::assertRan(fn ($process) => str_contains($process->command, 'incus stop deploy-42 --force'));
+});
+
+it('raises the failure when even a forced stop will not take', function () {
+    Process::fake([
+        'incus stop deploy-42*' => Process::result(errorOutput: 'container is wedged', exitCode: 1),
+        '*' => Process::result(),
+    ]);
+
+    $deployment = BranchDeployment::factory()->create(['container_name' => 'deploy-42']);
+
+    expect(fn () => app(DeploymentContainerManager::class)->stop($deployment))
+        ->toThrow(RuntimeException::class, 'container is wedged');
+});
+
+it('gives snapshot garbage collection room to unwind ZFS datasets', function () {
+    Process::fake([
+        'incus snapshot list --format plain' => Process::result("yak-tpl-orphan/ready-v1\n"),
+        '*' => Process::result(),
+    ]);
+
+    (new GarbageCollectTemplateSnapshotsJob)->handle();
+
+    Process::assertRan(fn ($process) => str_contains($process->command, 'incus snapshot delete yak-tpl-orphan/ready-v1')
+        && $process->timeout > 60);
+});


### PR DESCRIPTION
## Summary

Setup task 5511 (`Geocodio/chopchop`) ran its full 20 minutes and ~\$3.75 of agent work, then failed on the very last step with `The process "incus stop task-5511" exceeded the timeout of 60 seconds`.

Two bugs stacked:

1. `incus stop` defaults to `--timeout -1`, i.e. wait forever for a clean shutdown. A sandbox that just finished a setup run is usually holding a dev server, a docker daemon, or a stray agent process that never exits.
2. Laravel's Process facade caps every command at 60s unless told otherwise, and `IncusSandboxManager::exec()` used a bare `Process::run()`.

So the wrapper killed the shutdown before incus finished it. The repo never got a template, and the next task against it (5535) failed with `Repository 'Geocodio/chopchop' has not been set up yet`.

The same shape existed on the preview hibernation path, where the container is by definition running an app server, and `exec()` also fronted `incus copy` and `incus snapshot create` -- both of which move real data and can legitimately outrun a minute.

## Changes

**`IncusSandboxManager`**
- `exec()` now sets an explicit 600s ceiling, with a per-call override. This covers `incus copy`, `incus snapshot create`, and `config device add`.
- New `stopBeforeCapture()` replaces both bare `incus stop` calls (in `snapshot()` and `promoteToTemplate()`): a bounded graceful stop via `--timeout 60`, then `--force` if that fails. The container's only remaining job is to be captured or deleted, so a hard stop costs nothing.
- Explicit ceilings on the remaining calls: `delete` / `snapshot delete` at 300s, metadata reads (`list`, `info`, `config`, `file push`) at 30s.
- `waitForReady()` had a quieter version of the same bug -- its probes inherited the 60s default inside a 60 second wait loop, so a single stuck `incus exec` outlived the entire window and threw instead of being retried. Probes are capped at 10s and a timeout now reads as not-ready-yet.

**`DeploymentContainerManager`**
- `stop()` gets the same bounded-then-force treatment for hibernation.
- `incus copy` at 600s (it was cloning a full repo template under a 60s cap), `start` / `delete` at 300s, metadata reads at 30s.

**`GarbageCollectTemplateSnapshotsJob`** -- `incus snapshot delete` at 300s, list at 30s.

**`Mp4ChapterWriter`** -- the chapter remux is a stream copy, but a long walkthrough mp4 on a busy host can outrun 60s. Now 300s.

Three bare calls are deliberately left alone as sub-second metadata reads where the default is already generous: the two ffprobe duration probes and `ffmpeg -filters`.

## Verification

New `tests/Feature/Services/IncusProcessTimeoutTest.php` covers the bounded stop, the force fallback, the error path when even a force stop fails, and a guard asserting no incus command in a promotion is still sitting on the 60s default. 6 of its 7 tests fail against the pre-fix code; all 7 pass after.

Surrounding suites green: 299 passing across `Services`, `Jobs/Deployments`, the transcript test and the setup job test, plus 122 across `Agents` and the run/retry/follow-up jobs. Pint and PHPStan clean.

## After merge

`Geocodio/chopchop` still has no template. Once this deploys, its setup needs re-running before task 5535 can be retried.