### PR TITLE
fix(ci-scan): skip jobs whose logs have expired

### DIFF
--- a/app/Channels/GitHub/ActionsBuildScanner.php
+++ b/app/Channels/GitHub/ActionsBuildScanner.php
@@ -46,6 +46,10 @@ class ActionsBuildScanner implements CIBuildScanner
             foreach ($this->failedTestJobs($client, $repository->github_full_name, (int) $run['id']) as $job) {
                 $log = $this->getJobLog($client, $repository->github_full_name, (int) $job['id']);
 
+                if ($log === null) {
+                    continue;
+                }
+
                 foreach ($this->parser->parse($log) as $failure) {
                     $failures->push(new CIBuildFailure(
                         testName: $failure['test'],
@@ -111,12 +115,22 @@ class ActionsBuildScanner implements CIBuildScanner
     /**
      * Fetch a job's raw log. GitHub answers with a redirect to short-lived
      * blob storage; the HTTP client follows it for us.
+     *
+     * Returns null when the log is gone. GitHub expires job logs well before
+     * it forgets the run itself, so a 404 here is an ordinary fact about an
+     * older run — skip the job rather than abandoning the repository's whole
+     * scan. Every other failure still throws: a 403 means the App is missing
+     * `Actions: Read`, and silently reporting "no flaky tests" for a
+     * permissions problem is the bug this scanner just came out of.
      */
-    private function getJobLog(PendingRequest $client, string $repoSlug, int $jobId): string
+    private function getJobLog(PendingRequest $client, string $repoSlug, int $jobId): ?string
     {
-        return $client
-            ->get("https://api.github.com/repos/{$repoSlug}/actions/jobs/{$jobId}/logs")
-            ->throw()
-            ->body();
+        $response = $client->get("https://api.github.com/repos/{$repoSlug}/actions/jobs/{$jobId}/logs");
+
+        if ($response->status() === 404) {
+            return null;
+        }
+
+        return $response->throw()->body();
     }
 }

--- a/tests/Feature/Channels/GitHub/ActionsBuildScannerTest.php
+++ b/tests/Feature/Channels/GitHub/ActionsBuildScannerTest.php
@@ -191,3 +191,53 @@ test('raises instead of reporting zero failures when GitHub rejects a request', 
     expect(fn () => app(ActionsBuildScanner::class)->getRecentFailures($repo, 48))
         ->toThrow(RequestException::class);
 });
+
+test('skips a job whose log has expired instead of abandoning the repository scan', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'acme/app',
+        'default_branch' => 'master',
+        'ci_system' => 'github_actions',
+    ]);
+
+    // GitHub expires job logs long before it forgets the run, so a 404 here
+    // is routine for older runs — the rest of the scan must survive it.
+    Http::fake([
+        'api.github.com/repos/acme/app/actions/runs?*' => Http::response(failedRunResponse()),
+        'api.github.com/repos/acme/app/actions/runs/900/jobs*' => Http::response([
+            'jobs' => [
+                ['id' => 51, 'name' => 'Go tests', 'conclusion' => 'failure'],
+                ['id' => 52, 'name' => 'Tests (Pest)', 'conclusion' => 'failure'],
+            ],
+        ]),
+        'api.github.com/repos/acme/app/actions/jobs/51/logs' => Http::response(['message' => 'Not Found'], 404),
+        'api.github.com/repos/acme/app/actions/jobs/52/logs' => Http::response(pestJobLog()),
+    ]);
+
+    $failures = app(ActionsBuildScanner::class)->getRecentFailures($repo, 48);
+
+    expect($failures)->toHaveCount(1)
+        ->and($failures->first()->testName)->toBe('Tests\Dash\Feature\OneOffInvoiceIssuanceTest…');
+});
+
+test('still raises when a log is refused for a reason other than expiry', function () {
+    $repo = Repository::factory()->create([
+        'slug' => 'acme/app',
+        'default_branch' => 'master',
+        'ci_system' => 'github_actions',
+    ]);
+
+    // A 403 means the App lacks Actions: Read. Reporting "no flaky tests" for
+    // a permissions problem is exactly the silent failure this scanner had.
+    Http::fake([
+        'api.github.com/repos/acme/app/actions/runs?*' => Http::response(failedRunResponse()),
+        'api.github.com/repos/acme/app/actions/runs/900/jobs*' => Http::response([
+            'jobs' => [
+                ['id' => 61, 'name' => 'Tests (Pest)', 'conclusion' => 'failure'],
+            ],
+        ]),
+        'api.github.com/repos/acme/app/actions/jobs/61/logs' => Http::response(['message' => 'Forbidden'], 403),
+    ]);
+
+    expect(fn () => app(ActionsBuildScanner::class)->getRecentFailures($repo, 48))
+        ->toThrow(RequestException::class);
+});


### PR DESCRIPTION
## Summary

Follow-up to #29, found by the first production scan after it deployed.

`Geocodio/chopchop` aborted with `HTTP request returned status code 404`. The runs and jobs endpoints both answered 200; three job logs from a run on 2026-09-02 did not. GitHub expires job logs well before it forgets the run itself, so a 404 on a log is an ordinary fact about an older run rather than a fault.

Throwing there cost the repository its whole scan, including findings from runs whose logs were still available.

## Changes

- A 404 on a job log skips that job and the scan continues.
- Every other status still throws. A 403 means the App is missing `Actions: Read`, and reporting "no flaky tests" for a permissions problem is the exact silent failure #29 set out to remove.
- Two tests: one expired log among several does not lose the other findings; a 403 still raises.

## Verification

Reproduced against live data before the fix — `chopchop` run 33645296864 returns 404 for all three of its failed job logs, while runs from 2026-09-01 return 200. The `atlas` findings from #29 are unaffected.

596 tests pass. PHPStan and Pint clean.

https://claude.ai/code/session_01873wPyFwSPY6WenZZgFXKV