### PR TITLE
fix(agent): resume in place when Claude exits without a result event

### DIFF
--- a/app/Agents/SandboxedAgentRunner.php
+++ b/app/Agents/SandboxedAgentRunner.php
@@ -5,6 +5,7 @@ namespace App\Agents;
 use App\Contracts\AgentRunner;
 use App\DataTransferObjects\AgentRunRequest;
 use App\DataTransferObjects\AgentRunResult;
+use App\DataTransferObjects\StreamOutcome;
 use App\Exceptions\ClaudeAuthException;
 use App\Models\YakTask;
 use App\Services\ClaudeAuthDetector;
@@ -25,6 +26,21 @@ use Throwable;
 class SandboxedAgentRunner implements AgentRunner
 {
     /**
+     * Prompt sent when resuming a session whose stream ended without a
+     * `result` event. Claude usually already finished; this just makes
+     * the CLI close the turn properly so the result event is emitted.
+     */
+    private const string RESUME_AFTER_TRUNCATED_STREAM_PROMPT = 'Your previous turn ended before a result was recorded. If the task is complete, reply with your final summary. Otherwise finish the remaining work, commit it, and then reply with your final summary.';
+
+    /**
+     * Cap on task-log warnings for undecodable stream lines per run, so
+     * a chatty CLI cannot flood the timeline.
+     */
+    private const int MAX_MALFORMED_LINE_WARNINGS = 3;
+
+    private int $malformedLineWarnings = 0;
+
+    /**
      * After Claude emits its `result` event, we wait this many seconds
      * for the `incus exec` process to exit naturally before terminating
      * it. Backgrounded services inside the sandbox (e.g. `php artisan
@@ -39,6 +55,7 @@ class SandboxedAgentRunner implements AgentRunner
         private readonly float $heartbeatIntervalSeconds = 60.0,
         private readonly float $sigkillEscalationSeconds = 5.0,
         private readonly float $memorySnapshotIntervalSeconds = 30.0,
+        private readonly int $maxResumeAttempts = 1,
     ) {}
 
     public function run(AgentRunRequest $request): AgentRunResult
@@ -217,29 +234,164 @@ class SandboxedAgentRunner implements AgentRunner
             ]);
         });
 
+        $this->malformedLineWarnings = 0;
+
         try {
-            return $this->runStreamingInner(
-                $request,
-                $containerName,
-                $command,
-                $handler,
-            );
+            $outcome = $this->runStreamingInner($request, $containerName, $command, $handler);
+
+            $resumeAttempts = 0;
+            while ($outcome->endedCleanlyWithoutResult()
+                && $handler->getSessionId() !== null
+                && $resumeAttempts < $this->maxResumeAttempts) {
+                $resumeAttempts++;
+                $outcome = $this->resumeAfterTruncatedStream($request, $containerName, $handler, $outcome, $resumeAttempts);
+            }
+
+            return $this->resultFromOutcome($request, $outcome, $handler);
         } finally {
             $streamCompleted = true;
         }
     }
 
     /**
+     * The CLI exited cleanly but never emitted its `result` event. The
+     * sandbox is still alive, so Claude's work (commits included) is
+     * intact; `--resume` the same session there rather than failing the
+     * task and losing it. Uses the same StreamEventHandler so tool logs
+     * keep flowing into the same task timeline.
+     */
+    private function resumeAfterTruncatedStream(
+        AgentRunRequest $request,
+        string $containerName,
+        StreamEventHandler $handler,
+        StreamOutcome $outcome,
+        int $attempt,
+    ): StreamOutcome {
+        assert($request->task !== null);
+
+        $sessionId = (string) $handler->getSessionId();
+        $metadata = [
+            'container' => $containerName,
+            'session_id' => $sessionId,
+            'lines' => $outcome->lineCount,
+            'attempt' => $attempt,
+            'max_attempts' => $this->maxResumeAttempts,
+        ];
+
+        Log::channel('yak')->warning('Claude stream ended without a result event; resuming session in place', $metadata + ['task_id' => $request->task->id]);
+        TaskLogger::warning(
+            $request->task,
+            "Claude exited without a result event — resuming session {$sessionId} in place (attempt {$attempt}/{$this->maxResumeAttempts})",
+            $metadata,
+        );
+
+        $resumeRequest = new AgentRunRequest(
+            prompt: self::RESUME_AFTER_TRUNCATED_STREAM_PROMPT,
+            systemPrompt: $request->systemPrompt,
+            containerName: $containerName,
+            timeoutSeconds: $request->timeoutSeconds,
+            maxBudgetUsd: $request->maxBudgetUsd,
+            maxTurns: $request->maxTurns,
+            model: $request->model,
+            resumeSessionId: $sessionId,
+            mcpConfigPath: $request->mcpConfigPath,
+            task: $request->task,
+        );
+
+        $this->logPrompts($resumeRequest);
+
+        return $this->runStreamingInner(
+            $resumeRequest,
+            $containerName,
+            $this->buildClaudeCommand($resumeRequest),
+            $handler,
+        );
+    }
+
+    /**
+     * Turn what the stream left behind into an AgentRunResult. Prefers a
+     * real `result` event; otherwise a clean exit with a final assistant
+     * message is treated as success with a synthesized result so the
+     * job still pushes and opens the PR.
+     */
+    private function resultFromOutcome(
+        AgentRunRequest $request,
+        StreamOutcome $outcome,
+        StreamEventHandler $handler,
+    ): AgentRunResult {
+        assert($request->task !== null);
+
+        $resultEvent = $outcome->resultEvent;
+
+        if ($resultEvent !== null) {
+            Log::channel('yak')->info('Claude result event (sandboxed)', [
+                'task_id' => $request->task->id,
+                'is_error' => $resultEvent['is_error'] ?? false,
+                'subtype' => $resultEvent['subtype'] ?? null,
+                'result' => substr((string) ($resultEvent['result'] ?? ''), 0, 500),
+                'num_turns' => $resultEvent['num_turns'] ?? null,
+                'total_cost_usd' => $resultEvent['total_cost_usd'] ?? null,
+            ]);
+
+            return ClaudeCodeOutputParser::parse(json_encode($resultEvent, JSON_THROW_ON_ERROR))
+                ->withStderr($outcome->stderr);
+        }
+
+        if ($outcome->stderr !== '') {
+            return AgentRunResult::failure($outcome->stderr, '')->withStderr($outcome->stderr);
+        }
+
+        $finalText = $handler->getLastAssistantText();
+
+        if ($outcome->endedCleanlyWithoutResult() && $finalText !== '') {
+            $synthesized = [
+                'type' => 'result',
+                'subtype' => 'success',
+                'is_error' => false,
+                'result' => $finalText,
+                'session_id' => (string) $handler->getSessionId(),
+                'num_turns' => 0,
+                'total_cost_usd' => 0,
+                'duration_ms' => 0,
+                'synthesized' => true,
+            ];
+
+            Log::channel('yak')->warning('Claude result synthesized from final assistant message', [
+                'task_id' => $request->task->id,
+                'lines' => $outcome->lineCount,
+                'session_id' => $handler->getSessionId(),
+            ]);
+            TaskLogger::warning(
+                $request->task,
+                'No result event from Claude — result synthesized from its final message. Turn count and cost for this run are unknown.',
+                ['lines' => $outcome->lineCount, 'session_id' => $handler->getSessionId()],
+            );
+
+            return ClaudeCodeOutputParser::parse(json_encode($synthesized, JSON_THROW_ON_ERROR));
+        }
+
+        $terminationNote = $outcome->forcedTermination === 'stream_idle_timeout'
+            ? ' — terminated after stream idle timeout'
+            : '';
+
+        return AgentRunResult::failure(
+            "Claude Code stream ended without result event (lines={$outcome->lineCount}, exit={$outcome->exitCode}){$terminationNote}",
+            '',
+        );
+    }
+
+    /**
      * The actual streaming loop, split out so runStreaming() can wrap it
      * in a try/finally that marks the register_shutdown_function guard
-     * regardless of exception vs return.
+     * regardless of exception vs return. Reports what the stream left
+     * behind; runStreaming() decides what that means.
      */
     private function runStreamingInner(
         AgentRunRequest $request,
         string $containerName,
         string $command,
         StreamEventHandler $handler,
-    ): AgentRunResult {
+    ): StreamOutcome {
         assert($request->task !== null);
 
         [$process, $pipes] = $this->sandbox->streamExec($containerName, $command);
@@ -301,7 +453,7 @@ class SandboxedAgentRunner implements AgentRunner
                 $lineCount++;
                 $lastLineAt = microtime(true);
                 $lastHeartbeatAt = $lastLineAt;
-                $this->processLine($line, $handler);
+                $this->processLine($line, $handler, $request->task);
 
                 if ($resultReceivedAt === null && $handler->getResultEvent() !== null) {
                     $resultReceivedAt = microtime(true);
@@ -311,7 +463,7 @@ class SandboxedAgentRunner implements AgentRunner
                 if (! $status['running']) {
                     while (($line = fgets($stdout)) !== false) {
                         $lineCount++;
-                        $this->processLine($line, $handler);
+                        $this->processLine($line, $handler, $request->task);
                     }
                     break;
                 }
@@ -406,33 +558,12 @@ class SandboxedAgentRunner implements AgentRunner
             ]);
         }
 
-        $resultEvent = $handler->getResultEvent();
-
-        if ($resultEvent !== null) {
-            Log::channel('yak')->info('Claude result event (sandboxed)', [
-                'task_id' => $request->task->id,
-                'is_error' => $resultEvent['is_error'] ?? false,
-                'subtype' => $resultEvent['subtype'] ?? null,
-                'result' => substr((string) ($resultEvent['result'] ?? ''), 0, 500),
-                'num_turns' => $resultEvent['num_turns'] ?? null,
-                'total_cost_usd' => $resultEvent['total_cost_usd'] ?? null,
-            ]);
-
-            return ClaudeCodeOutputParser::parse(json_encode($resultEvent, JSON_THROW_ON_ERROR))
-                ->withStderr($stderrOutput);
-        }
-
-        if ($stderrOutput !== '') {
-            return AgentRunResult::failure($stderrOutput, '')->withStderr($stderrOutput);
-        }
-
-        $terminationNote = $forcedTermination === 'stream_idle_timeout'
-            ? ' — terminated after stream idle timeout'
-            : '';
-
-        return AgentRunResult::failure(
-            "Claude Code stream ended without result event (lines={$lineCount}, exit={$exitCode}){$terminationNote}",
-            '',
+        return new StreamOutcome(
+            resultEvent: $handler->getResultEvent(),
+            stderr: $stderrOutput,
+            exitCode: $exitCode,
+            lineCount: $lineCount,
+            forcedTermination: $forcedTermination,
         );
     }
 
@@ -536,7 +667,7 @@ class SandboxedAgentRunner implements AgentRunner
         }
     }
 
-    private function processLine(string $line, StreamEventHandler $handler): void
+    private function processLine(string $line, StreamEventHandler $handler, YakTask $task): void
     {
         $line = trim($line);
 
@@ -548,10 +679,38 @@ class SandboxedAgentRunner implements AgentRunner
         $event = json_decode($line, true);
 
         if (! is_array($event)) {
+            $this->warnMalformedLine($line, $task);
+
             return;
         }
 
         $handler->handle($event);
+    }
+
+    /**
+     * A non-empty stream line that is not JSON. Recorded on the task so a
+     * missing `result` event can be traced to a line the parser rejected
+     * rather than one the CLI never wrote.
+     */
+    private function warnMalformedLine(string $line, YakTask $task): void
+    {
+        $excerpt = mb_substr($line, 0, 200);
+
+        Log::channel('yak')->warning('Claude stream line is not valid JSON', [
+            'task_id' => $task->id,
+            'line' => $excerpt,
+            'length' => strlen($line),
+        ]);
+
+        if ($this->malformedLineWarnings >= self::MAX_MALFORMED_LINE_WARNINGS) {
+            return;
+        }
+
+        $this->malformedLineWarnings++;
+        TaskLogger::warning($task, 'Stream line is not valid JSON — ignored', [
+            'line' => $excerpt,
+            'length' => strlen($line),
+        ]);
     }
 
     /**

--- a/app/Agents/StreamEventHandler.php
+++ b/app/Agents/StreamEventHandler.php
@@ -23,6 +23,19 @@ class StreamEventHandler
     private ?array $resultEvent = null;
 
     /**
+     * Session id from the first stream event that carries one (the
+     * `system.init` event, normally). Captured early so the runner can
+     * `--resume` the session when the CLI exits before the `result` event.
+     */
+    private ?string $sessionId = null;
+
+    /**
+     * Full text of the most recent assistant message, untruncated. Used to
+     * synthesize a result when the stream ends without a `result` event.
+     */
+    private string $lastAssistantText = '';
+
+    /**
      * In-flight tool calls keyed by tool_use_id, so a result attaches to
      * the call it belongs to rather than to whichever call happened to be
      * most recent.
@@ -73,6 +86,11 @@ class StreamEventHandler
     {
         $type = $event['type'] ?? '';
 
+        $sessionId = $event['session_id'] ?? null;
+        if ($this->sessionId === null && is_string($sessionId) && $sessionId !== '') {
+            $this->sessionId = $sessionId;
+        }
+
         match ($type) {
             'assistant' => $this->handleAssistant($event),
             'user' => $this->handleUser($event),
@@ -89,6 +107,16 @@ class StreamEventHandler
     public function getResultEvent(): ?array
     {
         return $this->resultEvent;
+    }
+
+    public function getSessionId(): ?string
+    {
+        return $this->sessionId;
+    }
+
+    public function getLastAssistantText(): string
+    {
+        return $this->lastAssistantText;
     }
 
     /**
@@ -193,6 +221,8 @@ class StreamEventHandler
         if ($content === '') {
             return;
         }
+
+        $this->lastAssistantText = $content;
 
         // Truncate long assistant messages
         $display = mb_strlen($content) > 500

--- a/app/DataTransferObjects/StreamOutcome.php
+++ b/app/DataTransferObjects/StreamOutcome.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+/**
+ * What one `claude -p` stream invocation left behind, before the runner
+ * decides whether that amounts to a result, a resume, or a failure.
+ */
+final readonly class StreamOutcome
+{
+    /**
+     * @param  array<string, mixed>|null  $resultEvent
+     */
+    public function __construct(
+        public ?array $resultEvent,
+        public string $stderr,
+        public int $exitCode,
+        public int $lineCount,
+        public ?string $forcedTermination,
+    ) {}
+
+    /**
+     * The CLI exited on its own, cleanly, and never emitted a `result`
+     * event. Seen on task 5585: Claude committed and wrote its summary,
+     * then the process ended one second later with exit 0 and no stderr.
+     */
+    public function endedCleanlyWithoutResult(): bool
+    {
+        return $this->resultEvent === null
+            && $this->exitCode === 0
+            && $this->stderr === ''
+            && $this->forcedTermination === null;
+    }
+}

--- a/tests/Feature/Agents/SandboxedAgentRunnerTest.php
+++ b/tests/Feature/Agents/SandboxedAgentRunnerTest.php
@@ -688,3 +688,186 @@ it('points the sandbox CLI at the shared claude config dir', function () {
 
     expect($command)->toContain("CLAUDE_CONFIG_DIR='/home/yak/.claude' claude -p");
 });
+
+/**
+ * Fake sandbox whose streamExec replays a scripted sequence of stream-json
+ * line sets: the Nth `claude -p` invocation prints the Nth script and exits 0.
+ */
+class ScriptedStreamSandbox extends RecordingSandboxManager
+{
+    /** @param list<list<array<string, mixed>>> $scripts */
+    public function __construct(public array $scripts) {}
+
+    public int $streamCalls = 0;
+
+    public function streamExec(string $containerName, string $command, bool $asRoot = false): array
+    {
+        $this->calls[] = ['command' => $command, 'asRoot' => $asRoot, 'timeout' => null];
+
+        $events = $this->scripts[$this->streamCalls] ?? [];
+        $this->streamCalls++;
+
+        $lines = implode("\n", array_map(fn (array $e): string => json_encode($e), $events));
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open(['bash', '-c', sprintf('cat > /dev/null; printf "%%s\n" %s', escapeshellarg($lines))], $descriptors, $pipes);
+
+        return [$process, $pipes];
+    }
+
+    /** @return list<string> */
+    public function claudeCommands(): array
+    {
+        return array_values(array_map(
+            fn (array $c): string => $c['command'],
+            array_filter($this->calls, fn (array $c): bool => str_contains($c['command'], 'claude -p')),
+        ));
+    }
+}
+
+function truncatedStreamScript(string $sessionId, string $finalText): array
+{
+    return [
+        ['type' => 'system', 'subtype' => 'init', 'session_id' => $sessionId],
+        ['type' => 'assistant', 'session_id' => $sessionId, 'message' => ['content' => [['type' => 'text', 'text' => $finalText]]]],
+    ];
+}
+
+it('resumes the session in place when the stream ends cleanly without a result event', function () {
+    // Regression for task 5585: Claude committed, wrote its summary, then the
+    // CLI exited 0 without ever emitting the `result` line. The sandbox is
+    // still alive at that point, so resume the same session there instead of
+    // failing the task and losing the commit.
+    $task = YakTask::factory()->running()->create();
+
+    $sandbox = new ScriptedStreamSandbox([
+        truncatedStreamScript('sess_cut', '## Summary\nDone, committed.'),
+        [[
+            'type' => 'result',
+            'is_error' => false,
+            'result' => 'Finished: committed the change.',
+            'num_turns' => 2,
+            'total_cost_usd' => 0.05,
+            'duration_ms' => 100,
+            'session_id' => 'sess_cut',
+        ]],
+    ]);
+
+    $runner = new SandboxedAgentRunner($sandbox, postResultGraceSeconds: 0.1, streamPollIntervalSeconds: 0);
+    $result = $runner->run(buildAgentRunRequest($task));
+
+    $commands = $sandbox->claudeCommands();
+    expect($commands)->toHaveCount(2);
+    expect($commands[0])->not->toContain('--resume');
+    expect($commands[1])->toContain("--resume 'sess_cut'");
+
+    expect($result->isError)->toBeFalse();
+    expect($result->resultSummary)->toBe('Finished: committed the change.');
+    expect($result->sessionId)->toBe('sess_cut');
+
+    $log = TaskLog::where('yak_task_id', $task->id)
+        ->where('message', 'like', '%without a result event%')
+        ->first();
+    expect($log)->not->toBeNull();
+    expect($log->level)->toBe('warning');
+});
+
+it('synthesizes a success result from the final assistant message when the resume also ends without a result event', function () {
+    $task = YakTask::factory()->running()->create();
+
+    $sandbox = new ScriptedStreamSandbox([
+        truncatedStreamScript('sess_cut', '## Summary\nDone, committed.'),
+        truncatedStreamScript('sess_cut', 'Already finished. The change is committed.'),
+    ]);
+
+    $runner = new SandboxedAgentRunner($sandbox, postResultGraceSeconds: 0.1, streamPollIntervalSeconds: 0);
+    $result = $runner->run(buildAgentRunRequest($task));
+
+    expect($sandbox->claudeCommands())->toHaveCount(2);
+    expect($result->isError)->toBeFalse();
+    expect($result->resultSummary)->toBe('Already finished. The change is committed.');
+    expect($result->sessionId)->toBe('sess_cut');
+
+    $log = TaskLog::where('yak_task_id', $task->id)
+        ->where('message', 'like', '%synthesized%')
+        ->first();
+    expect($log)->not->toBeNull();
+    expect($log->level)->toBe('warning');
+});
+
+it('still fails when the stream ends without a result event and Claude never said anything', function () {
+    $task = YakTask::factory()->running()->create();
+
+    $sandbox = new ScriptedStreamSandbox([
+        [['type' => 'system', 'subtype' => 'init', 'session_id' => 'sess_silent']],
+        [['type' => 'system', 'subtype' => 'init', 'session_id' => 'sess_silent']],
+    ]);
+
+    $runner = new SandboxedAgentRunner($sandbox, postResultGraceSeconds: 0.1, streamPollIntervalSeconds: 0);
+    $result = $runner->run(buildAgentRunRequest($task));
+
+    expect($sandbox->claudeCommands())->toHaveCount(2);
+    expect($result->isError)->toBeTrue();
+    expect($result->resultSummary)->toContain('without result event');
+});
+
+it('does not resume when there is no session id to resume', function () {
+    $task = YakTask::factory()->running()->create();
+
+    $sandbox = new ScriptedStreamSandbox([
+        [['type' => 'assistant', 'message' => ['content' => [['type' => 'text', 'text' => 'hi']]]]],
+    ]);
+
+    $runner = new SandboxedAgentRunner($sandbox, postResultGraceSeconds: 0.1, streamPollIntervalSeconds: 0);
+    $result = $runner->run(buildAgentRunRequest($task));
+
+    expect($sandbox->claudeCommands())->toHaveCount(1);
+    // No session to resume, but a final message exists: synthesize rather than fail.
+    expect($result->isError)->toBeFalse();
+    expect($result->resultSummary)->toBe('hi');
+});
+
+it('records stream lines that are not valid JSON on the task log instead of dropping them silently', function () {
+    $task = YakTask::factory()->running()->create();
+
+    $sandbox = new class extends RecordingSandboxManager
+    {
+        public function streamExec(string $containerName, string $command, bool $asRoot = false): array
+        {
+            $this->calls[] = ['command' => $command, 'asRoot' => $asRoot, 'timeout' => null];
+
+            $resultEvent = json_encode([
+                'type' => 'result',
+                'is_error' => false,
+                'result' => 'ok',
+                'num_turns' => 1,
+                'total_cost_usd' => 0.0,
+                'duration_ms' => 1,
+                'session_id' => 'sess_garbage',
+            ]);
+
+            $descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+            $shell = sprintf('cat > /dev/null; echo "not json at all {"; echo %s', escapeshellarg($resultEvent));
+            $process = proc_open(['bash', '-c', $shell], $descriptors, $pipes);
+
+            return [$process, $pipes];
+        }
+    };
+
+    $runner = new SandboxedAgentRunner($sandbox, postResultGraceSeconds: 0.1, streamPollIntervalSeconds: 0);
+    $result = $runner->run(buildAgentRunRequest($task));
+
+    expect($result->isError)->toBeFalse();
+
+    $log = TaskLog::where('yak_task_id', $task->id)
+        ->where('level', 'warning')
+        ->where('message', 'like', '%not valid JSON%')
+        ->first();
+    expect($log)->not->toBeNull();
+    expect($log->metadata['line'] ?? null)->toBe('not json at all {');
+});

--- a/tests/Feature/Agents/StreamEventHandlerTest.php
+++ b/tests/Feature/Agents/StreamEventHandlerTest.php
@@ -494,3 +494,37 @@ test('heartbeat is a no-op when no tool is pending but still touches the task', 
     expect(TaskLog::where('yak_task_id', $this->task->id)->count())->toBe(0);
     expect($this->task->fresh()->updated_at->greaterThan($before))->toBeTrue();
 });
+
+test('captures the session id from the first event that carries one', function () {
+    expect($this->handler->getSessionId())->toBeNull();
+
+    $this->handler->handle([
+        'type' => 'system',
+        'subtype' => 'init',
+        'session_id' => 'sess_from_init',
+    ]);
+
+    $this->handler->handle([
+        'type' => 'assistant',
+        'session_id' => 'sess_from_init',
+        'message' => ['content' => [['type' => 'text', 'text' => 'hello']]],
+    ]);
+
+    expect($this->handler->getSessionId())->toBe('sess_from_init');
+});
+
+test('keeps the full text of the most recent assistant message', function () {
+    $longText = str_repeat('x', 800);
+
+    $this->handler->handle([
+        'type' => 'assistant',
+        'message' => ['content' => [['type' => 'text', 'text' => 'first']]],
+    ]);
+    $this->handler->handle([
+        'type' => 'assistant',
+        'message' => ['content' => [['type' => 'text', 'text' => $longText]]],
+    ]);
+
+    // The task log truncates at 500 chars; the handler keeps the whole message.
+    expect($this->handler->getLastAssistantText())->toBe($longText);
+});


### PR DESCRIPTION
## Why

Task 5585 (https://geocodio.yak.build/tasks/5585) committed its change, wrote its summary, then the Claude CLI exited 0 one second later without emitting the `result` event. Yak failed the task with `Claude Code stream ended without result event (lines=189, exit=0)` and destroyed the sandbox, so the commit was lost and no PR was opened. Three other tasks on the same CLI version succeeded minutes later, so this was a one-off truncation, not a version issue.

## What changes

- `StreamEventHandler` captures the session id from the first event that carries one, and keeps the full text of the last assistant message.
- `SandboxedAgentRunner` now returns a `StreamOutcome` from the stream loop and decides afterwards:
  1. A `result` event is used as before.
  2. Clean exit (code 0, no stderr, no forced termination) with no result and a known session id: `--resume` that session in the same sandbox with a short "finish and report" prompt. One attempt by default (`maxResumeAttempts`).
  3. Still no result but Claude wrote a final message: synthesize a success result from that message, flag it on the task timeline as synthesized, and continue to push and PR creation.
  4. Otherwise fail as before.
- Stream lines that fail to decode as JSON are logged to `yak.log`, and the first three are recorded on the task timeline, instead of being dropped silently.

## Notes

- A synthesized result has unknown turn count and cost for that run; the task log says so.
- The resume path does not reduce the budget by what the first run spent, because without a result event that number is unknown.

## Tests

`tests/Feature/Agents/SandboxedAgentRunnerTest.php` and `StreamEventHandlerTest.php` cover: resume command carries `--resume <session>`, synthesized fallback, failure when Claude never spoke, no-session case, and malformed line warnings.

https://claude.ai/code/session_018Kv7KLnMinzeBKV4KnRsfE
