### PR TITLE
fix(pr): describe the whole branch and drop dead walkthrough placeholders

### DIFF
--- a/app/Jobs/CreatePullRequestJob.php
+++ b/app/Jobs/CreatePullRequestJob.php
@@ -159,6 +159,7 @@ class CreatePullRequestJob implements ShouldQueue
             $parts[] = "**Task:** [{$this->task->external_id}]({$taskUrl})";
         }
 
+        $parts[] = "**Yak task:** [#{$this->task->id}]({$this->yakTaskUrl()})";
         $parts[] = "**Repository:** {$this->task->repo}";
         $parts[] = "**Attempts:** {$this->task->attempts}";
 
@@ -180,22 +181,55 @@ class CreatePullRequestJob implements ShouldQueue
             );
         }
 
-        $parts[] = '';
-        $parts[] = $this->walkthroughSection();
+        $walkthrough = $this->walkthroughSection();
+
+        if ($walkthrough !== '') {
+            $parts[] = '';
+            $parts[] = $walkthrough;
+        }
 
         return implode("\n", $parts);
     }
 
     /**
+     * Whether a render is on its way. The v3 pipeline needs both a script
+     * and a manifest artifact (RenderWalkthroughJob's own precondition);
+     * the legacy v2 pipeline renders from raw footage alone.
+     */
+    private function hasRenderableCapture(): bool
+    {
+        if ($this->task->artifacts()->rawFootage()->exists()) {
+            return true;
+        }
+
+        return $this->task->artifacts()->role('script')->exists()
+            && $this->task->artifacts()->role('manifest')->exists();
+    }
+
+    /**
+     * Deep link back to the task's page on this Yak install, so a reviewer
+     * can reach the run log, the cost, and the follow-up box from the PR.
+     */
+    private function yakTaskUrl(): string
+    {
+        return route('tasks.show', $this->task);
+    }
+
+    /**
      * The PR opens on green CI, usually before the render finishes, so the
      * section starts as a placeholder the render replaces (spec §8).
+     *
+     * A task that captured nothing — a backend-only change, or a run that
+     * skipped visual capture — never dispatches a render, so a placeholder
+     * would sit at "Rendering…" forever. The section is omitted unless a
+     * render is actually coming.
      */
     private function walkthroughSection(): string
     {
         $cut = $this->task->artifacts()->cut()->latest('id')->first();
 
         if ($cut === null) {
-            return WalkthroughPrSection::pending();
+            return $this->hasRenderableCapture() ? WalkthroughPrSection::pending() : '';
         }
 
         $preview = $this->task->artifacts()->preview()->latest('id')->first();

--- a/resources/views/prompts/tasks/retry.blade.php
+++ b/resources/views/prompts/tasks/retry.blade.php
@@ -27,4 +27,13 @@ No CI output was captured. Investigate the test/build failures by running the re
 3. Fix it — either by amending the approach, adjusting the implementation, or addressing a test flake if that's genuinely what it is.
 4. Commit the fix on the same branch and push. Yak will wait for CI to re-run.
 
+## How to write your final summary
+
+Your final summary replaces the **entire** pull request body — not just the part about this retry. Reviewers read it to understand the whole branch, and most of them do not care that CI needed a second pass.
+
+- Summarize everything on the branch (`git log main..HEAD`), not only what you changed in this attempt. Merge the previous attempt's summary above with your own work.
+- The original task is the headline. `## Summary` must describe the problem the branch solves, in the terms of the original task.
+- A CI fix that was unrelated to the original task (a flaky test, a dependency advisory that predates the branch, an infrastructure failure) gets at most one bullet near the end of `## Changes`. Never make it the summary, and do not open the body with an explanation of it.
+- Do not complain about the CI failure, argue that it was pre-existing, or justify your choices to the reviewer in the PR body. State what changed. If a decision genuinely needs the reviewer's attention, make it one short bullet.
+
 @include('prompts.partials.clarification-contract')

--- a/tests/Feature/CreatePullRequestJobTest.php
+++ b/tests/Feature/CreatePullRequestJobTest.php
@@ -534,7 +534,7 @@ test('PR body includes source, repo, attempts, and result summary', function () 
     $job = new CreatePullRequestJob($task);
     app()->call([$job, 'handle']);
 
-    Http::assertSent(function ($request) {
+    Http::assertSent(function ($request) use ($task) {
         if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
             return false;
         }
@@ -545,7 +545,8 @@ test('PR body includes source, repo, attempts, and result summary', function () 
             && str_contains($body, '**Repository:** org/test-repo')
             && str_contains($body, '**Attempts:** 2')
             && str_contains($body, 'Refactored authentication flow')
-            && str_contains($body, '**Task:** [LIN-500](https://linear.app/team/LIN-500)');
+            && str_contains($body, '**Task:** [LIN-500](https://linear.app/team/LIN-500)')
+            && str_contains($body, "**Yak task:** [#{$task->id}](" . route('tasks.show', $task) . ')');
     });
 });
 
@@ -818,6 +819,116 @@ test('PR body shows the rendering placeholder when no rendered walkthrough exist
         return str_contains($body, WalkthroughPrSection::MARKER_START)
             && str_contains($body, '_Rendering, this section will update automatically._')
             && ! str_contains($body, 'walkthrough.webm');
+    });
+});
+
+test('PR body omits the walkthrough section when nothing was captured', function () {
+    Http::fake([
+        'api.github.com/app/installations/*/access_tokens' => Http::response([
+            'token' => 'ghs_test',
+            'expires_at' => now()->addHour()->toIso8601String(),
+        ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
+        'api.github.com/repos/*/pulls' => Http::response([
+            'number' => 1,
+            'html_url' => 'https://github.com/org/my-repo/pull/1',
+        ]),
+        'api.github.com/repos/*/issues/*/labels' => Http::response(['ok' => true]),
+        'api.github.com/repos/*/compare/*' => Http::response(['files' => []]),
+    ]);
+
+    Process::fake([
+        'git diff --name-only *' => Process::result(''),
+    ]);
+
+    Repository::factory()->create([
+        'slug' => 'org/my-repo',
+        'path' => '/home/yak/repos/my-repo',
+    ]);
+
+    // A backend-only change: the run skipped visual capture, so no render
+    // is dispatched and a placeholder would never be replaced.
+    $task = YakTask::factory()->awaitingCi()->create([
+        'repo' => 'org/my-repo',
+        'branch_name' => 'yak/FIX-BACKEND',
+        'source' => 'manual',
+        'description' => 'Fix a multiplier',
+        'attempts' => 1,
+    ]);
+
+    $job = new CreatePullRequestJob($task);
+    app()->call([$job, 'handle']);
+
+    Http::assertSent(function ($request) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
+            return false;
+        }
+
+        $body = $request['body'];
+
+        return ! str_contains($body, WalkthroughPrSection::MARKER_START)
+            && ! str_contains($body, '### Video walkthrough')
+            && ! str_contains($body, '_Rendering, this section will update automatically._');
+    });
+});
+
+test('PR body keeps the rendering placeholder when a v3 capture is waiting on its render', function () {
+    Http::fake([
+        'api.github.com/app/installations/*/access_tokens' => Http::response([
+            'token' => 'ghs_test',
+            'expires_at' => now()->addHour()->toIso8601String(),
+        ]),
+        'api.github.com/repos/*/pulls?*' => Http::response([]),
+        'api.github.com/repos/*/pulls' => Http::response([
+            'number' => 1,
+            'html_url' => 'https://github.com/org/my-repo/pull/1',
+        ]),
+        'api.github.com/repos/*/issues/*/labels' => Http::response(['ok' => true]),
+        'api.github.com/repos/*/compare/*' => Http::response(['files' => []]),
+    ]);
+
+    Process::fake([
+        'git diff --name-only *' => Process::result(''),
+    ]);
+
+    Repository::factory()->create([
+        'slug' => 'org/my-repo',
+        'path' => '/home/yak/repos/my-repo',
+    ]);
+
+    $task = YakTask::factory()->awaitingCi()->create([
+        'repo' => 'org/my-repo',
+        'branch_name' => 'yak/FIX-V3',
+        'source' => 'manual',
+        'description' => 'Restyle the dashboard',
+        'attempts' => 1,
+    ]);
+
+    Artifact::factory()->create([
+        'yak_task_id' => $task->id,
+        'type' => 'script',
+        'role' => 'script',
+        'filename' => 'script.json',
+        'disk_path' => 'script.json',
+    ]);
+
+    Artifact::factory()->create([
+        'yak_task_id' => $task->id,
+        'type' => 'manifest',
+        'role' => 'manifest',
+        'filename' => 'manifest.json',
+        'disk_path' => 'manifest.json',
+    ]);
+
+    $job = new CreatePullRequestJob($task);
+    app()->call([$job, 'handle']);
+
+    Http::assertSent(function ($request) {
+        if ($request->method() !== 'POST' || ! str_contains($request->url(), '/pulls')) {
+            return false;
+        }
+
+        return str_contains($request['body'], '_Rendering, this section will update automatically._');
     });
 });
 

--- a/tests/Feature/Jobs/CreatePullRequestJobWalkthroughTest.php
+++ b/tests/Feature/Jobs/CreatePullRequestJobWalkthroughTest.php
@@ -20,13 +20,24 @@ function invokeBuildPrBody(YakTask $task, array $signedUrls): string
     return (string) $method->invoke($job, $signedUrls);
 }
 
-it('writes the rendering placeholder when there is no cut', function (): void {
+it('writes the rendering placeholder when a capture is waiting on its render', function (): void {
     $task = YakTask::factory()->create();
+    Artifact::create(['yak_task_id' => $task->id, 'type' => 'script', 'role' => 'script', 'filename' => 'script.json', 'disk_path' => "{$task->id}/script.json", 'size_bytes' => 1]);
+    Artifact::create(['yak_task_id' => $task->id, 'type' => 'manifest', 'role' => 'manifest', 'filename' => 'manifest.json', 'disk_path' => "{$task->id}/manifest.json", 'size_bytes' => 1]);
 
     $body = invokeBuildPrBody($task, []);
 
     expect($body)->toContain(WalkthroughPrSection::MARKER_START)
         ->toContain('_Rendering, this section will update automatically._');
+});
+
+it('omits the walkthrough section entirely when nothing was captured', function (): void {
+    $task = YakTask::factory()->create();
+
+    $body = invokeBuildPrBody($task, []);
+
+    expect($body)->not->toContain(WalkthroughPrSection::MARKER_START)
+        ->not->toContain('### Video walkthrough');
 });
 
 it('embeds the gif by public url and captions the screenshots', function (): void {

--- a/tests/Feature/YakPromptBuilderTest.php
+++ b/tests/Feature/YakPromptBuilderTest.php
@@ -424,6 +424,17 @@ test('retry prompt omits the previous-summary block when none is stored', functi
         ->not->toContain('What the previous attempt did');
 });
 
+test('retry prompt tells the agent its summary becomes the whole PR body', function () {
+    $task = YakTask::factory()->make(['description' => 'Do a thing']);
+
+    $prompt = YakPromptBuilder::retryPrompt($task, 'CI blew up');
+
+    expect($prompt)
+        ->toContain('replaces the **entire** pull request body')
+        ->toContain('The original task is the headline.')
+        ->toContain('Do not complain about the CI failure');
+});
+
 test('retry prompt handles null failure output', function () {
     $task = YakTask::factory()->make(['description' => 'Do a thing']);
 


### PR DESCRIPTION
## Summary

Three fixes to the pull request bodies Yak writes, all found on the same PR: a retry had replaced a real bug fix's description with a complaint about an unrelated CI security failure, the body had no link back to the Yak task, and it carried a "Rendering…" walkthrough placeholder for a run that never captured anything.

## Changes

### Retry summaries describe the whole branch
- **`resources/views/prompts/tasks/retry.blade.php`** — new "How to write your final summary" section. A retry overwrites `result_summary`, which is the PR body, so the prompt now states that the summary replaces the entire body, that the original task is the headline, that an unrelated CI fix gets at most one late bullet, and that the body is not the place to argue a failure was pre-existing.

### Link the Yak task
- **`app/Jobs/CreatePullRequestJob.php`** — the header now carries `**Yak task:** [#123](…/tasks/123)`, built from `route('tasks.show', $task)`, so a reviewer can reach the run log, the cost and the follow-up box from the PR. Requires `APP_URL` to be set correctly on the install.

### No placeholder when no walkthrough is coming
- **`app/Jobs/CreatePullRequestJob.php`** — the walkthrough section was emitted whenever no `cut` artifact existed. A run that skipped visual capture dispatches no render, so that placeholder never got replaced. `hasRenderableCapture()` now gates it: raw footage for the legacy v2 path, or a script plus a manifest for v3, mirroring `RenderWalkthroughJob`'s own precondition.

### Tests
- **`tests/Feature/YakPromptBuilderTest.php`** — asserts the retry prompt carries the summary contract.
- **`tests/Feature/CreatePullRequestJobTest.php`** — asserts the Yak task link, the omitted section when nothing was captured, and the kept placeholder when a v3 capture is waiting on its render.
- **`tests/Feature/Jobs/CreatePullRequestJobWalkthroughTest.php`** — the "no cut" case previously asserted a placeholder for a task with zero artifacts, which is the behaviour being fixed. It now supplies a script and manifest, and a companion test covers the empty case.

Not addressed: `RetryYakJob` still overwrites `result_summary`, so the original attempt's summary survives only because the prompt tells the agent to merge it. Persisting it separately is a larger change.