### PR TITLE
fix(ci-scan): read test failures from GitHub Actions job logs

### DIFF
--- a/app/Channels/Drone/BuildScanner.php
+++ b/app/Channels/Drone/BuildScanner.php
@@ -6,6 +6,7 @@ use App\Channels\Contracts\CIBuildScanner;
 use App\DataTransferObjects\BuildResult;
 use App\DataTransferObjects\CIBuildFailure;
 use App\Models\Repository;
+use App\Services\TestFailureParser;
 use Carbon\Carbon;
 use DateTimeInterface;
 use Illuminate\Support\Collection;
@@ -13,6 +14,10 @@ use Illuminate\Support\Facades\Http;
 
 class BuildScanner implements CIBuildScanner
 {
+    public function __construct(
+        private readonly TestFailureParser $parser = new TestFailureParser,
+    ) {}
+
     /**
      * @return Collection<int, CIBuildFailure>
      */
@@ -44,7 +49,7 @@ class BuildScanner implements CIBuildScanner
 
             $buildUrl = $build['link'];
             $logs = $this->getBuildLogs($droneUrl, $droneToken, $repository->github_full_name, $build['number']);
-            $testFailures = $this->parseTestFailures($logs);
+            $testFailures = $this->parser->parse($logs);
 
             foreach ($testFailures as $failure) {
                 $failures->push(new CIBuildFailure(
@@ -151,66 +156,5 @@ class BuildScanner implements CIBuildScanner
         }
 
         return $logs;
-    }
-
-    /**
-     * Parses Pest's `FAILED` markers from a build log. Only lines matching
-     * the `Class\\Path > it does something` shape are accepted — bare
-     * `FAILED` banners (e.g. build summaries, parallel runner stats) are
-     * ignored so we don't emit blank test names.
-     *
-     * @return array<int, array{test: string, output: string}>
-     */
-    private function parseTestFailures(string $output): array
-    {
-        // Drone interleaves ANSI colour codes; strip them so the regex
-        // doesn't match "FAILED<esc>[0m" and capture garbage.
-        $output = preg_replace('/\e\[[0-9;]*[A-Za-z]/', '', $output) ?? $output;
-
-        $failures = [];
-        $lines = explode("\n", $output);
-
-        /** @var string|null $currentTest */
-        $currentTest = null;
-        $currentOutput = '';
-
-        $flush = function () use (&$failures, &$currentTest, &$currentOutput): void {
-            if ($currentTest !== null) {
-                $failures[] = [
-                    'test' => $currentTest,
-                    'output' => trim($currentOutput),
-                ];
-            }
-            $currentTest = null;
-            $currentOutput = '';
-        };
-
-        foreach ($lines as $line) {
-            // Pest's FAILED header: `   FAILED  Tests\Foo > it does something`.
-            // Require the ` > ` separator so bare `FAILED` banners don't count.
-            if (preg_match('/^\s*FAILED\s+(\S.*?\s>\s.+?)\s*$/', $line, $matches)) {
-                $flush();
-                $currentTest = trim($matches[1]);
-                $currentOutput = $line . "\n";
-
-                continue;
-            }
-
-            // Pest summary line ends the failure block:
-            //   `Tests:    1 failed, 8 skipped, 64 passed (225 assertions)`
-            if (preg_match('/^\s*Tests:\s+\d+\s+failed/', $line)) {
-                $flush();
-
-                continue;
-            }
-
-            if ($currentTest !== null) {
-                $currentOutput .= $line . "\n";
-            }
-        }
-
-        $flush();
-
-        return $failures;
     }
 }

--- a/app/Channels/GitHub/ActionsBuildScanner.php
+++ b/app/Channels/GitHub/ActionsBuildScanner.php
@@ -5,13 +5,16 @@ namespace App\Channels\GitHub;
 use App\Channels\Contracts\CIBuildScanner;
 use App\DataTransferObjects\CIBuildFailure;
 use App\Models\Repository;
+use App\Services\TestFailureParser;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class ActionsBuildScanner implements CIBuildScanner
 {
     public function __construct(
         private readonly AppService $gitHubAppService,
+        private readonly TestFailureParser $parser = new TestFailureParser,
     ) {}
 
     /**
@@ -31,6 +34,7 @@ class ActionsBuildScanner implements CIBuildScanner
                 'created' => '>=' . $cutoff,
                 'per_page' => 10,
             ])
+            ->throw()
             ->json();
 
         /** @var array<int, array{id: int, html_url: string, conclusion: string, created_at: string, head_branch?: string|null, head_sha?: string|null}> $runs */
@@ -39,17 +43,19 @@ class ActionsBuildScanner implements CIBuildScanner
         $failures = collect();
 
         foreach ($runs as $run) {
-            $annotations = $this->getFailureAnnotations($client, $repository->github_full_name, (int) $run['id']);
+            foreach ($this->failedTestJobs($client, $repository->github_full_name, (int) $run['id']) as $job) {
+                $log = $this->getJobLog($client, $repository->github_full_name, (int) $job['id']);
 
-            foreach ($annotations as $annotation) {
-                $failures->push(new CIBuildFailure(
-                    testName: $annotation['title'],
-                    output: $annotation['message'],
-                    buildUrl: $run['html_url'],
-                    buildId: (string) $run['id'],
-                    branch: $run['head_branch'] ?? null,
-                    commitSha: $run['head_sha'] ?? null,
-                ));
+                foreach ($this->parser->parse($log) as $failure) {
+                    $failures->push(new CIBuildFailure(
+                        testName: $failure['test'],
+                        output: $failure['output'],
+                        buildUrl: $run['html_url'],
+                        buildId: (string) $run['id'],
+                        branch: $run['head_branch'] ?? null,
+                        commitSha: $run['head_sha'] ?? null,
+                    ));
+                }
             }
         }
 
@@ -57,37 +63,60 @@ class ActionsBuildScanner implements CIBuildScanner
     }
 
     /**
-     * @return array<int, array{title: string, message: string}>
+     * The failed jobs in a run that actually ran tests.
+     *
+     * A workflow run mixes test jobs with build, lint, deploy and notify
+     * jobs. Only test jobs can produce a flaky test, and their logs run to
+     * megabytes apiece — so the filter is both a correctness guard and the
+     * thing that keeps this scan affordable.
+     *
+     * @return array<int, array{id: int, name: string}>
      */
-    private function getFailureAnnotations(PendingRequest $client, string $repoSlug, int $runId): array
+    private function failedTestJobs(PendingRequest $client, string $repoSlug, int $runId): array
     {
-        /** @var array<string, mixed> $checkRunsResponse */
-        $checkRunsResponse = $client
-            ->get("https://api.github.com/repos/{$repoSlug}/actions/runs/{$runId}/check-runs", [
+        /** @var array<string, mixed> $response */
+        $response = $client
+            ->get("https://api.github.com/repos/{$repoSlug}/actions/runs/{$runId}/jobs", [
                 'filter' => 'latest',
+                'per_page' => 100,
             ])
+            ->throw()
             ->json();
 
-        /** @var array<int, array{id: int}> $checkRuns */
-        $checkRuns = $checkRunsResponse['check_runs'] ?? [];
-        $annotations = [];
+        /** @var array<int, array{id: int, name: string, conclusion?: string|null}> $jobs */
+        $jobs = $response['jobs'] ?? [];
 
-        foreach ($checkRuns as $checkRun) {
-            /** @var array<int, array{annotation_level: string, title: string, message: string}> $checkAnnotations */
-            $checkAnnotations = $client
-                ->get("https://api.github.com/repos/{$repoSlug}/check-runs/{$checkRun['id']}/annotations")
-                ->json();
+        return array_values(array_filter(
+            $jobs,
+            fn (array $job): bool => ($job['conclusion'] ?? null) === 'failure'
+                && $this->isTestJob($job['name']),
+        ));
+    }
 
-            foreach ($checkAnnotations as $annotation) {
-                if ($annotation['annotation_level'] === 'failure') {
-                    $annotations[] = [
-                        'title' => $annotation['title'],
-                        'message' => $annotation['message'],
-                    ];
-                }
-            }
+    private function isTestJob(string $jobName): bool
+    {
+        /** @var array<int, string> $excluded */
+        $excluded = config('yak.ci_scan.test_job_exclude_patterns', []);
+
+        if (Str::contains($jobName, $excluded, ignoreCase: true)) {
+            return false;
         }
 
-        return $annotations;
+        /** @var array<int, string> $patterns */
+        $patterns = config('yak.ci_scan.test_job_patterns', []);
+
+        return Str::contains($jobName, $patterns, ignoreCase: true);
+    }
+
+    /**
+     * Fetch a job's raw log. GitHub answers with a redirect to short-lived
+     * blob storage; the HTTP client follows it for us.
+     */
+    private function getJobLog(PendingRequest $client, string $repoSlug, int $jobId): string
+    {
+        return $client
+            ->get("https://api.github.com/repos/{$repoSlug}/actions/jobs/{$jobId}/logs")
+            ->throw()
+            ->body();
     }
 }

--- a/app/Channels/Sentry/WebhookController.php
+++ b/app/Channels/Sentry/WebhookController.php
@@ -10,6 +10,7 @@ use App\Services\RepoDetector;
 use App\Services\TaskLogger;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 class WebhookController extends Controller
 {
@@ -34,9 +35,12 @@ class WebhookController extends Controller
 
         $tags = $this->extractTagKeys($request);
 
-        // Must have yak-eligible tag
-        if (! in_array('yak-eligible', $tags, true)) {
-            return response()->json(['ok' => true]);
+        // Optional per-event opt-in, off unless configured. See
+        // `yak.channels.sentry.required_tag`.
+        $requiredTag = config('yak.channels.sentry.required_tag');
+
+        if (is_string($requiredTag) && ! in_array($requiredTag, $tags, true)) {
+            return $this->rejected($request, "missing_tag:{$requiredTag}", $tags);
         }
 
         $hasPriorityTag = in_array('yak-priority', $tags, true);
@@ -53,7 +57,7 @@ class WebhookController extends Controller
         );
 
         if ($rejection !== null) {
-            return response()->json(['ok' => true, 'filtered' => $rejection]);
+            return $this->rejected($request, $rejection, $tags);
         }
 
         // Parse the payload into a task description
@@ -65,7 +69,7 @@ class WebhookController extends Controller
 
         // Repo must be resolved (sentry_project mapped to an active repository)
         if (! $detection->resolved) {
-            return response()->json(['ok' => true, 'filtered' => 'unknown_project']);
+            return $this->rejected($request, 'unknown_project', $tags);
         }
 
         $resolvedSlug = $detection->firstRepository()->slug;
@@ -94,18 +98,61 @@ class WebhookController extends Controller
     }
 
     /**
+     * Record why an issue was dropped and answer 200 so Sentry doesn't retry.
+     *
+     * Every rejection here is a deliberate no-op, but a silent one is
+     * indistinguishable from a webhook that never arrived — which is how the
+     * Sentry channel sat idle unnoticed. The log line is the only trace.
+     *
+     * @param  list<string>  $tags
+     */
+    private function rejected(Request $request, string $reason, array $tags): JsonResponse
+    {
+        Log::channel('yak')->debug('Sentry issue filtered', [
+            'reason' => $reason,
+            'issue_id' => $request->input('data.issue.id'),
+            'project' => $request->input('data.issue.project.slug'),
+            'tag_keys' => $tags,
+        ]);
+
+        return response()->json(['ok' => true, 'filtered' => $reason]);
+    }
+
+    /**
      * Extract tag key names from the event's tags array.
+     *
+     * Sentry serializes event tags two ways depending on the payload: a list
+     * of `{key, value}` objects, or a list of `[key, value]` pairs. Read both
+     * so an opt-in tag can't be missed on a shape technicality.
      *
      * @return list<string>
      */
     private function extractTagKeys(Request $request): array
     {
-        /** @var list<array{key?: string, value?: string}> $tags */
+        // Deliberately typed loose: this is unvalidated webhook JSON, and the
+        // guards below are the only thing standing between a malformed
+        // payload and a fatal.
+        /** @var mixed $tags */
         $tags = $request->input('data.event.tags', []);
 
-        return array_map(
-            fn (array $tag): string => (string) ($tag['key'] ?? ''),
-            $tags,
-        );
+        if (! is_array($tags)) {
+            return [];
+        }
+
+        $keys = [];
+
+        foreach ($tags as $tag) {
+            if (! is_array($tag)) {
+                continue;
+            }
+
+            $key = $tag['key'] ?? ($tag[0] ?? null);
+
+            if (is_string($key) && $key !== '') {
+                $keys[] = $key;
+            }
+        }
+
+        return $keys;
     }
 }

--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -47,7 +47,7 @@ class ChannelController extends Controller
         [
             'slug' => 'sentry',
             'name' => 'Sentry',
-            'description' => 'Sentry alerts tagged yak-eligible flow into Yak as fix tasks.',
+            'description' => 'Sentry alerts routed to Yak by an issue alert rule become fix tasks.',
             'docs_anchor' => 'channels.sentry',
             'health_check_id' => 'sentry',
             'required' => false,

--- a/app/Services/TestFailureParser.php
+++ b/app/Services/TestFailureParser.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * Parses Pest failure blocks out of a raw CI build log.
+ *
+ * Shared by every CI build scanner. Drone hands us step logs; GitHub Actions
+ * hands us job logs with an RFC3339 timestamp glued to the front of every
+ * line. Both interleave ANSI colour codes. Normalizing both quirks here keeps
+ * the scanners thin and means a parser fix lands for every CI system at once.
+ */
+class TestFailureParser
+{
+    /**
+     * Pest's failure header. The separator is two-or-more spaces:
+     *
+     *   FAILED  Tests\Foo\BarTest > it does something
+     *   FAILED  Tests\Foo\BarTest…   RateLimitException
+     *
+     * Pest truncates the test name to the terminal width, so the ` > it does
+     * something` half is frequently missing and an exception class sits in
+     * its place. Both shapes must parse.
+     */
+    private const FAILED_HEADER = '/^\s*FAILED\s{2,}(\S.*?)\s*$/';
+
+    /** Pest's run summary — ends the trailing failure block. */
+    private const SUMMARY_LINE = '/^\s*Tests:\s+\d+\s+failed/';
+
+    /**
+     * A captured name only counts as a test identifier if it looks like one:
+     * a namespaced class, a file path, or Pest's `class > description` form.
+     * Without this, bare `FAILED` banners from build summaries and parallel
+     * runner stats would produce blank test names.
+     */
+    private const LOOKS_LIKE_TEST = '/[\\\\\/]|\s>\s/';
+
+    /**
+     * @return array<int, array{test: string, output: string}>
+     */
+    public function parse(string $log): array
+    {
+        $lines = explode("\n", $this->normalize($log));
+
+        $failures = [];
+
+        /** @var string|null $currentTest */
+        $currentTest = null;
+        $currentOutput = '';
+
+        $flush = function () use (&$failures, &$currentTest, &$currentOutput): void {
+            if ($currentTest !== null) {
+                $failures[] = [
+                    'test' => $currentTest,
+                    'output' => trim($currentOutput),
+                ];
+            }
+            $currentTest = null;
+            $currentOutput = '';
+        };
+
+        foreach ($lines as $line) {
+            $testName = $this->matchFailureHeader($line);
+
+            if ($testName !== null) {
+                $flush();
+                $currentTest = $testName;
+                $currentOutput = $line . "\n";
+
+                continue;
+            }
+
+            if (preg_match(self::SUMMARY_LINE, $line) === 1) {
+                $flush();
+
+                continue;
+            }
+
+            if ($currentTest !== null) {
+                $currentOutput .= $line . "\n";
+            }
+        }
+
+        $flush();
+
+        return $failures;
+    }
+
+    /**
+     * Strip the noise both CI systems wrap around the useful output: ANSI
+     * colour codes, GitHub Actions' per-line timestamp prefix, and CRs.
+     */
+    private function normalize(string $log): string
+    {
+        $log = preg_replace('/\e\[[0-9;]*[A-Za-z]/', '', $log) ?? $log;
+
+        // GitHub Actions prefixes every log line with e.g.
+        // "2026-08-27T07:24:34.4244357Z ". Left in place it defeats every
+        // line-anchored pattern below.
+        $log = preg_replace('/^\d{4}-\d{2}-\d{2}T[\d:.]+Z /m', '', $log) ?? $log;
+
+        return str_replace("\r", '', $log);
+    }
+
+    /**
+     * Returns the test name from a Pest `FAILED` header, or null if the line
+     * isn't one.
+     */
+    private function matchFailureHeader(string $line): ?string
+    {
+        if (preg_match(self::FAILED_HEADER, $line, $matches) !== 1) {
+            return null;
+        }
+
+        // Split the trailing exception class off the test name. Pest pads the
+        // gap between them to at least two spaces; the test name itself is
+        // single-spaced.
+        $parts = preg_split('/\s{2,}/', $matches[1]);
+        $testName = $parts === false ? trim($matches[1]) : trim($parts[0]);
+
+        if ($testName === '' || preg_match(self::LOOKS_LIKE_TEST, $testName) !== 1) {
+            return null;
+        }
+
+        return $testName;
+    }
+}

--- a/config/yak.php
+++ b/config/yak.php
@@ -219,6 +219,30 @@ return [
     'ci_scan' => [
         'scan_interval_minutes' => (int) env('YAK_SCAN_INTERVAL_MINUTES', 120),
         'max_failure_age_hours' => (int) env('YAK_MAX_FAILURE_AGE_HOURS', 48),
+
+        // Which CI jobs are worth reading logs from. A workflow run also
+        // contains build, lint, deploy and notify jobs; their failures are
+        // real breakage, not flaky tests, and their logs are large. A job
+        // qualifies when its name contains one of these (case-insensitive).
+        // Set YAK_CI_TEST_JOB_PATTERNS to a comma-separated list to override.
+        'test_job_patterns' => array_values(array_filter(array_map(
+            trim(...),
+            explode(',', (string) env(
+                'YAK_CI_TEST_JOB_PATTERNS',
+                'test,spec,pest,phpunit,jest,vitest,pytest,rspec',
+            )),
+        ))),
+
+        // Checked after the list above and wins over it. Jobs that act *on* a
+        // test run rather than running one — "Notify Slack (tests)", "Deploy
+        // after tests" — otherwise match on the word alone.
+        'test_job_exclude_patterns' => array_values(array_filter(array_map(
+            trim(...),
+            explode(',', (string) env(
+                'YAK_CI_TEST_JOB_EXCLUDE_PATTERNS',
+                'notify,deploy,publish,release,announce,upload',
+            )),
+        ))),
     ],
 
     /*
@@ -263,6 +287,13 @@ return [
             'region_url' => env('YAK_SENTRY_REGION_URL', 'https://us.sentry.io'),
             'min_events' => (int) env('YAK_SENTRY_MIN_EVENTS', 5),
             'min_actionability' => env('YAK_SENTRY_MIN_ACTIONABILITY', 'medium'),
+
+            // Optional extra opt-in: when set, an issue is only picked up if
+            // its event carries a tag with this key. Off by default — the
+            // alert rule you point at Yak is already the opt-in, and a tag
+            // has to be set in application code at the moment the error is
+            // thrown, which is the wrong place to decide this.
+            'required_tag' => env('YAK_SENTRY_REQUIRED_TAG') ?: null,
         ],
 
         'drone' => [

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -49,6 +49,7 @@ If you already have a GitHub App and want to reuse it, fill in `github_app_id`, 
 | Pull requests | Read & Write (create PRs, add labels) |
 | Issues | Read & Write (react to follow-up comments) |
 | Checks | Read (CI results) |
+| Actions | Read (flaky-test scan reads workflow jobs and their logs) |
 | Metadata | Read (default) |
 
 ### Webhook Events
@@ -309,7 +310,7 @@ The picked-up → started transition is automatic: Yak queries the issue's team'
 1. Create an internal integration at **Settings → Developer Settings → Internal Integrations**
 2. Permissions required: **Organization: Read**, **Project: Read**, **Issue & Event: Read**. Organization+Project read are what lets the Add Repository form populate the Sentry project dropdown — skip them and the form silently falls back to a plain slug text input.
 3. Set the webhook URL: `https://{your-domain}/webhooks/sentry`
-4. Create an alert rule tagged `yak-eligible` for the issues you want Yak to pick up
+4. Create an issue alert rule whose action notifies this integration. The rule is the opt-in: whichever issues it fires on are the ones Yak considers
 5. Map Sentry projects to repositories via the `sentry_project` field on each repo (see the [Repositories](repositories.md) page)
 6. Add to `ansible/vault/secrets.yml`:
 
@@ -341,6 +342,8 @@ Issues tagged `yak-priority` bypass both the event count and actionability filte
 
 - **Inactive repos are skipped.** If `sentry_project` points to a repo where `is_active = 0`, the webhook is silently dropped.
 - **No fallback repo.** Unlike Slack/Linear, Sentry webhooks do not fall back to the default repo — they require an explicit `sentry_project` mapping.
+- **Rejections are logged, not silent.** Every filtered issue writes a `Sentry issue filtered` debug line to the `yak` log channel with its reason and the event's tag keys. Start there when an alert you expected never became a task.
+- **Optional per-event opt-in.** Set `YAK_SENTRY_REQUIRED_TAG` (e.g. `yak-eligible`) to additionally require that tag key on the event. Off by default — the tag has to be set in application code at the moment the error is thrown, so the alert rule is usually the better place to decide eligibility.
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -30,7 +30,7 @@ Only configure the channels you use. Everything except GitHub (for pushing branc
 |---|---|
 | **Slack** | Slack app with bot token plus signing secret. |
 | **Linear** | OAuth application (client id + secret + webhook signing secret). Authorize at `/settings/linear`. Requires workspace admin approval. |
-| **Sentry** | Auth token plus webhook secret. Alert rules tagged `yak-eligible`. |
+| **Sentry** | Auth token plus webhook secret. An issue alert rule that notifies the integration. |
 | **Drone CI** | API token. Yak polls the Drone API — no webhook needed. |
 | **GitHub Actions** | Included with the GitHub App — no additional setup. |
 
@@ -259,7 +259,7 @@ See [Channels → Linear](channels.md#linear-optional) for usage and gotchas.
 5. Copy the **Token** into `sentry_auth_token`
 6. Copy the **Webhook Signing Secret** (under "Webhook Secret" in the integration's Client Secret section) into `sentry_webhook_secret`
 7. Set `sentry_org_slug` to your Sentry organization slug
-8. Create an alert rule tagged `yak-eligible` for the issues you want Yak to pick up
+8. Create an issue alert rule whose action notifies this integration, scoped to the issues you want Yak to pick up
 9. Map Sentry projects to repos via the `sentry_project` field on each repo in the dashboard
 
 See [Channels → Sentry](channels.md#sentry-optional) for filtering rules and gotchas.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -142,7 +142,7 @@ Symptoms: you `@yak` in Slack (or assign a Linear issue to Yak, or trigger a Sen
 
 - **Slack** — channel history scope is required for thread reply matching. If clarification replies don't route to the right task, verify `channels:history` is in the bot scopes.
 - **Linear** — the webhook must subscribe to **Agent session events** so delegation events come through, and the OAuth connection must be active; if the `linear_oauth_connections.installer_user_id` column is null, re-authorize the app from Yak's settings. The install requires workspace admin approval — a non-admin install will appear to succeed but agent session events will not arrive.
-- **Sentry** — alerts must be tagged `yak-eligible`. Alerts without the tag are ignored even if they hit the webhook.
+- **Sentry** — the issue must reach the webhook *and* clear the filters: not a CSP violation, not a transient infra error, Seer actionability at least `medium`, and at least 5 events (a `yak-priority` tag bypasses the last two). Each rejection is logged to the `yak` channel with its reason — check there first. If `YAK_SENTRY_REQUIRED_TAG` is set, the event must also carry that tag key.
 - **GitHub** — the App must be installed on the target org and must have webhook events for `check_suite.completed` and `pull_request.closed`.
 
 ## Claude CLI Errors

--- a/tests/Feature/Channels/GitHub/ActionsBuildScannerTest.php
+++ b/tests/Feature/Channels/GitHub/ActionsBuildScannerTest.php
@@ -1,0 +1,193 @@
+<?php
+
+use App\Channels\GitHub\ActionsBuildScanner;
+use App\Channels\GitHub\AppService;
+use App\Models\Repository;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config(['yak.channels.github.installation_id' => 4242]);
+
+    $github = $this->mock(AppService::class);
+    // Built lazily: the client must be created after each test installs its
+    // Http::fake(), otherwise the request escapes to the real API.
+    $github->shouldReceive('installationClient')
+        ->with(4242)
+        ->andReturnUsing(fn () => Http::withToken('installation-token'));
+});
+
+function failedRunResponse(int $runId = 900): array
+{
+    return [
+        'workflow_runs' => [
+            [
+                'id' => $runId,
+                'html_url' => "https://github.com/acme/app/actions/runs/{$runId}",
+                'conclusion' => 'failure',
+                'created_at' => now()->subHour()->toIso8601String(),
+                'head_branch' => 'master',
+                'head_sha' => 'abc123',
+            ],
+        ],
+    ];
+}
+
+/** A realistic GitHub Actions job log: timestamp-prefixed, truncated name. */
+function pestJobLog(string $testName = 'Tests\Dash\Feature\OneOffInvoiceIssuanceTest…'): string
+{
+    return implode("\n", [
+        '2026-08-27T07:24:30.0000000Z   ────────────────────────────────────',
+        "2026-08-27T07:24:34.4244357Z    FAILED  {$testName}   RateLimitException",
+        '2026-08-27T07:24:34.4244400Z   at vendor/stripe/stripe-php/lib/Exception/ApiErrorException.php:38',
+        '2026-08-27T07:24:35.0000000Z   Tests:    1 failed, 7227 passed (16779 assertions)',
+    ]);
+}
+
+test('reads logs from failed test jobs and parses the flaky test out of them', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'acme/app',
+        'default_branch' => 'master',
+        'ci_system' => 'github_actions',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/acme/app/actions/runs?*' => Http::response(failedRunResponse()),
+        'api.github.com/repos/acme/app/actions/runs/900/jobs*' => Http::response([
+            'jobs' => [
+                ['id' => 11, 'name' => 'Test (Main)', 'conclusion' => 'failure'],
+            ],
+        ]),
+        'api.github.com/repos/acme/app/actions/jobs/11/logs' => Http::response(pestJobLog()),
+    ]);
+
+    $failures = app(ActionsBuildScanner::class)->getRecentFailures($repo, 48);
+
+    expect($failures)->toHaveCount(1);
+
+    $failure = $failures->first();
+
+    expect($failure->testName)->toBe('Tests\Dash\Feature\OneOffInvoiceIssuanceTest…')
+        ->and($failure->output)->toContain('RateLimitException')
+        ->and($failure->buildId)->toBe('900')
+        ->and($failure->buildUrl)->toBe('https://github.com/acme/app/actions/runs/900')
+        ->and($failure->branch)->toBe('master')
+        ->and($failure->commitSha)->toBe('abc123');
+});
+
+// "Notify Slack (tests)" is a real job name in Geocodio/geocodio. It reports
+// on a test run without running one, and the word "tests" in its name is
+// enough to match the include list — so the exclude list has to win.
+test('skips non-test jobs so build, lint, deploy and notify failures are never read', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'acme/app',
+        'default_branch' => 'master',
+        'ci_system' => 'github_actions',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/acme/app/actions/runs?*' => Http::response(failedRunResponse()),
+        'api.github.com/repos/acme/app/actions/runs/900/jobs*' => Http::response([
+            'jobs' => [
+                ['id' => 21, 'name' => 'Build App Images', 'conclusion' => 'failure'],
+                ['id' => 22, 'name' => 'Security Audit', 'conclusion' => 'failure'],
+                ['id' => 23, 'name' => 'Lint', 'conclusion' => 'failure'],
+                ['id' => 24, 'name' => 'Deploy staging', 'conclusion' => 'failure'],
+                ['id' => 25, 'name' => 'Notify Slack (tests)', 'conclusion' => 'failure'],
+                ['id' => 26, 'name' => 'Move the branch tag', 'conclusion' => 'failure'],
+            ],
+        ]),
+    ]);
+
+    expect(app(ActionsBuildScanner::class)->getRecentFailures($repo, 48))->toBeEmpty();
+
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), '/logs'));
+});
+
+test('skips jobs that passed, even when their name looks like a test job', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'acme/app',
+        'default_branch' => 'master',
+        'ci_system' => 'github_actions',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/acme/app/actions/runs?*' => Http::response(failedRunResponse()),
+        'api.github.com/repos/acme/app/actions/runs/900/jobs*' => Http::response([
+            'jobs' => [
+                ['id' => 31, 'name' => 'Test (Browser)', 'conclusion' => 'success'],
+                ['id' => 32, 'name' => 'Test (Skipped)', 'conclusion' => 'skipped'],
+            ],
+        ]),
+    ]);
+
+    expect(app(ActionsBuildScanner::class)->getRecentFailures($repo, 48))->toBeEmpty();
+
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), '/logs'));
+});
+
+test('scopes the run query to the default branch, failures, and the age cutoff', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'acme/app',
+        'default_branch' => 'master',
+        'ci_system' => 'github_actions',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/acme/app/actions/runs?*' => Http::response(['workflow_runs' => []]),
+    ]);
+
+    app(ActionsBuildScanner::class)->getRecentFailures($repo, 48);
+
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), 'branch=master')
+            && str_contains($request->url(), 'status=failure')
+            && str_contains($request->url(), 'created=');
+    });
+});
+
+test('honours a custom test job pattern list', function () {
+    config(['yak.ci_scan.test_job_patterns' => ['pytest']]);
+
+    $repo = Repository::factory()->create([
+        'slug' => 'acme/app',
+        'default_branch' => 'master',
+        'ci_system' => 'github_actions',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/acme/app/actions/runs?*' => Http::response(failedRunResponse()),
+        'api.github.com/repos/acme/app/actions/runs/900/jobs*' => Http::response([
+            'jobs' => [
+                ['id' => 41, 'name' => 'Test (Main)', 'conclusion' => 'failure'],
+                ['id' => 42, 'name' => 'pytest suite', 'conclusion' => 'failure'],
+            ],
+        ]),
+        'api.github.com/repos/acme/app/actions/jobs/42/logs' => Http::response(pestJobLog('Tests\Feature\PyTest > it runs')),
+    ]);
+
+    $failures = app(ActionsBuildScanner::class)->getRecentFailures($repo, 48);
+
+    expect($failures)->toHaveCount(1);
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/actions/jobs/42/logs'));
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), '/actions/jobs/41/logs'));
+});
+
+test('raises instead of reporting zero failures when GitHub rejects a request', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'acme/app',
+        'default_branch' => 'master',
+        'ci_system' => 'github_actions',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/acme/app/actions/runs?*' => Http::response(failedRunResponse()),
+        'api.github.com/repos/acme/app/actions/runs/900/jobs*' => Http::response(['message' => 'Not Found'], 404),
+    ]);
+
+    // A silently-swallowed 404 is what hid this scanner's breakage for
+    // months; an unreachable endpoint must surface as a failed scan.
+    expect(fn () => app(ActionsBuildScanner::class)->getRecentFailures($repo, 48))
+        ->toThrow(RequestException::class);
+});

--- a/tests/Feature/Channels/Sentry/WebhookTest.php
+++ b/tests/Feature/Channels/Sentry/WebhookTest.php
@@ -714,11 +714,17 @@ it('ignores non-triggered action events', function () {
 
 /*
 |--------------------------------------------------------------------------
-| Missing yak-eligible Tag Ignored
+| Optional Required Tag
 |--------------------------------------------------------------------------
+|
+| The alert rule pointed at Yak is the opt-in. An extra per-event tag gate
+| is available for installs that want one, but it stays off by default: the
+| tag has to be set in application code when the error is thrown, which is
+| the wrong place to decide whether an issue is worth fixing.
+|
 */
 
-it('ignores events without yak-eligible tag', function () {
+it('processes events with no opt-in tag when no required tag is configured', function () {
     $secret = enableSentryChannel();
     Queue::fake();
 
@@ -741,6 +747,66 @@ it('ignores events without yak-eligible tag', function () {
         'CONTENT_TYPE' => 'application/json',
     ])->assertSuccessful();
 
+    expect(YakTask::count())->toBe(1);
+    Queue::assertPushed(RunYakJob::class);
+});
+
+it('ignores events missing the required tag when one is configured', function () {
+    $secret = enableSentryChannel();
+    config(['yak.channels.sentry.required_tag' => 'yak-eligible']);
+    Queue::fake();
+
+    Repository::factory()->withSentry()->create([
+        'sentry_project' => 'my-sentry-project',
+    ]);
+
+    $body = sentryAlertPayload([
+        'issueId' => '99070',
+        'tags' => [
+            ['key' => 'environment', 'value' => 'production'],
+        ],
+        'seerActionability' => 'high',
+        'count' => 10,
+    ]);
+    $signature = signSentryPayload($body, $secret);
+
+    $this->call('POST', '/webhooks/sentry', content: $body, server: [
+        'HTTP_Sentry-Hook-Signature' => $signature,
+        'CONTENT_TYPE' => 'application/json',
+    ])->assertSuccessful()
+        ->assertJson(['filtered' => 'missing_tag:yak-eligible']);
+
     expect(YakTask::count())->toBe(0);
     Queue::assertNotPushed(RunYakJob::class);
+});
+
+it('accepts the required tag when Sentry sends tags as [key, value] pairs', function () {
+    $secret = enableSentryChannel();
+    config(['yak.channels.sentry.required_tag' => 'yak-eligible']);
+    Queue::fake();
+
+    Repository::factory()->withSentry()->create([
+        'sentry_project' => 'my-sentry-project',
+    ]);
+
+    // Sentry serializes event tags as objects in some payloads and as plain
+    // pairs in others. Both have to satisfy the gate.
+    $body = sentryAlertPayload([
+        'issueId' => '99071',
+        'tags' => [
+            ['environment', 'production'],
+            ['yak-eligible', 'yes'],
+        ],
+        'seerActionability' => 'high',
+        'count' => 10,
+    ]);
+    $signature = signSentryPayload($body, $secret);
+
+    $this->call('POST', '/webhooks/sentry', content: $body, server: [
+        'HTTP_Sentry-Hook-Signature' => $signature,
+        'CONTENT_TYPE' => 'application/json',
+    ])->assertSuccessful();
+
+    expect(YakTask::count())->toBe(1);
+    Queue::assertPushed(RunYakJob::class);
 });

--- a/tests/Unit/TestFailureParserTest.php
+++ b/tests/Unit/TestFailureParserTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Services\TestFailureParser;
+
+beforeEach(function () {
+    $this->parser = new TestFailureParser;
+});
+
+test('parses the full Pest header with a class > description name', function () {
+    $log = <<<'LOG'
+    ......s.......
+       FAILED  Tests\Dash\Browser\MultipleSessionsTest > it can access change password
+      Timeout 30000ms exceeded.
+      Tests:    1 failed, 64 passed (225 assertions)
+    LOG;
+
+    $failures = $this->parser->parse($log);
+
+    expect($failures)->toHaveCount(1)
+        ->and($failures[0]['test'])->toBe('Tests\Dash\Browser\MultipleSessionsTest > it can access change password')
+        ->and($failures[0]['output'])->toContain('Timeout 30000ms exceeded.');
+});
+
+test('parses a truncated name followed by an exception class', function () {
+    // Pest truncates to the terminal width, dropping the ` > description`
+    // half and leaving the exception type in the trailing column.
+    $log = <<<'LOG'
+       FAILED  Tests\Dash\Feature\OneOffInvoiceIssuanceTest…   RateLimitException
+      This object cannot be accessed right now.
+      Tests:    1 failed, 7227 passed (16779 assertions)
+    LOG;
+
+    $failures = $this->parser->parse($log);
+
+    expect($failures)->toHaveCount(1)
+        ->and($failures[0]['test'])->toBe('Tests\Dash\Feature\OneOffInvoiceIssuanceTest…')
+        ->and($failures[0]['output'])->toContain('cannot be accessed right now');
+});
+
+test('strips the GitHub Actions timestamp prefix from every line', function () {
+    $log = implode("\n", [
+        '2026-08-27T07:24:34.4244357Z    FAILED  Tests\Feature\FooTest > it works   RuntimeException',
+        '2026-08-27T07:24:34.4244400Z   at app/Foo.php:12',
+        '2026-08-27T07:24:35.0000000Z   Tests:    1 failed, 10 passed (20 assertions)',
+    ]);
+
+    $failures = $this->parser->parse($log);
+
+    expect($failures)->toHaveCount(1)
+        ->and($failures[0]['test'])->toBe('Tests\Feature\FooTest > it works')
+        ->and($failures[0]['output'])->toContain('at app/Foo.php:12')
+        ->and($failures[0]['output'])->not->toContain('2026-08-27T');
+});
+
+test('strips ANSI colour codes', function () {
+    $log = "  \e[31;1mFAILED\e[39;22m  Tests\\Feature\\BarTest > it fails\n  Tests:    1 failed, 2 passed";
+
+    $failures = $this->parser->parse($log);
+
+    expect($failures)->toHaveCount(1)
+        ->and($failures[0]['test'])->toBe('Tests\Feature\BarTest > it fails');
+});
+
+test('ignores bare FAILED banners that carry no test identifier', function () {
+    $log = <<<'LOG'
+       FAILED  build step 7
+       FAILED
+      Process completed with exit code 1.
+    LOG;
+
+    expect($this->parser->parse($log))->toBeEmpty();
+});
+
+test('separates consecutive failures into one entry each', function () {
+    $log = <<<'LOG'
+       FAILED  Tests\Feature\OneTest > it does a
+      first failure detail
+       FAILED  Tests\Feature\TwoTest > it does b
+      second failure detail
+      Tests:    2 failed, 5 passed (9 assertions)
+    LOG;
+
+    $failures = $this->parser->parse($log);
+
+    expect($failures)->toHaveCount(2)
+        ->and($failures[0]['test'])->toBe('Tests\Feature\OneTest > it does a')
+        ->and($failures[0]['output'])->toContain('first failure detail')
+        ->and($failures[0]['output'])->not->toContain('second failure detail')
+        ->and($failures[1]['test'])->toBe('Tests\Feature\TwoTest > it does b');
+});
+
+test('returns nothing for a log with no test failures', function () {
+    expect($this->parser->parse("Process completed with exit code 1.\nCleaning up orphan processes"))
+        ->toBeEmpty();
+});


### PR DESCRIPTION
## Summary

Two task sources had gone quiet in production. Neither was a coincidence.

**Flaky-test tasks stopped on 2026-06-12.** All 108 ever created came from Drone; the GitHub Actions scanner has never produced one. When `Geocodio/geocodio` moved to Actions, detection stopped and nothing reported it.

**Sentry has never created a task.** The webhook URL pointed at a hostname that no longer resolves to the Yak box (fixed separately, in Sentry). Behind that, a second gate would have dropped every issue anyway.

## Changes

### GitHub Actions build scanner

- Replaced `/actions/runs/{id}/check-runs` — an endpoint that does not exist and answered 404 — with a walk over the run's failed jobs. `->json()` on the 404 returned the error body, so the scan reported zero failures rather than raising.
- Requests now `->throw()`. An unreachable endpoint fails the scan instead of looking like a clean run.
- Test names are parsed from job logs. Check annotations only carry GitHub's generic `Process completed with exit code 1`; the names are in the logs, which is where the Drone scanner has always looked.
- Only test jobs are read, matched against `yak.ci_scan.test_job_patterns` with an exclude list that wins over it. A run also holds build, lint, deploy and notify jobs whose failures are real breakage rather than flakes, and whose logs run to megabytes each. The exclude list is not hypothetical: `Notify Slack (tests)` matches on the word alone.

### Shared test-failure parser

- Pest parsing moves out of the Drone scanner into `TestFailureParser`, shared by both CI systems.
- Handles two cases the GitHub logs require: lines prefixed with an RFC3339 timestamp, and Pest's width-truncated header, where `Foo\BarTest…   RateLimitException` stands in for the usual `Foo\BarTest > it does something`.

### Sentry

- The `yak-eligible` tag is no longer required by default; `YAK_SENTRY_REQUIRED_TAG` turns it back on. It was meant as a human opt-in, but an event tag has to be set in application code at the moment the error is thrown, and the alert rule pointed at Yak is already that opt-in. Content filters and the `yak-priority` bypass are unchanged.
- Tag keys are read from both shapes Sentry serializes them in — `{key, value}` objects and `[key, value]` pairs. The old code assumed the first, and since no real payload had ever reached it, that assumption was never tested against reality.
- Filtered issues log their rejection reason and the event's tag keys to the `yak` channel. Every drop previously returned `{"ok": true}` with no trace, which is why this sat idle for months.

### Docs

- `Actions: Read` added to the GitHub App permission table; the scan now reads workflow jobs and their logs.
- Sentry setup describes the alert rule as the opt-in, and troubleshooting lists the real conditions plus where the rejection log lands.

## Verification

Run against live GitHub data before committing. Correctly skipped Security Audit, Pint, PHPStan and four `deploy /` jobs; correctly scanned the Pest, Go and vitest jobs. Found a genuine flake in `Geocodio/atlas` — `SavedViewMenuTest > it deletes a…` failing on `main` across three separate runs.

594 tests pass. PHPStan and Pint clean.

## Known gap

The parser understands Pest output only. `chopchop`'s `Go tests` and `Frontend (tsc + vitest + vite build)` jobs are scanned but their failures are not recognized. Not a regression — a gap worth closing separately.

https://claude.ai/code/session_01873wPyFwSPY6WenZZgFXKV