### PR TITLE
feat(tasks): show PR state, requester, preview link, and hover GIF in the task list

### DIFF
--- a/app/Livewire/Tasks/TaskList.php
+++ b/app/Livewire/Tasks/TaskList.php
@@ -3,13 +3,16 @@
 namespace App\Livewire\Tasks;
 
 use App\Channels\ChannelRegistry;
+use App\Enums\DeploymentStatus;
 use App\Enums\TaskMode;
 use App\Enums\TaskStatus;
 use App\Livewire\Tasks\Support\ArtifactPreviewUrl;
 use App\Models\Artifact;
+use App\Models\BranchDeployment;
 use App\Models\Repository;
 use App\Models\YakTask;
 use App\Support\Docs;
+use Carbon\CarbonInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -21,6 +24,7 @@ use Livewire\WithPagination;
 
 /**
  * @property-read LengthAwarePaginator<int, YakTask> $tasks
+ * @property-read Collection<string, BranchDeployment> $deploymentsByTask
  */
 #[Title('Tasks')]
 class TaskList extends Component
@@ -39,6 +43,19 @@ class TaskList extends Component
     #[Url]
     public string $repo = '';
 
+    /** PR lifecycle filter: '', 'open', 'merged', 'closed', or 'none'. */
+    #[Url]
+    public string $pr = '';
+
+    #[Url]
+    public string $sort = 'created_at';
+
+    #[Url]
+    public string $direction = 'desc';
+
+    /** @var list<string> */
+    public const SORTABLE_COLUMNS = ['status', 'source', 'author_name', 'repo', 'created_at'];
+
     /**
      * @return LengthAwarePaginator<int, YakTask>
      */
@@ -51,8 +68,89 @@ class TaskList extends Component
             ->when($this->status !== '', fn ($query) => $query->where('status', $this->status))
             ->when($this->tab === 'tasks' && $this->source !== '', fn ($query) => $query->where('source', $this->source))
             ->when($this->repo !== '', fn ($query) => $query->where('repo', $this->repo))
-            ->latest()
+            ->when($this->pr !== '', fn ($query) => $this->applyPrFilter($query, $this->pr))
+            ->orderBy($this->sortColumn(), $this->sortDirection())
+            ->orderByDesc('id')
             ->paginate(50);
+    }
+
+    /**
+     * @param  Builder<YakTask>  $query
+     * @return Builder<YakTask>
+     */
+    protected function applyPrFilter(Builder $query, string $state): Builder
+    {
+        return match ($state) {
+            'open' => $query->whereNotNull('pr_url')->whereNull('pr_merged_at')->whereNull('pr_closed_at'),
+            'merged' => $query->whereNotNull('pr_merged_at'),
+            'closed' => $query->whereNotNull('pr_closed_at')->whereNull('pr_merged_at'),
+            'none' => $query->whereNull('pr_url'),
+            default => $query,
+        };
+    }
+
+    protected function sortColumn(): string
+    {
+        return in_array($this->sort, self::SORTABLE_COLUMNS, true) ? $this->sort : 'created_at';
+    }
+
+    protected function sortDirection(): string
+    {
+        return $this->direction === 'asc' ? 'asc' : 'desc';
+    }
+
+    /**
+     * Clicking a column header sorts by it; clicking the active column
+     * flips the direction. Created defaults to newest first, everything
+     * else to ascending.
+     */
+    public function sortBy(string $column): void
+    {
+        if (! in_array($column, self::SORTABLE_COLUMNS, true)) {
+            return;
+        }
+
+        if ($this->sort === $column) {
+            $this->direction = $this->direction === 'asc' ? 'desc' : 'asc';
+        } else {
+            $this->sort = $column;
+            $this->direction = $column === 'created_at' ? 'desc' : 'asc';
+        }
+
+        $this->resetPage();
+    }
+
+    /**
+     * Live branch deployments for the roots on the current page, keyed by
+     * "repo slug/branch name" so the table can show a preview link without
+     * a per-row lookup.
+     *
+     * @return Collection<string, BranchDeployment>
+     */
+    #[Computed]
+    public function deploymentsByTask(): Collection
+    {
+        $tasks = collect($this->tasks->items())->filter(fn (YakTask $task) => $task->branch_name !== null);
+
+        if ($tasks->isEmpty()) {
+            return collect();
+        }
+
+        return BranchDeployment::query()
+            ->with('repository')
+            ->whereIn('branch_name', $tasks->pluck('branch_name')->unique()->values())
+            ->whereNotIn('status', [DeploymentStatus::Destroyed, DeploymentStatus::Destroying])
+            ->get()
+            ->keyBy(fn (BranchDeployment $deployment): string => $deployment->repository->slug . '/' . $deployment->branch_name);
+    }
+
+    public function deploymentFor(YakTask $task): ?BranchDeployment
+    {
+        if ($task->branch_name === null) {
+            return null;
+        }
+
+        return $this->deploymentsByTask->get($task->repo . '/' . $task->branch_name);
     }
 
     /**
@@ -234,6 +332,12 @@ class TaskList extends Component
         $this->status = '';
         $this->source = '';
         $this->repo = '';
+        $this->pr = '';
+        $this->resetPage();
+    }
+
+    public function updatedPr(): void
+    {
         $this->resetPage();
     }
 
@@ -295,6 +399,55 @@ class TaskList extends Component
             TaskStatus::Expired => 'bg-[rgba(200,184,154,0.12)] text-[#c8b89a]',
             TaskStatus::Cancelled => 'bg-[rgba(200,184,154,0.12)] text-[#c8b89a]',
         };
+    }
+
+    /**
+     * Fill colour for the compact status dot in the task table. The full
+     * label lives in the dot's tooltip and visually-hidden text.
+     */
+    public static function statusDotClasses(TaskStatus $status): string
+    {
+        return match ($status) {
+            TaskStatus::Pending => 'bg-[#6b8fa3]',
+            TaskStatus::Running => 'bg-[#8fb3c4] animate-pulse',
+            TaskStatus::AwaitingClarification => 'bg-[#d4915e]',
+            TaskStatus::AwaitingCi => 'bg-[#8fb3c4] animate-pulse',
+            TaskStatus::Retrying => 'bg-[#d4915e] animate-pulse',
+            TaskStatus::Success => 'bg-[#7a8c5e]',
+            TaskStatus::Failed => 'bg-[#b85450]',
+            TaskStatus::Expired => 'bg-[#c8b89a]',
+            TaskStatus::Cancelled => 'bg-[#e0b84c]',
+        };
+    }
+
+    public static function statusLabel(TaskStatus $status): string
+    {
+        return str_replace('_', ' ', $status->value);
+    }
+
+    /**
+     * Badge classes for the PR lifecycle column.
+     */
+    public static function prStateBadgeClasses(string $state): string
+    {
+        return match ($state) {
+            'merged' => 'bg-[rgba(139,92,246,0.12)] text-[#7c5cbf]',
+            'closed' => 'bg-[rgba(184,84,80,0.12)] text-[#b85450]',
+            default => 'bg-[rgba(122,140,94,0.12)] text-[#7a8c5e]',
+        };
+    }
+
+    /**
+     * Relative age shown in the table, e.g. "3h ago". The tooltip carries
+     * the absolute timestamps.
+     */
+    public static function formatAge(?CarbonInterface $timestamp): string
+    {
+        if ($timestamp === null) {
+            return '—';
+        }
+
+        return $timestamp->diffForHumans(['short' => true, 'parts' => 1]);
     }
 
     public static function formatDuration(?int $durationMs): string

--- a/app/Models/YakTask.php
+++ b/app/Models/YakTask.php
@@ -146,6 +146,27 @@ class YakTask extends Model
     }
 
     /**
+     * Lifecycle of the task's PR: 'open', 'merged', or 'closed'. Null when
+     * the task never opened a PR.
+     */
+    public function prState(): ?string
+    {
+        if ($this->pr_url === null) {
+            return null;
+        }
+
+        if ($this->pr_merged_at !== null) {
+            return 'merged';
+        }
+
+        if ($this->pr_closed_at !== null) {
+            return 'closed';
+        }
+
+        return 'open';
+    }
+
+    /**
      * The whole follow-up conversation this task belongs to: the chain's
      * root plus every descendant, ordered oldest-first. Each follow-up's
      * parent is the previous head, so the chain is walked up to the root

--- a/resources/views/components/tasks/sort-header.blade.php
+++ b/resources/views/components/tasks/sort-header.blade.php
@@ -1,0 +1,20 @@
+@props(['column', 'sort', 'direction'])
+
+@php($active = $sort === $column)
+
+<button
+    type="button"
+    wire:click="sortBy('{{ $column }}')"
+    class="inline-flex items-center gap-1 uppercase tracking-wider transition-colors hover:text-zinc-800 dark:hover:text-zinc-200 {{ $active ? 'text-zinc-800 dark:text-zinc-200' : '' }}"
+    aria-sort="{{ $active ? ($direction === 'asc' ? 'ascending' : 'descending') : 'none' }}"
+    data-testid="sort-{{ $column }}"
+>
+    {{ $slot }}
+    @if($active)
+        @if($direction === 'asc')
+            <flux:icon.chevron-up class="!size-3" />
+        @else
+            <flux:icon.chevron-down class="!size-3" />
+        @endif
+    @endif
+</button>

--- a/resources/views/livewire/tasks/task-list.blade.php
+++ b/resources/views/livewire/tasks/task-list.blade.php
@@ -1,5 +1,20 @@
 <div wire:poll.15s>
-    <div x-data="{ newTaskOpen: false }">
+    <div
+        x-data="{
+            newTaskOpen: false,
+            hoverPreview: null,
+            showPreview(src) {
+                if (! src || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                    return;
+                }
+
+                this.hoverPreview = src;
+            },
+            hidePreview() {
+                this.hoverPreview = null;
+            },
+        }"
+    >
         {{-- Getting started card (shown when the install is bare and the user hasn't dismissed it) --}}
     @if($this->showSetupCard)
         <div class="mb-5 rounded-[20px] border border-yak-orange/30 bg-gradient-to-br from-yak-orange/5 to-yak-cream p-5" data-testid="setup-card">
@@ -115,7 +130,19 @@
             </flux:select>
         </div>
 
-        @if($status !== '' || $source !== '' || $repo !== '')
+        @if($tab === 'tasks')
+            <div class="w-full sm:w-40">
+                <flux:select wire:model.live="pr" size="sm" aria-label="Filter by PR state">
+                    <flux:select.option value="">All PRs</flux:select.option>
+                    <flux:select.option value="open">Open</flux:select.option>
+                    <flux:select.option value="merged">Merged</flux:select.option>
+                    <flux:select.option value="closed">Closed</flux:select.option>
+                    <flux:select.option value="none">No PR</flux:select.option>
+                </flux:select>
+            </div>
+        @endif
+
+        @if($status !== '' || $source !== '' || $repo !== '' || $pr !== '')
             <flux:button size="sm" variant="ghost" icon="x-mark" wire:click="clearFilters" data-testid="clear-filters">Clear</flux:button>
         @endif
 
@@ -132,28 +159,51 @@
 
     <div class="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
         <table class="w-full text-sm">
+            @php($headerClasses = 'px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400')
             <thead>
                 <tr class="border-b border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800">
-                    <th class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400">Status</th>
-                    <th class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400">Source</th>
-                    <th class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400">Repo</th>
-                    <th class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400">ID</th>
-                    <th class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400">Description</th>
-                    <th class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400">Duration</th>
-                    <th class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-zinc-500 sm:px-5 dark:text-zinc-400">PR</th>
+                    <th class="{{ $headerClasses }}"><x-tasks.sort-header column="status" :sort="$sort" :direction="$direction"><span class="sr-only">Status</span></x-tasks.sort-header></th>
+                    <th class="{{ $headerClasses }}"><x-tasks.sort-header column="source" :sort="$sort" :direction="$direction">Source</x-tasks.sort-header></th>
+                    <th class="{{ $headerClasses }}"><x-tasks.sort-header column="author_name" :sort="$sort" :direction="$direction">By</x-tasks.sort-header></th>
+                    <th class="{{ $headerClasses }}"><x-tasks.sort-header column="repo" :sort="$sort" :direction="$direction">Repo</x-tasks.sort-header></th>
+                    <th class="{{ $headerClasses }}">ID</th>
+                    <th class="{{ $headerClasses }}">Description</th>
+                    <th class="{{ $headerClasses }}">PR</th>
+                    <th class="{{ $headerClasses }}"><x-tasks.sort-header column="created_at" :sort="$sort" :direction="$direction">Created</x-tasks.sort-header></th>
                 </tr>
             </thead>
             <tbody class="divide-y divide-zinc-200 dark:divide-zinc-700">
                 @forelse($this->tasks as $task)
+                    @php($children = $task->branch_name ? ($this->descendantsByBranch[$task->branch_name] ?? collect()) : collect())
+                    @php($preview = $this->previewsByTask[$task->id] ?? null)
+                    @php($prState = $task->prState())
+                    @php($deployment = $this->deploymentFor($task))
                     {{-- `transform: translateZ(0)` forces Safari to treat the <tr> as a containing block for
                          the stretched-link anchor below. Without it, Safari leaks the anchor up to the viewport,
-                         every row's anchor stacks, and every tap hits the last row. --}}
-                    <tr wire:key="task-{{ $task->id }}" class="relative h-14 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/50" style="transform: translateZ(0)">
-                        <td class="px-3 py-2 sm:px-5">
+                         every row's anchor stacks, and every tap hits the last row.
+
+                         Rows with a preview GIF hand its URL to the shared `hoverPreview` overlay on hover.
+                         The overlay is Alpine-only so the 15s poll cannot reset the GIF mid-hover, and the
+                         GIF is only fetched once a row is actually hovered. --}}
+                    <tr
+                        wire:key="task-{{ $task->id }}"
+                        class="relative h-14 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+                        style="transform: translateZ(0)"
+                        @if($preview && $preview['gif'])
+                            data-preview-src="{{ $preview['gif'] }}"
+                            data-testid="task-row-preview-{{ $task->id }}"
+                            @mouseenter="showPreview($el.dataset.previewSrc)"
+                            @mouseleave="hidePreview()"
+                        @endif
+                    >
+                        <td class="w-px whitespace-nowrap px-3 py-2 sm:px-5">
                             <a href="{{ route('tasks.show', $task) }}" wire:navigate class="absolute inset-0" aria-label="Open task {{ $task->external_id ?? $task->id }}"></a>
-                            <span class="inline-block rounded-lg px-3 py-1 text-xs font-medium {{ \App\Livewire\Tasks\TaskList::statusBadgeClasses($task->status) }}">
-                                {{ str_replace('_', ' ', $task->status->value) }}
-                            </span>
+                            <flux:tooltip :content="ucfirst(\App\Livewire\Tasks\TaskList::statusLabel($task->status))">
+                                <span class="relative inline-flex items-center justify-center p-1" data-testid="status-dot-{{ $task->id }}">
+                                    <span class="block size-2.5 rounded-full {{ \App\Livewire\Tasks\TaskList::statusDotClasses($task->status) }}"></span>
+                                    <span class="sr-only">{{ \App\Livewire\Tasks\TaskList::statusLabel($task->status) }}</span>
+                                </span>
+                            </flux:tooltip>
                         </td>
                         <td class="px-3 py-2 sm:px-5">
                             <div class="flex items-center gap-1.5">
@@ -169,95 +219,109 @@
                                 <span class="text-zinc-700 dark:text-zinc-300">{{ ucfirst($task->source ?? 'manual') }}</span>
                             </div>
                         </td>
+                        <td class="max-w-[10rem] truncate px-3 py-2 text-zinc-700 sm:px-5 dark:text-zinc-300" data-testid="task-author-{{ $task->id }}">
+                            {{ $task->author_name ?? '—' }}
+                        </td>
                         <td class="px-3 py-2 text-zinc-700 sm:px-5 dark:text-zinc-300">
-                            @if($task->repository)
+                            @if($task->pr_url)
+                                <a href="{{ $task->pr_url }}" target="_blank" rel="noopener noreferrer" class="relative font-medium text-accent hover:underline" title="Open the PR on GitHub">{{ $task->repo }}</a>
+                            @elseif($task->repository)
                                 <a href="{{ route('repos.edit', $task->repository) }}" wire:navigate class="relative font-medium text-accent hover:underline">{{ $task->repo }}</a>
                             @else
                                 {{ $task->repo ?? '—' }}
                             @endif
                         </td>
-                        <td class="px-3 py-2 sm:px-5">
+                        <td class="whitespace-nowrap px-3 py-2 sm:px-5">
                             @if($task->external_url)
                                 <a href="{{ $task->external_url }}" target="_blank" class="relative font-medium text-accent hover:underline">{{ $task->external_id }}</a>
                             @else
                                 <span class="text-zinc-700 dark:text-zinc-300">{{ $task->external_id ?? '—' }}</span>
                             @endif
                         </td>
-                        <td class="max-w-xs px-3 py-2 text-zinc-700 sm:px-5 dark:text-zinc-300">
-                            @php($children = $task->branch_name ? ($this->descendantsByBranch[$task->branch_name] ?? collect()) : collect())
-                            @php($preview = $this->previewsByTask[$task->id] ?? null)
-                            <div class="flex items-center gap-2">
+                        {{-- `w-full max-w-0` lets this cell absorb the remaining width in an auto-layout table
+                             while still truncating, so the fixed columns to its right never get clipped. --}}
+                        <td class="w-full max-w-0 px-3 py-2 text-zinc-700 sm:px-5 dark:text-zinc-300">
+                            <div class="flex min-w-0 items-center gap-2">
                                 @if($preview)
-                                    {{-- Alpine-only swap: the list polls every 15s, and a Livewire
-                                         round-trip here would reset the GIF mid-hover. The GIF URL
-                                         rides along in a data attribute and is only assigned to
-                                         `src` on the first hover, so nothing is fetched on load. --}}
                                     <a
                                         href="{{ route('tasks.show', $task) }}?t=0"
                                         wire:navigate
                                         wire:key="preview-{{ $task->id }}"
                                         class="relative shrink-0"
                                         aria-label="Open the walkthrough for task {{ $task->external_id ?? $task->id }}"
-                                        @if($preview['gif']) data-preview-src="{{ $preview['gif'] }}" @endif
                                         data-testid="task-preview-{{ $task->id }}"
-                                        x-data="{
-                                            src: @js($preview['poster']),
-                                            swapped: false,
-                                            swap() {
-                                                if (this.swapped || ! this.$el.dataset.previewSrc) {
-                                                    return;
-                                                }
-
-                                                if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-                                                    return;
-                                                }
-
-                                                this.src = this.$el.dataset.previewSrc;
-                                                this.swapped = true;
-                                            },
-                                        }"
-                                        @mouseenter="swap()"
-                                        @focus="swap()"
                                     >
-                                        <img :src="src" alt="" loading="lazy" class="h-8 w-14 rounded-md border border-zinc-200 object-cover dark:border-zinc-700" />
+                                        <img src="{{ $preview['poster'] }}" alt="" loading="lazy" class="h-8 w-14 rounded-md border border-zinc-200 object-cover dark:border-zinc-700" />
                                     </a>
                                 @endif
-                                <span class="truncate">{{ \Illuminate\Support\Str::limit($task->description, 60) }}</span>
+                                <span class="truncate">{{ \Illuminate\Support\Str::limit($task->description, 140) }}</span>
                                 @if($children->isNotEmpty())
                                     <span class="shrink-0 rounded-full bg-[rgba(212,145,94,0.12)] px-2 py-0.5 text-[10px] font-semibold text-[#d4915e]">{{ $children->count() }} follow-ups</span>
                                 @endif
                             </div>
                         </td>
-                        <td class="px-3 py-2 text-zinc-500 sm:px-5 dark:text-zinc-400">{{ \App\Livewire\Tasks\TaskList::formatDuration($task->duration_ms) }}</td>
-                        <td class="px-3 py-2 sm:px-5">
-                            @if($task->pr_url)
-                                <a href="{{ $task->pr_url }}" target="_blank" class="relative font-medium text-accent hover:underline">PR</a>
+                        <td class="whitespace-nowrap px-3 py-2 sm:px-5">
+                            @if($prState !== null)
+                                <a
+                                    href="{{ $task->pr_url }}"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="relative inline-block rounded-lg px-2.5 py-0.5 text-xs font-medium hover:underline {{ \App\Livewire\Tasks\TaskList::prStateBadgeClasses($prState) }}"
+                                    data-testid="pr-state-{{ $task->id }}"
+                                >{{ ucfirst($prState) }}</a>
                             @else
                                 <span class="text-zinc-400">—</span>
                             @endif
+                            @if($deployment)
+                                <flux:tooltip content="Open the branch preview ({{ ucfirst($deployment->status->value) }})">
+                                    <a
+                                        href="https://{{ $deployment->hostname }}"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="relative ml-1.5 inline-flex align-middle text-zinc-400 hover:text-accent"
+                                        aria-label="Open the branch preview for task {{ $task->external_id ?? $task->id }}"
+                                        data-testid="task-preview-link-{{ $task->id }}"
+                                    >
+                                        <flux:icon.globe-alt class="!size-4" />
+                                    </a>
+                                </flux:tooltip>
+                            @endif
+                        </td>
+                        <td class="whitespace-nowrap px-3 py-2 text-zinc-500 sm:px-5 dark:text-zinc-400">
+                            <flux:tooltip content="Created {{ $task->created_at?->format('M j, Y H:i') }} · Updated {{ $task->updated_at?->format('M j, Y H:i') }} · Ran for {{ \App\Livewire\Tasks\TaskList::formatDuration($task->duration_ms) }}">
+                                <span class="relative">{{ \App\Livewire\Tasks\TaskList::formatAge($task->created_at) }}</span>
+                            </flux:tooltip>
                         </td>
                     </tr>
                     @foreach($children as $child)
                         <tr wire:key="child-{{ $child->id }}" class="relative h-12 bg-zinc-50/60 transition-colors hover:bg-zinc-100/60 dark:bg-zinc-800/30 dark:hover:bg-zinc-800/60" style="transform: translateZ(0)">
-                            <td class="py-2 pl-8 pr-3 sm:pr-5">
+                            <td class="w-px whitespace-nowrap py-2 pl-8 pr-3 sm:pr-5">
                                 <a href="{{ route('tasks.show', $child) }}" wire:navigate class="absolute inset-0" aria-label="Open task {{ $child->external_id ?? $child->id }}"></a>
-                                <span class="inline-block rounded-lg px-3 py-1 text-xs font-medium {{ \App\Livewire\Tasks\TaskList::statusBadgeClasses($child->status) }}">
-                                    {{ str_replace('_', ' ', $child->status->value) }}
-                                </span>
+                                <flux:tooltip :content="ucfirst(\App\Livewire\Tasks\TaskList::statusLabel($child->status))">
+                                    <span class="relative inline-flex items-center justify-center p-1">
+                                        <span class="block size-2.5 rounded-full {{ \App\Livewire\Tasks\TaskList::statusDotClasses($child->status) }}"></span>
+                                        <span class="sr-only">{{ \App\Livewire\Tasks\TaskList::statusLabel($child->status) }}</span>
+                                    </span>
+                                </flux:tooltip>
                             </td>
                             <td class="px-3 py-2 text-zinc-400 sm:px-5 dark:text-zinc-600">—</td>
+                            <td class="max-w-[10rem] truncate px-3 py-2 text-zinc-500 sm:px-5 dark:text-zinc-400">{{ $child->author_name ?? '—' }}</td>
                             <td class="px-3 py-2 text-zinc-400 sm:px-5 dark:text-zinc-600">—</td>
-                            <td class="px-3 py-2 sm:px-5">
+                            <td class="whitespace-nowrap px-3 py-2 sm:px-5">
                                 <span class="text-zinc-500 dark:text-zinc-400">{{ $child->external_id ?? '—' }}</span>
                             </td>
-                            <td class="max-w-xs truncate px-3 py-2 text-zinc-500 sm:px-5 dark:text-zinc-400">{{ \Illuminate\Support\Str::limit($child->description, 60) }}</td>
-                            <td class="px-3 py-2 text-zinc-400 sm:px-5 dark:text-zinc-600">{{ \App\Livewire\Tasks\TaskList::formatDuration($child->duration_ms) }}</td>
+                            <td class="w-full max-w-0 truncate px-3 py-2 text-zinc-500 sm:px-5 dark:text-zinc-400">{{ \Illuminate\Support\Str::limit($child->description, 140) }}</td>
                             <td class="px-3 py-2 text-zinc-400 sm:px-5 dark:text-zinc-600">—</td>
+                            <td class="whitespace-nowrap px-3 py-2 text-zinc-400 sm:px-5 dark:text-zinc-600">
+                                <flux:tooltip content="Created {{ $child->created_at?->format('M j, Y H:i') }} · Ran for {{ \App\Livewire\Tasks\TaskList::formatDuration($child->duration_ms) }}">
+                                    <span class="relative">{{ \App\Livewire\Tasks\TaskList::formatAge($child->created_at) }}</span>
+                                </flux:tooltip>
+                            </td>
                         </tr>
                     @endforeach
                 @empty
                     <tr>
-                        <td colspan="7" class="px-3 py-16 text-center text-zinc-500 sm:px-5 dark:text-zinc-400">
+                        <td colspan="8" class="px-3 py-16 text-center text-zinc-500 sm:px-5 dark:text-zinc-400">
                             <div class="flex flex-col items-center gap-3">
                                 <p class="text-sm">No tasks yet. Yak picks up work from your configured channels.</p>
                                 <x-doc-link anchor="channels" class="text-sm">How tasks get created</x-doc-link>
@@ -267,6 +331,28 @@
                 @endforelse
             </tbody>
         </table>
+    </div>
+
+    {{-- Floating walkthrough preview. Pointer events are off so the hovered row keeps its hover state
+         while the GIF is shown as large as the viewport allows. --}}
+    <div
+        x-show="hoverPreview !== null"
+        x-cloak
+        x-transition.opacity.duration.150ms
+        class="pointer-events-none fixed inset-0 z-40 flex items-center justify-center p-6"
+        style="display:none"
+        data-testid="hover-preview-overlay"
+        aria-hidden="true"
+    >
+        <img
+            :src="hoverPreview ?? ''"
+            alt=""
+            {{-- Preview GIFs are encoded at 720px wide, so the height is derived from the viewport and the
+                 width follows the GIF's own aspect ratio. This upscales it to fill the screen without distortion. --}}
+            style="height: min(85vh, calc(90vw * 9 / 16)); width: auto;"
+            class="max-w-[90vw] rounded-xl border border-zinc-200 bg-white object-contain shadow-2xl dark:border-zinc-700 dark:bg-zinc-900"
+            data-testid="hover-preview-image"
+        />
     </div>
 
     @if($this->tasks->hasPages())

--- a/tests/Browser/TaskListPreviewHoverTest.php
+++ b/tests/Browser/TaskListPreviewHoverTest.php
@@ -4,7 +4,7 @@ use App\Models\Artifact;
 use App\Models\User;
 use App\Models\YakTask;
 
-test('hovering a task-list thumbnail swaps in the preview gif', function () {
+test('hovering a task row with a preview gif shows it in the floating overlay', function () {
     if (! file_exists(base_path('node_modules/playwright-core'))) {
         $this->markTestSkipped('Playwright browsers are unavailable in this environment.');
     }
@@ -20,12 +20,13 @@ test('hovering a task-list thumbnail swaps in the preview gif', function () {
         'disk_path' => 'walkthrough-preview.gif',
     ]);
 
-    $selector = '[data-testid="task-preview-' . $task->id . '"] img';
+    $overlayImage = '[data-testid="hover-preview-image"]';
 
     $page = visit(route('tasks'));
 
     $page->assertSee('Hover preview task')
-        ->assertAttributeContains($selector, 'src', 'walkthrough-thumbnail.jpg')
-        ->hover('[data-testid="task-preview-' . $task->id . '"]')
-        ->assertAttributeContains($selector, 'src', 'walkthrough-preview.gif');
+        ->assertMissing('[data-testid="hover-preview-overlay"]')
+        ->hover('[data-testid="task-row-preview-' . $task->id . '"]')
+        ->assertVisible('[data-testid="hover-preview-overlay"]')
+        ->assertAttributeContains($overlayImage, 'src', '/artifacts/public/');
 });

--- a/tests/Feature/Livewire/Tasks/TaskListPreviewTest.php
+++ b/tests/Feature/Livewire/Tasks/TaskListPreviewTest.php
@@ -10,7 +10,7 @@ beforeEach(function () {
     $this->actingAs(User::factory()->create());
 });
 
-test('a task with a preview artifact renders a poster and a data-preview-src', function () {
+test('a task with a preview artifact renders a poster and hands the gif to the row hover overlay', function () {
     $task = YakTask::factory()->success()->create();
     Artifact::factory()->for($task, 'task')->videoThumbnail()->create();
     Artifact::factory()->for($task, 'task')->create([
@@ -22,7 +22,9 @@ test('a task with a preview artifact renders a poster and a data-preview-src', f
 
     Livewire::test(TaskList::class)
         ->assertSeeHtml('data-testid="task-preview-' . $task->id . '"')
-        ->assertSeeHtml('data-preview-src=');
+        ->assertSeeHtml('data-testid="task-row-preview-' . $task->id . '"')
+        ->assertSeeHtml('data-preview-src=')
+        ->assertSeeHtml('data-testid="hover-preview-overlay"');
 });
 
 test('a task with only a poster renders the image without a preview source', function () {
@@ -31,6 +33,7 @@ test('a task with only a poster renders the image without a preview source', fun
 
     Livewire::test(TaskList::class)
         ->assertSeeHtml('data-testid="task-preview-' . $task->id . '"')
+        ->assertDontSeeHtml('data-testid="task-row-preview-' . $task->id . '"')
         ->assertDontSeeHtml('data-preview-src=');
 });
 

--- a/tests/Feature/Livewire/Tasks/TaskListTest.php
+++ b/tests/Feature/Livewire/Tasks/TaskListTest.php
@@ -3,6 +3,7 @@
 use App\Enums\TaskMode;
 use App\Enums\TaskStatus;
 use App\Livewire\Tasks\TaskList;
+use App\Models\BranchDeployment;
 use App\Models\Repository;
 use App\Models\User;
 use App\Models\YakTask;
@@ -87,15 +88,68 @@ test('it shows status badges with correct labels', function () {
     }
 });
 
-test('it shows pr link when available', function () {
-    YakTask::factory()->success()->create([
+test('it shows an open pr badge linking to the pr', function () {
+    $task = YakTask::factory()->success()->create([
         'pr_url' => 'https://github.com/org/repo/pull/123',
         'description' => 'Task with PR',
     ]);
 
     Livewire::test(TaskList::class)
         ->assertSeeHtml('href="https://github.com/org/repo/pull/123"')
-        ->assertSee('PR');
+        ->assertSeeHtml('data-testid="pr-state-' . $task->id . '"')
+        ->assertSee('Open');
+});
+
+test('it shows merged and closed pr states', function () {
+    $merged = YakTask::factory()->merged()->create();
+    $closed = YakTask::factory()->closedWithoutMerge()->create();
+
+    Livewire::test(TaskList::class)
+        ->assertSeeHtml('data-testid="pr-state-' . $merged->id . '"')
+        ->assertSeeHtml('data-testid="pr-state-' . $closed->id . '"')
+        ->assertSee('Merged')
+        ->assertSee('Closed');
+});
+
+test('repo column links to the pr when the task has one', function () {
+    Repository::factory()->create(['slug' => 'pr-project']);
+    YakTask::factory()->success()->create([
+        'repo' => 'pr-project',
+        'pr_url' => 'https://github.com/org/pr-project/pull/7',
+    ]);
+
+    $html = Livewire::test(TaskList::class)->html();
+
+    expect($html)
+        ->toContain('href="https://github.com/org/pr-project/pull/7"')
+        ->not->toContain('href="' . route('repos.edit', 'pr-project') . '"');
+});
+
+test('status is rendered as a dot with a visually hidden label', function () {
+    $task = YakTask::factory()->failed()->create();
+
+    Livewire::test(TaskList::class)
+        ->assertSeeHtml('data-testid="status-dot-' . $task->id . '"')
+        ->assertSeeHtml(TaskList::statusDotClasses(TaskStatus::Failed))
+        ->assertSee('failed');
+});
+
+test('it shows the relative creation time with absolute timestamps in the tooltip', function () {
+    $task = YakTask::factory()->success()->create([
+        'created_at' => now()->subHours(3),
+        'duration_ms' => 180000,
+    ]);
+
+    Livewire::test(TaskList::class)
+        ->assertSee('3h ago')
+        ->assertSee('Created ' . $task->created_at->format('M j, Y H:i'))
+        ->assertSee('Ran for 3m');
+});
+
+test('it formats age as a short relative time', function () {
+    expect(TaskList::formatAge(null))->toBe('—')
+        ->and(TaskList::formatAge(now()->subMinutes(5)))->toBe('5m ago')
+        ->and(TaskList::formatAge(now()->subDays(2)))->toBe('2d ago');
 });
 
 test('it shows dash when no pr', function () {
@@ -301,4 +355,104 @@ test('setup checklist reflects real state', function () {
     $component = Livewire::test(TaskList::class);
     $checklist = $component->get('setupChecklist');
     expect($checklist[0]['done'])->toBeTrue();
+});
+
+/*
+|--------------------------------------------------------------------------
+| Requester, preview link, PR filter, sorting
+|--------------------------------------------------------------------------
+*/
+
+test('it shows the requester when known', function () {
+    $task = YakTask::factory()->create(['author_name' => 'Ada Lovelace']);
+
+    Livewire::test(TaskList::class)
+        ->assertSeeHtml('data-testid="task-author-' . $task->id . '"')
+        ->assertSee('Ada Lovelace');
+});
+
+test('it links to the live branch preview when one exists', function () {
+    $repository = Repository::factory()->create(['slug' => 'preview-repo']);
+    $task = YakTask::factory()->success()->create(['repo' => 'preview-repo', 'branch_name' => 'yak/preview-branch']);
+    BranchDeployment::factory()->running()->create([
+        'repository_id' => $repository->id,
+        'branch_name' => 'yak/preview-branch',
+        'hostname' => 'preview-repo-preview-branch.yak.example.com',
+    ]);
+
+    Livewire::test(TaskList::class)
+        ->assertSeeHtml('data-testid="task-preview-link-' . $task->id . '"')
+        ->assertSeeHtml('href="https://preview-repo-preview-branch.yak.example.com"');
+});
+
+test('it hides the preview link once the deployment is destroyed', function () {
+    $repository = Repository::factory()->create(['slug' => 'gone-repo']);
+    $task = YakTask::factory()->success()->create(['repo' => 'gone-repo', 'branch_name' => 'yak/gone-branch']);
+    BranchDeployment::factory()->destroyed()->create([
+        'repository_id' => $repository->id,
+        'branch_name' => 'yak/gone-branch',
+    ]);
+
+    Livewire::test(TaskList::class)
+        ->assertDontSeeHtml('data-testid="task-preview-link-' . $task->id . '"');
+});
+
+test('it filters by pr state', function () {
+    YakTask::factory()->success()->create(['description' => 'Open PR task']);
+    YakTask::factory()->merged()->create(['description' => 'Merged PR task']);
+    YakTask::factory()->closedWithoutMerge()->create(['description' => 'Closed PR task']);
+    YakTask::factory()->create(['description' => 'No PR task', 'pr_url' => null]);
+
+    $component = Livewire::test(TaskList::class);
+
+    $component->set('pr', 'open')
+        ->assertSee('Open PR task')
+        ->assertDontSee('Merged PR task')
+        ->assertDontSee('Closed PR task')
+        ->assertDontSee('No PR task');
+
+    $component->set('pr', 'merged')
+        ->assertSee('Merged PR task')
+        ->assertDontSee('Open PR task');
+
+    $component->set('pr', 'closed')
+        ->assertSee('Closed PR task')
+        ->assertDontSee('Merged PR task');
+
+    $component->set('pr', 'none')
+        ->assertSee('No PR task')
+        ->assertDontSee('Open PR task');
+
+    $component->call('clearFilters')
+        ->assertSet('pr', '')
+        ->assertSee('Open PR task')
+        ->assertSee('No PR task');
+});
+
+test('it sorts by a column and flips direction on a second click', function () {
+    YakTask::factory()->create(['repo' => 'zebra', 'description' => 'Zebra task', 'created_at' => now()]);
+    YakTask::factory()->create(['repo' => 'apple', 'description' => 'Apple task', 'created_at' => now()->subDay()]);
+
+    Livewire::test(TaskList::class)
+        ->assertSeeInOrder(['Zebra task', 'Apple task'])
+        ->call('sortBy', 'repo')
+        ->assertSet('sort', 'repo')
+        ->assertSet('direction', 'asc')
+        ->assertSeeInOrder(['Apple task', 'Zebra task'])
+        ->call('sortBy', 'repo')
+        ->assertSet('direction', 'desc')
+        ->assertSeeInOrder(['Zebra task', 'Apple task'])
+        ->call('sortBy', 'created_at')
+        ->assertSet('direction', 'desc')
+        ->assertSeeInOrder(['Zebra task', 'Apple task']);
+});
+
+test('it ignores unknown sort columns', function () {
+    YakTask::factory()->create(['description' => 'Only task']);
+
+    Livewire::test(TaskList::class)
+        ->set('sort', 'password')
+        ->assertSee('Only task')
+        ->call('sortBy', 'password')
+        ->assertSet('sort', 'password');
 });

--- a/tests/Feature/TwoWayFeedback/YakTaskConversationTest.php
+++ b/tests/Feature/TwoWayFeedback/YakTaskConversationTest.php
@@ -9,6 +9,13 @@ test('prIsOpen reflects PR lifecycle', function () {
         ->and(YakTask::factory()->pending()->create(['pr_url' => null])->prIsOpen())->toBeFalse();
 });
 
+test('prState reflects PR lifecycle', function () {
+    expect(YakTask::factory()->success()->create()->prState())->toBe('open')
+        ->and(YakTask::factory()->merged()->create()->prState())->toBe('merged')
+        ->and(YakTask::factory()->closedWithoutMerge()->create()->prState())->toBe('closed')
+        ->and(YakTask::factory()->pending()->create(['pr_url' => null])->prState())->toBeNull();
+});
+
 test('conversation returns the full chain ordered by created_at', function () {
     $root = YakTask::factory()->success()->create(['branch_name' => 'yak/CHAIN-1']);
     $child = YakTask::factory()->create([


### PR DESCRIPTION
## Summary

The task list only showed whether a run succeeded and how long it took. This makes the list answer the questions people actually have when scanning it: what happened to the PR, who asked for it, is there a preview to click, and what does the change look like.

## Changes

- **Status dot.** The status badge is now a small colour dot with a tooltip (green success, red failed, yellow cancelled, blue running or pending, orange awaiting or retrying). A visually hidden label keeps it readable by screen readers.
- **Repo links to the PR.** When the task has a PR, the repo name opens it on GitHub. Without a PR it still opens the repository settings page.
- **PR column.** Shows Open, Merged, or Closed, from the `pr_merged_at` and `pr_closed_at` timestamps the GitHub webhook already records. New `YakTask::prState()` backs it. A globe icon next to the badge opens the live branch preview when a deployment exists for that branch.
- **By column.** Shows the requester (`author_name`, which Slack fills in).
- **Created replaces Duration.** A short relative time such as "3h ago". Its tooltip shows the absolute created and updated timestamps and the run duration.
- **Hover preview.** Hovering any row that has a walkthrough GIF shows it in a floating overlay sized to the viewport. The overlay is Alpine-only so the 15s poll cannot reset the GIF mid-hover, the GIF is only fetched on first hover, and it is skipped under `prefers-reduced-motion`.
- **PR state filter** (All PRs, Open, Merged, Closed, No PR) alongside the existing filters, and **sortable headers** for status, source, requester, repo, and created. Both are URL-backed.
- **Layout.** The description cell now absorbs remaining width and truncates, so the fixed columns to its right are never clipped.

## Tests

Feature tests cover the PR badges and filter, the repo link fallback, the status dot, the age column, the requester, the preview link (including destroyed deployments), and sorting. The browser hover test now asserts the floating overlay. It previously asserted a filename in the thumbnail `src` and was already failing on `main` because artifact URLs are public tokens now.

https://claude.ai/code/session_01QkQgUafsJExYRazWDdAX9o
