### PR TITLE
fix(deploy): stop deploys losing work, and self-heal stranded tasks

### DIFF
--- a/ansible/group_vars/yak.yml
+++ b/ansible/group_vars/yak.yml
@@ -34,3 +34,11 @@ incus_zfs_arc_max: "8589934592"  # 8GB ZFS ARC cache (tune based on total RAM)
 # templates whose stored `sandbox_base_version` is older.
 # 4: playwright 1.62.1 pinned + PLAYWRIGHT_BROWSERS_PATH, required by `yak-browser shoot`.
 yak_sandbox_base_version: 4
+
+# Hard ceiling for yak:drain before a container recreate: every in-flight
+# task (Running or Retrying) is force-failed once this many seconds have
+# elapsed, regardless of activity. Agent tasks routinely run 30-40
+# minutes, so this is deliberately generous — a deploy can block for up
+# to this long rather than destroy live work. --wait keeps its shorter
+# meaning: the minimum patience for a task that's gone silent.
+yak_drain_max_wait_seconds: 2700

--- a/ansible/group_vars/yak.yml
+++ b/ansible/group_vars/yak.yml
@@ -4,6 +4,7 @@ yak_home: /home/yak
 yak_repo_path: /home/yak/repos
 yak_data_path: /home/yak/data
 yak_claude_path: /home/yak/.claude
+yak_logs_path: /home/yak/logs
 yak_container_name: yak
 
 swap_size_mb: 4096

--- a/ansible/roles/yak-container/tasks/main.yml
+++ b/ansible/roles/yak-container/tasks/main.yml
@@ -152,3 +152,14 @@
     command: "php /app/artisan yak:resume"
   failed_when: false
 
+# Must run after the drain flag is cleared above — otherwise a task
+# resumed here would immediately be paused again by PausesDuringDrain,
+# sitting Pending until the next scheduled yak:reap-lost-pending sweep
+# picks it up instead of resuming right away.
+- name: Resume tasks a drain force-failed for this deploy
+  community.docker.docker_container_exec:
+    container: "{{ yak_container_name }}"
+    user: www-data
+    command: "php /app/artisan yak:resume-interrupted-tasks"
+  failed_when: false
+

--- a/ansible/roles/yak-container/tasks/main.yml
+++ b/ansible/roles/yak-container/tasks/main.yml
@@ -42,7 +42,7 @@
   community.docker.docker_container_exec:
     container: "{{ yak_container_name }}"
     user: www-data
-    command: "php /app/artisan yak:drain --wait={{ yak_drain_wait_seconds | default(300) }}"
+    command: "php /app/artisan yak:drain --wait={{ yak_drain_wait_seconds | default(300) }} --max-wait={{ yak_drain_max_wait_seconds | default(2700) }}"
   when: yak_container_info.exists and yak_container_info.container.State.Running | default(false)
   # Drain is best-effort — if it fails (e.g. DB unreachable) we still
   # want the deploy to proceed rather than leave the instance stuck on

--- a/ansible/roles/yak-container/tasks/main.yml
+++ b/ansible/roles/yak-container/tasks/main.yml
@@ -24,6 +24,36 @@
     mode: "0644"
   when: github_app_private_key | default('') | length > 0
 
+- name: Ensure Yak logs directory exists
+  ansible.builtin.file:
+    path: "{{ yak_logs_path }}"
+    state: directory
+    owner: "{{ yak_user }}"
+    group: "{{ yak_user }}"
+    mode: "0755"
+
+# storage/logs is bind-mounted below so a container recreate (every deploy)
+# no longer truncates it. Rotate it the same way as Caddy's logs (see the
+# ssl role): copytruncate, because the `single` Laravel driver and every
+# supervisord program hold their log file handles open for the life of the
+# process, so a rename-based rotation would just keep writing into the
+# renamed file. copytruncate truncates the file in place, which both
+# writers tolerate without reopening.
+- name: Configure log rotation for Yak logs
+  ansible.builtin.copy:
+    dest: /etc/logrotate.d/yak
+    content: |
+      {{ yak_logs_path }}/*.log {
+          daily
+          rotate 14
+          compress
+          delaycompress
+          missingok
+          notifempty
+          copytruncate
+      }
+    mode: "0644"
+
 - name: Pull Yak Docker image
   community.docker.docker_image:
     name: "geocodio/yak"
@@ -65,6 +95,13 @@
     volumes:
       - "{{ yak_data_path }}:/data"
       - "{{ yak_claude_path }}:/home/yak/.claude"
+      # Persist storage/logs across recreates. A 2026-09-03 incident lost
+      # the evidence for two stuck tasks because the container recreate
+      # that a routine deploy performs truncates any log living only
+      # inside the container. entrypoint.sh already chowns /app/storage
+      # to www-data on every start, so no extra ownership handling is
+      # needed here.
+      - "{{ yak_logs_path }}:/app/storage/logs"
       - "/etc/yak/github-app.pem:/etc/yak/github-app.pem:ro"
       - "{{ yak_home }}/mcp-config.json:/home/yak/mcp-config.json:ro"
       - "{{ yak_home }}/.docker:/home/yak/.docker:ro"

--- a/app/Actions/DispatchRepositorySetupTask.php
+++ b/app/Actions/DispatchRepositorySetupTask.php
@@ -6,6 +6,7 @@ use App\Enums\TaskMode;
 use App\Jobs\SetupYakJob;
 use App\Models\Repository;
 use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
 use Illuminate\Support\Str;
 
 /**
@@ -15,6 +16,8 @@ use Illuminate\Support\Str;
  */
 class DispatchRepositorySetupTask
 {
+    public function __construct(private readonly AgentJobDispatcher $dispatcher) {}
+
     public function __invoke(Repository $repository): YakTask
     {
         $task = YakTask::create([
@@ -30,7 +33,7 @@ class DispatchRepositorySetupTask
             'setup_status' => 'pending',
         ]);
 
-        SetupYakJob::dispatch($task);
+        $this->dispatcher->dispatch($task, SetupYakJob::class);
 
         return $task;
     }

--- a/app/Channels/Linear/WebhookController.php
+++ b/app/Channels/Linear/WebhookController.php
@@ -12,6 +12,7 @@ use App\Jobs\ResearchYakJob;
 use App\Jobs\RunYakJob;
 use App\Models\LinearOauthConnection;
 use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
 use App\Services\FollowUpTaskFactory;
 use App\Services\RepoDetector;
 use App\Services\TaskLogger;
@@ -255,13 +256,15 @@ class WebhookController extends Controller
      */
     private function dispatchAgentJob(YakTask $task): void
     {
+        $dispatcher = app(AgentJobDispatcher::class);
+
         if ($task->mode === TaskMode::Research) {
-            ResearchYakJob::dispatch($task);
+            $dispatcher->dispatch($task, ResearchYakJob::class);
 
             return;
         }
 
-        RunYakJob::dispatch($task);
+        $dispatcher->dispatch($task, RunYakJob::class);
     }
 
     /**

--- a/app/Channels/Sentry/WebhookController.php
+++ b/app/Channels/Sentry/WebhookController.php
@@ -6,6 +6,7 @@ use App\Http\Concerns\VerifiesWebhookSignature;
 use App\Http\Controllers\Controller;
 use App\Jobs\RunYakJob;
 use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
 use App\Services\RepoDetector;
 use App\Services\TaskLogger;
 use Illuminate\Http\JsonResponse;
@@ -92,7 +93,7 @@ class WebhookController extends Controller
         ]);
 
         TaskLogger::info($task, 'Task created', ['source' => 'sentry', 'repo' => $resolvedSlug]);
-        RunYakJob::dispatch($task);
+        app(AgentJobDispatcher::class)->dispatch($task, RunYakJob::class);
 
         return response()->json(['ok' => true, 'task_id' => $task->id], 201);
     }

--- a/app/Channels/Slack/WebhookController.php
+++ b/app/Channels/Slack/WebhookController.php
@@ -13,6 +13,7 @@ use App\Jobs\RunYakJob;
 use App\Jobs\SendNotificationJob;
 use App\Models\PendingSteeringMessage;
 use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
 use App\Services\FollowUpTaskFactory;
 use App\Services\RepoClarificationResolver;
 use App\Services\RepoDetector;
@@ -287,13 +288,15 @@ class WebhookController extends Controller
      */
     private function dispatchAgentJob(YakTask $task): void
     {
+        $dispatcher = app(AgentJobDispatcher::class);
+
         if ($task->mode === TaskMode::Research) {
-            ResearchYakJob::dispatch($task);
+            $dispatcher->dispatch($task, ResearchYakJob::class);
 
             return;
         }
 
-        RunYakJob::dispatch($task);
+        $dispatcher->dispatch($task, RunYakJob::class);
     }
 
     /**

--- a/app/Console/Commands/DrainForDeployCommand.php
+++ b/app/Console/Commands/DrainForDeployCommand.php
@@ -9,27 +9,59 @@ use App\Jobs\SendNotificationJob;
 use App\Models\YakTask;
 use App\Services\IncusSandboxManager;
 use App\Services\TaskLogger;
+use Carbon\CarbonInterface;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Sleep;
 
-#[Signature('yak:drain {--wait=300 : Max seconds to wait for running tasks before forcing failure} {--poll=5 : Polling interval in seconds}')]
-#[Description('Pause new task pickups and wait for Running tasks to finish before a container recreate')]
+#[Signature('yak:drain {--wait=300 : Minimum seconds to wait for a silent-but-in-flight task before forcing failure} {--max-wait=2700 : Hard ceiling in seconds — every in-flight task is force-failed once this is reached, regardless of activity} {--poll=5 : Polling interval in seconds}')]
+#[Description('Pause new task pickups and wait for in-flight tasks to finish before a container recreate')]
 class DrainForDeployCommand extends Command
 {
     /**
+     * Silence window used to decide whether an in-flight task is still
+     * demonstrably alive. Matches yak:reap-orphaned-tasks so the two
+     * sweeps agree on what "stalled" means — a long tool call (a full
+     * test suite, a docker-compose warmup) can legitimately emit
+     * nothing for 10+ minutes (see RunYakJob's class docblock), so a
+     * shorter window would force-fail healthy tasks.
+     */
+    private const SILENCE_MINUTES = 15;
+
+    private const CLAUDE_QUEUE = 'yak-claude';
+
+    /**
+     * Bounded grace period, after all tasks have settled, for straggler
+     * queue workers to release their reserved job row. A row that
+     * survives the container recreate is redelivered `retry_after`
+     * seconds later (config/queue.php) against a task that may have
+     * moved on in the meantime. Change 0's atomic claim makes that
+     * non-destructive, but not hitting it at all is better.
+     */
+    private const WORKER_EXIT_WAIT_SECONDS = 30;
+
+    /**
      * Called by Ansible before a container recreate. Sets the drain
      * cache flag (read by PausesDuringDrain middleware) so queue
-     * workers stop picking up new agent jobs, then polls for
-     * in-flight Running tasks to finish.
+     * workers stop picking up new agent jobs, then polls for in-flight
+     * tasks to finish.
      *
-     * After the wait budget is exhausted, still-Running tasks are
-     * marked Failed with a "deploy interrupted" error, their sandboxes
-     * torn down, and their source channels notified. That leaves the
-     * system in a clean state for Ansible to proceed with the
-     * container recreate.
+     * "In-flight" is `Running` **or** `Retrying` — a task set back to
+     * Retrying by ProcessCIResultJob is running a full agent session
+     * via RetryYakJob and never sets Running again, so a drain that
+     * only looked at Running would miss it entirely and report
+     * "nothing to drain" while a live retry is destroyed underneath it.
+     *
+     * The wait is adaptive rather than a fixed budget: a task is only
+     * forced to Failed once it has gone quiet (no task_log activity
+     * within the silence window) AND at least --wait seconds have
+     * elapsed. A task that keeps logging is left alone until --max-wait,
+     * a hard ceiling that forces everything regardless of activity.
      *
      * AwaitingCi / AwaitingClarification tasks don't hold a worker and
      * are left alone — they'll resume polling under the new container.
@@ -37,55 +69,175 @@ class DrainForDeployCommand extends Command
     public function handle(IncusSandboxManager $sandbox): int
     {
         $waitSeconds = (int) $this->option('wait');
+        $maxWaitSeconds = (int) $this->option('max-wait');
         $pollSeconds = max(1, (int) $this->option('poll'));
 
-        // TTL comfortably outlasts the expected deploy window so the
-        // flag doesn't accidentally expire mid-drain and let a worker
-        // grab a new job.
-        Cache::put(PausesDuringDrain::CACHE_KEY, true, now()->addSeconds($waitSeconds + 600));
+        // TTL is derived from --max-wait, not --wait: the ceiling is the
+        // longest this command can legitimately still be waiting, so the
+        // flag must outlast it. Deriving it from --wait would let the
+        // flag expire mid-drain (e.g. wait+600=900s against a 2700s
+        // ceiling), letting workers resume pickups into a container
+        // that's about to be recreated.
+        Cache::put(PausesDuringDrain::CACHE_KEY, true, now()->addSeconds($maxWaitSeconds + 600));
 
-        $this->components->info('Drain flag set — workers will pause new pickups.');
+        $this->components->info(
+            "Drain flag set — workers will pause new pickups. Waiting up to {$maxWaitSeconds}s total " .
+            "(minimum {$waitSeconds}s patience for a silent task, " . self::SILENCE_MINUTES . ' min silence window).'
+        );
 
         $elapsed = 0;
-        while ($elapsed < $waitSeconds) {
-            $runningCount = YakTask::where('status', TaskStatus::Running)->count();
+        while (true) {
+            $inFlight = YakTask::whereIn('status', [TaskStatus::Running, TaskStatus::Retrying])->get();
 
-            if ($runningCount === 0) {
-                $this->components->info('No Running tasks — drain complete.');
+            if ($inFlight->isEmpty()) {
+                $this->components->info('No in-flight tasks — drain complete.');
 
-                return self::SUCCESS;
+                break;
             }
 
-            $this->components->info("Waiting on {$runningCount} Running task(s)... ({$elapsed}s / {$waitSeconds}s)");
+            $ceilingReached = $elapsed >= $maxWaitSeconds;
+            $silenceThreshold = now()->subMinutes(self::SILENCE_MINUTES);
 
-            sleep($pollSeconds);
+            $remaining = $this->settleStragglers($inFlight, $sandbox, $ceilingReached, $elapsed, $waitSeconds, $maxWaitSeconds, $silenceThreshold);
+
+            if ($remaining->isEmpty()) {
+                break;
+            }
+
+            $this->reportProgress($remaining, $silenceThreshold, $elapsed, $waitSeconds, $maxWaitSeconds);
+
+            Sleep::for($pollSeconds)->seconds();
             $elapsed += $pollSeconds;
         }
 
-        $stragglers = YakTask::where('status', TaskStatus::Running)->get();
-
-        if ($stragglers->isEmpty()) {
-            $this->components->info('All tasks finished during final poll.');
-
-            return self::SUCCESS;
-        }
-
-        $this->components->warn("Forcing {$stragglers->count()} straggler(s) to Failed after {$waitSeconds}s wait.");
-
-        foreach ($stragglers as $task) {
-            $this->failStraggler($task, $sandbox, $waitSeconds);
-        }
+        $this->waitForStragglerWorkers($pollSeconds);
 
         return self::SUCCESS;
     }
 
-    private function failStraggler(YakTask $task, IncusSandboxManager $sandbox, int $waitSeconds): void
-    {
-        $reason = "Deploy interrupted the task after {$waitSeconds}s wait. Retry it once the deploy is done.";
+    /**
+     * Force-fail whichever of the in-flight tasks are past the point
+     * they're allowed to keep running, returning the ones still owed
+     * more patience.
+     *
+     * @param  Collection<int, YakTask>  $inFlight
+     * @return Collection<int, YakTask>
+     */
+    private function settleStragglers(
+        Collection $inFlight,
+        IncusSandboxManager $sandbox,
+        bool $ceilingReached,
+        int $elapsed,
+        int $waitSeconds,
+        int $maxWaitSeconds,
+        CarbonInterface $silenceThreshold,
+    ): Collection {
+        $remaining = collect();
 
-        TaskLogger::warning($task, 'Task interrupted by deploy drain', [
-            'wait_seconds' => $waitSeconds,
-        ]);
+        foreach ($inFlight as $task) {
+            if ($ceilingReached) {
+                $this->failStraggler(
+                    $task,
+                    $sandbox,
+                    "Deploy interrupted the task after hitting the {$maxWaitSeconds}s drain ceiling. Retry it once the deploy is done.",
+                    ['max_wait_seconds' => $maxWaitSeconds],
+                );
+
+                continue;
+            }
+
+            $silent = $this->isSilent($task, $silenceThreshold);
+
+            if ($elapsed >= $waitSeconds && $silent) {
+                $this->failStraggler(
+                    $task,
+                    $sandbox,
+                    "Deploy interrupted the task after {$waitSeconds}s with no activity. Retry it once the deploy is done.",
+                    ['wait_seconds' => $waitSeconds, 'silence_minutes' => self::SILENCE_MINUTES],
+                );
+
+                continue;
+            }
+
+            $remaining->push($task);
+        }
+
+        return $remaining;
+    }
+
+    /**
+     * @param  Collection<int, YakTask>  $remaining
+     */
+    private function reportProgress(Collection $remaining, CarbonInterface $silenceThreshold, int $elapsed, int $waitSeconds, int $maxWaitSeconds): void
+    {
+        $alive = $remaining->filter(fn (YakTask $task) => ! $this->isSilent($task, $silenceThreshold))->count();
+        $silent = $remaining->count() - $alive;
+
+        $this->components->info(
+            "Waiting on {$remaining->count()} in-flight task(s) — {$alive} actively logging, {$silent} silent. " .
+            "({$elapsed}s elapsed, min patience {$waitSeconds}s, hard ceiling {$maxWaitSeconds}s)"
+        );
+    }
+
+    private function isSilent(YakTask $task, CarbonInterface $silenceThreshold): bool
+    {
+        $latestLog = $task->logs()->latest('created_at')->first();
+
+        return $latestLog === null || $latestLog->created_at < $silenceThreshold;
+    }
+
+    /**
+     * Give straggler yak-claude queue workers a bounded chance to
+     * finish releasing their reserved job row before returning control
+     * to Ansible. This narrows, but cannot close, the race between "a
+     * worker just picked up a job" and the container recreate that
+     * follows — Change 0's atomic claim makes a redelivered row
+     * non-destructive if we run out of patience here.
+     */
+    private function waitForStragglerWorkers(int $pollSeconds): void
+    {
+        $elapsed = 0;
+
+        while ($elapsed < self::WORKER_EXIT_WAIT_SECONDS) {
+            $reserved = $this->reservedWorkerCount();
+
+            if ($reserved === 0) {
+                return;
+            }
+
+            $this->components->info(
+                "Waiting for {$reserved} reserved " . self::CLAUDE_QUEUE . ' job(s) to release... ' .
+                "({$elapsed}s / " . self::WORKER_EXIT_WAIT_SECONDS . 's)'
+            );
+
+            Sleep::for($pollSeconds)->seconds();
+            $elapsed += $pollSeconds;
+        }
+
+        $remaining = $this->reservedWorkerCount();
+
+        if ($remaining > 0) {
+            $this->components->warn(
+                "{$remaining} reserved " . self::CLAUDE_QUEUE . ' job(s) still outstanding after ' .
+                self::WORKER_EXIT_WAIT_SECONDS . 's — proceeding with the recreate anyway.'
+            );
+        }
+    }
+
+    private function reservedWorkerCount(): int
+    {
+        return (int) DB::table('jobs')
+            ->where('queue', self::CLAUDE_QUEUE)
+            ->whereNotNull('reserved_at')
+            ->count();
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    private function failStraggler(YakTask $task, IncusSandboxManager $sandbox, string $reason, array $context = []): void
+    {
+        TaskLogger::warning($task, 'Task interrupted by deploy drain', $context);
 
         $task->update([
             'status' => TaskStatus::Failed,

--- a/app/Console/Commands/DrainForDeployCommand.php
+++ b/app/Console/Commands/DrainForDeployCommand.php
@@ -7,6 +7,7 @@ use App\Enums\TaskStatus;
 use App\Jobs\Middleware\PausesDuringDrain;
 use App\Jobs\SendNotificationJob;
 use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
 use App\Services\IncusSandboxManager;
 use App\Services\TaskLogger;
 use Carbon\CarbonInterface;
@@ -139,7 +140,7 @@ class DrainForDeployCommand extends Command
                 $this->failStraggler(
                     $task,
                     $sandbox,
-                    "Deploy interrupted the task after hitting the {$maxWaitSeconds}s drain ceiling. Retry it once the deploy is done.",
+                    "Deploy interrupted the task after hitting the {$maxWaitSeconds}s drain ceiling.",
                     ['max_wait_seconds' => $maxWaitSeconds],
                 );
 
@@ -152,7 +153,7 @@ class DrainForDeployCommand extends Command
                 $this->failStraggler(
                     $task,
                     $sandbox,
-                    "Deploy interrupted the task after {$waitSeconds}s with no activity. Retry it once the deploy is done.",
+                    "Deploy interrupted the task after {$waitSeconds}s with no activity.",
                     ['wait_seconds' => $waitSeconds, 'silence_minutes' => self::SILENCE_MINUTES],
                 );
 
@@ -237,12 +238,26 @@ class DrainForDeployCommand extends Command
      */
     private function failStraggler(YakTask $task, IncusSandboxManager $sandbox, string $reason, array $context = []): void
     {
-        TaskLogger::warning($task, 'Task interrupted by deploy drain', $context);
+        // yak:resume-interrupted-tasks only resumes a task that was
+        // actually running one of the four claiming jobs when interrupted —
+        // a Retrying task is mid-CI-retry via RetryYakJob, and a Running
+        // task can also be driven by RunFollowUpJob or ClarificationReplyJob
+        // (both stamp claimed_job_class themselves at pickup). Any of
+        // those needs a human, so the message must not promise otherwise.
+        $resumable = $task->status === TaskStatus::Running
+            && in_array($task->claimed_job_class, AgentJobDispatcher::claimableJobClasses(), true);
+
+        $reason .= $resumable
+            ? ' It will resume automatically once the deploy finishes.'
+            : ' It needs a manual retry once the deploy is done.';
+
+        TaskLogger::warning($task, 'Task interrupted by deploy drain', $context + ['resumable' => $resumable]);
 
         $task->update([
             'status' => TaskStatus::Failed,
             'error_log' => $reason,
             'completed_at' => now(),
+            'interrupted_by_deploy_at' => now(),
         ]);
 
         try {

--- a/app/Console/Commands/ReapLostPendingCommand.php
+++ b/app/Console/Commands/ReapLostPendingCommand.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\TaskMode;
+use App\Enums\TaskStatus;
+use App\Jobs\Middleware\PausesDuringDrain;
+use App\Jobs\ResearchYakJob;
+use App\Jobs\RunYakJob;
+use App\Jobs\RunYakReviewJob;
+use App\Jobs\SetupYakJob;
+use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
+use App\Services\HealthCheck\ClaudeAuthCheck;
+use App\Services\TaskLogger;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+#[Signature('yak:reap-lost-pending {--minutes=10 : Age threshold for dispatched_at before a Pending task is considered lost}')]
+#[Description('Re-dispatch Pending tasks whose queued job appears to have vanished')]
+class ReapLostPendingCommand extends Command
+{
+    /**
+     * On 2026-09-03, two Linear tasks sat Pending forever: `attempts = 0`,
+     * no `started_at`, and their `RunYakJob` rows had vanished from the
+     * `jobs` table with nothing blocking them. No existing sweep looks at
+     * Pending tasks — `yak:reap-orphaned-tasks` scopes to Running only, by
+     * design, since a task that's merely queued isn't "orphaned" in the
+     * usual sense. This command covers that gap.
+     *
+     * A task qualifies when it's Pending, has never started
+     * (`started_at IS NULL` — NOT `attempts = 0`, which would wrongly
+     * exclude every retried or resumed task), and was dispatched more than
+     * `--minutes` ago. `App\Services\AgentJobDispatcher` is the only thing
+     * that stamps `dispatched_at`, and only for the four "claiming" agent
+     * jobs (RunYakJob, ResearchYakJob, RunYakReviewJob, SetupYakJob) — see
+     * its docblock. Tasks dispatched via RetryYakJob, RunFollowUpJob or
+     * ClarificationReplyJob never get `dispatched_at` set at all, so this
+     * query can never see them; re-dispatching one of those as a fresh
+     * RunYakJob would run the wrong job and discard branch/session
+     * context.
+     *
+     * Before assuming a candidate is actually lost, check the queue
+     * itself via the stored `queue_job_uuid`: if a `jobs` row still
+     * carries that uuid, the job is still queued or reserved by a worker
+     * and re-dispatching would risk a duplicate run — change 0's atomic
+     * claim makes that merely wasteful rather than destructive, but
+     * skipping it is better. When no uuid was captured (a dispatch that
+     * hit a `ShouldBeUnique` lock, or ran on the `sync` driver), fall back
+     * to `dispatched_at` age alone, which the query already filtered on.
+     *
+     * Skips entirely while a deploy is draining or the shared Claude
+     * session is unusable — those flags make every Pending task look
+     * stale by the same threshold, and re-dispatching under either
+     * condition would either be dispatched into a container about to be
+     * recreated or held by HoldsForClaudeAuth anyway, so it's simplest
+     * (and quietest) to no-op the whole sweep.
+     */
+    public function handle(AgentJobDispatcher $dispatcher): int
+    {
+        if (Cache::has(PausesDuringDrain::CACHE_KEY)) {
+            $this->components->info('Drain in progress — skipping.');
+
+            return self::SUCCESS;
+        }
+
+        if (Cache::has(ClaudeAuthCheck::UNUSABLE_CACHE_KEY)) {
+            $this->components->info('Claude session unusable — skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $minutes = (int) $this->option('minutes');
+        $threshold = now()->subMinutes($minutes);
+
+        $candidates = YakTask::query()
+            ->where('status', TaskStatus::Pending)
+            ->whereNull('started_at')
+            ->whereNotNull('dispatched_at')
+            ->where('dispatched_at', '<', $threshold)
+            ->get();
+
+        $reDispatched = 0;
+
+        foreach ($candidates as $task) {
+            if ($this->stillQueued($task)) {
+                continue;
+            }
+
+            $jobClass = $this->jobClassFor($task);
+
+            TaskLogger::warning($task, 'Task self-healed — dispatched job appears lost', [
+                'dispatched_at' => $task->dispatched_at?->toIso8601String(),
+                'queue_job_uuid' => $task->queue_job_uuid,
+                'redispatched_as' => $jobClass,
+            ]);
+
+            $dispatcher->dispatch($task, $jobClass);
+            $reDispatched++;
+        }
+
+        $this->components->info("Re-dispatched {$reDispatched} lost pending task(s) (checked {$candidates->count()}).");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Checks the `jobs` table for a row still carrying this task's queue
+     * uuid — queued or reserved, either way still tracked by the queue.
+     * The uuid lives inside the JSON `payload` column, not a dedicated
+     * column, so this is a text search rather than an indexed lookup;
+     * the `jobs` table is small enough in practice for that to be fine.
+     *
+     * A task with no `queue_job_uuid` (dispatch didn't go through the
+     * queue at all, or lost a ShouldBeUnique race and never actually
+     * pushed) has nothing to check here — the caller's `dispatched_at`
+     * age filter is the only signal available for it.
+     */
+    private function stillQueued(YakTask $task): bool
+    {
+        $uuid = $task->queue_job_uuid;
+
+        if ($uuid === null) {
+            return false;
+        }
+
+        return DB::table('jobs')
+            ->where('payload', 'like', '%"uuid":"' . $uuid . '"%')
+            ->exists();
+    }
+
+    /**
+     * @return class-string<RunYakJob|ResearchYakJob|RunYakReviewJob|SetupYakJob>
+     */
+    private function jobClassFor(YakTask $task): string
+    {
+        /** @var TaskMode $mode */
+        $mode = $task->mode;
+
+        return match ($mode) {
+            TaskMode::Setup => SetupYakJob::class,
+            TaskMode::Research => ResearchYakJob::class,
+            TaskMode::Review => RunYakReviewJob::class,
+            default => RunYakJob::class,
+        };
+    }
+}

--- a/app/Console/Commands/ReapOrphanedTasksCommand.php
+++ b/app/Console/Commands/ReapOrphanedTasksCommand.php
@@ -13,27 +13,31 @@ use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-#[Signature('yak:reap-orphaned-tasks {--minutes=15 : Silence threshold before a Running task is considered orphaned}')]
-#[Description('Finalise tasks stuck in Running whose queue worker crashed without calling failed()')]
+#[Signature('yak:reap-orphaned-tasks {--minutes=15 : Silence threshold before a Running or Retrying task is considered orphaned}')]
+#[Description('Finalise tasks stuck in Running or Retrying whose queue worker crashed without calling failed()')]
 class ReapOrphanedTasksCommand extends Command
 {
     /**
      * A worker can die without triggering Laravel's failed() hook —
      * an OOM kill, a container restart, a supervisord-initiated stop
      * during deploy, etc. When that happens the task row stays
-     * `running`, the Incus sandbox stays alive, and the existing
-     * yak:cleanup-sandboxes sweep (which only touches containers for
-     * terminal tasks) doesn't help.
+     * `running` (or `retrying`), the Incus sandbox stays alive, and
+     * the existing yak:cleanup-sandboxes sweep (which only touches
+     * containers for terminal tasks) doesn't help.
      *
-     * This command finds Running tasks whose latest task_log is
-     * older than the threshold, marks them Failed with a helpful
-     * error, destroys the sandbox, and notifies the source channel
-     * via the standard failure path.
+     * This command finds Running or Retrying tasks whose latest
+     * task_log is older than the threshold, marks them Failed with a
+     * helpful error, destroys the sandbox, and notifies the source
+     * channel via the standard failure path.
      *
-     * Only `Running` is in scope:
+     * `Running` and `Retrying` are both in scope:
+     *   - Retrying is set by ProcessCIResultJob before dispatching
+     *     RetryYakJob, which runs a full agent session and never sets
+     *     Running again. It is not a brief transitional state — a
+     *     worker crash mid-retry leaves the task stuck exactly like a
+     *     crash mid-Running would, with no other sweep covering it.
      *   - AwaitingCi has its own yak:timeout-ci command
      *   - AwaitingClarification has its own yak:cleanup-expired-clarifications
-     *   - Retrying is a brief transitional state
      *   - Pending tasks are just queued, not orphaned
      */
     public function handle(IncusSandboxManager $sandbox): int
@@ -42,7 +46,7 @@ class ReapOrphanedTasksCommand extends Command
         $threshold = now()->subMinutes($minutes);
 
         $candidates = YakTask::query()
-            ->where('status', TaskStatus::Running)
+            ->whereIn('status', [TaskStatus::Running, TaskStatus::Retrying])
             ->where('updated_at', '<', $threshold)
             ->get();
 

--- a/app/Console/Commands/ResumeInterruptedTasksCommand.php
+++ b/app/Console/Commands/ResumeInterruptedTasksCommand.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\NotificationType;
+use App\Enums\TaskStatus;
+use App\Jobs\Middleware\PausesDuringDrain;
+use App\Jobs\ResearchYakJob;
+use App\Jobs\RunYakJob;
+use App\Jobs\RunYakReviewJob;
+use App\Jobs\SendNotificationJob;
+use App\Jobs\SetupYakJob;
+use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
+use App\Services\TaskLogger;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+#[Signature('yak:resume-interrupted-tasks {--max-resumes=3 : How many times a task may be auto-resumed before it is left for a manual retry}')]
+#[Description('Requeue tasks a deploy drain force-failed, so a deploy costs time, never work')]
+class ResumeInterruptedTasksCommand extends Command
+{
+    /**
+     * Run by Ansible after the container is healthy AND after `yak:resume`
+     * has cleared the drain flag — resumed work must not be immediately
+     * re-paused by a flag the previous step just lifted.
+     *
+     * Only tasks whose `claimed_job_class` is one of the four claiming jobs
+     * (RunYakJob, ResearchYakJob, RunYakReviewJob, SetupYakJob) — see
+     * AgentJobDispatcher::claimableJobClasses() — are faithfully
+     * reconstructable from what's persisted on the row. DrainForDeployCommand
+     * only stamps that promise into the failure message for tasks that
+     * qualify (see failStraggler()); everything else — a follow-up
+     * (RunFollowUpJob), a clarification reply (ClarificationReplyJob), or a
+     * CI retry (RetryYakJob, via a `Retrying` task) — already carries an
+     * accurate "needs a manual retry" message and is left alone here beyond
+     * clearing the marker so it isn't reconsidered on the next deploy.
+     *
+     * Resume must not touch `tasks.attempts`: it gates CI retries against
+     * `yak.max_attempts` (config/yak.php, default 2), and the claim this
+     * re-dispatch triggers (App\Jobs\Concerns\ClaimsTask::claimTask())
+     * unconditionally increments it. Decrementing by one here first cancels
+     * that out, so a task's CI-retry budget is exactly what it would have
+     * been without the deploy interruption. `deploy_resume_count` is the
+     * counter that actually bounds how many times a task can be resumed.
+     */
+    public function handle(AgentJobDispatcher $dispatcher): int
+    {
+        if (Cache::has(PausesDuringDrain::CACHE_KEY)) {
+            $this->components->info('Drain in progress — skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $maxResumes = (int) $this->option('max-resumes');
+
+        $candidates = YakTask::query()
+            ->where('status', TaskStatus::Failed)
+            ->whereNotNull('interrupted_by_deploy_at')
+            ->get();
+
+        $resumed = 0;
+        $left = 0;
+
+        foreach ($candidates as $task) {
+            $jobClass = $this->resumableJobClassFor($task);
+
+            if ($jobClass === null) {
+                // Not one of the four claiming jobs — the drain message
+                // already told the operator this needs a manual retry.
+                // Just clear the marker so it isn't reconsidered.
+                $task->update(['interrupted_by_deploy_at' => null]);
+                $left++;
+
+                continue;
+            }
+
+            if ($task->deploy_resume_count >= $maxResumes) {
+                TaskLogger::warning($task, 'Task exceeded deploy-resume budget — left for a manual retry', [
+                    'deploy_resume_count' => $task->deploy_resume_count,
+                    'max_resumes' => $maxResumes,
+                ]);
+
+                $task->update([
+                    'interrupted_by_deploy_at' => null,
+                    'error_log' => "Deploy interrupted this task {$task->deploy_resume_count} time(s) already — it needs a manual retry.",
+                ]);
+                $left++;
+
+                continue;
+            }
+
+            $task->update([
+                'status' => TaskStatus::Pending,
+                'error_log' => null,
+                'completed_at' => null,
+                'interrupted_by_deploy_at' => null,
+                // Cancels out the claim this dispatch is about to trigger,
+                // so the resume itself never costs a CI retry.
+                'attempts' => max(0, $task->attempts - 1),
+                'deploy_resume_count' => $task->deploy_resume_count + 1,
+            ]);
+
+            TaskLogger::info($task, 'Task resumed after deploy interruption', [
+                'job_class' => $jobClass,
+                'deploy_resume_count' => $task->deploy_resume_count,
+            ]);
+
+            $dispatcher->dispatch($task, $jobClass);
+
+            if ($task->source !== 'system') {
+                SendNotificationJob::dispatch(
+                    $task,
+                    NotificationType::Retry,
+                    'Deploy finished — resuming automatically.',
+                );
+            }
+
+            $resumed++;
+        }
+
+        $this->components->info(
+            "Resumed {$resumed} interrupted task(s), left {$left} for a manual retry (checked {$candidates->count()})."
+        );
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return class-string<RunYakJob|ResearchYakJob|RunYakReviewJob|SetupYakJob>|null
+     */
+    private function resumableJobClassFor(YakTask $task): ?string
+    {
+        $jobClass = $task->claimed_job_class;
+
+        if ($jobClass === null || ! in_array($jobClass, AgentJobDispatcher::claimableJobClasses(), true)) {
+            return null;
+        }
+
+        /** @var class-string<RunYakJob|ResearchYakJob|RunYakReviewJob|SetupYakJob> $jobClass */
+        return $jobClass;
+    }
+}

--- a/app/Console/Commands/RunCommand.php
+++ b/app/Console/Commands/RunCommand.php
@@ -7,6 +7,7 @@ use App\Jobs\ResearchYakJob;
 use App\Jobs\RunYakJob;
 use App\Models\Repository;
 use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
 use App\Services\TaskLogger;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
@@ -52,15 +53,14 @@ class RunCommand extends Command
 
         TaskLogger::info($task, 'Task created', ['source' => 'cli', 'repo' => $repository->slug]);
 
-        $job = $isResearch
-            ? new ResearchYakJob($task)
-            : new RunYakJob($task);
+        $jobClass = $isResearch ? ResearchYakJob::class : RunYakJob::class;
+        $dispatcher = app(AgentJobDispatcher::class);
 
         if ($isSync) {
             $this->components->info("Running task #{$task->id} synchronously...");
-            dispatch_sync($job);
+            $dispatcher->dispatchSync($task, $jobClass);
         } else {
-            dispatch($job);
+            $dispatcher->dispatch($task, $jobClass);
         }
 
         $this->components->info("Task #{$task->id} dispatched for {$repository->name}.");

--- a/app/Console/Commands/ScanCiCommand.php
+++ b/app/Console/Commands/ScanCiCommand.php
@@ -10,6 +10,7 @@ use App\Enums\TaskMode;
 use App\Jobs\RunYakJob;
 use App\Models\Repository;
 use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
 use App\Services\TaskLogger;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
@@ -143,7 +144,7 @@ class ScanCiCommand extends Command
             ]);
 
             TaskLogger::info($task, 'Task created', ['source' => 'flaky-test', 'repo' => $repository->slug]);
-            RunYakJob::dispatch($task);
+            app(AgentJobDispatcher::class)->dispatch($task, RunYakJob::class);
             $tasksCreated++;
 
             $this->components->info("Created task #{$task->id} for flaky test: {$canonical->testName}");

--- a/app/Console/Commands/SetupRepoCommand.php
+++ b/app/Console/Commands/SetupRepoCommand.php
@@ -6,6 +6,7 @@ use App\Enums\TaskMode;
 use App\Jobs\SetupYakJob;
 use App\Models\Repository;
 use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
@@ -39,7 +40,7 @@ class SetupRepoCommand extends Command
             'setup_status' => 'pending',
         ]);
 
-        SetupYakJob::dispatch($task);
+        app(AgentJobDispatcher::class)->dispatch($task, SetupYakJob::class);
 
         $this->components->info("Setup task dispatched for {$repository->name} (task #{$task->id}).");
 

--- a/app/Http/Controllers/Tasks/StoreTaskController.php
+++ b/app/Http/Controllers/Tasks/StoreTaskController.php
@@ -8,13 +8,14 @@ use App\Http\Requests\Tasks\StoreTaskRequest;
 use App\Jobs\ResearchYakJob;
 use App\Jobs\RunYakJob;
 use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
 use App\Services\TaskLogger;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Str;
 
 class StoreTaskController extends Controller
 {
-    public function __invoke(StoreTaskRequest $request): RedirectResponse
+    public function __invoke(StoreTaskRequest $request, AgentJobDispatcher $dispatcher): RedirectResponse
     {
         $validated = $request->validated();
 
@@ -32,9 +33,9 @@ class StoreTaskController extends Controller
         $mode = $task->mode;
 
         if ($mode === TaskMode::Research) {
-            ResearchYakJob::dispatch($task);
+            $dispatcher->dispatch($task, ResearchYakJob::class);
         } else {
-            RunYakJob::dispatch($task);
+            $dispatcher->dispatch($task, RunYakJob::class);
         }
 
         return redirect()->route('tasks.show', $task)->with('success', 'Task created.');

--- a/app/Http/Controllers/Tasks/TaskActionController.php
+++ b/app/Http/Controllers/Tasks/TaskActionController.php
@@ -18,6 +18,7 @@ use App\Jobs\SetupYakJob;
 use App\Models\PrReview;
 use App\Models\Repository;
 use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
 use App\Services\IncusSandboxManager;
 use App\Services\TaskLogger;
 use Illuminate\Http\RedirectResponse;
@@ -46,14 +47,14 @@ class TaskActionController extends Controller
         /** @var TaskMode $mode */
         $mode = $task->mode;
 
-        $job = match ($mode) {
-            TaskMode::Setup => new SetupYakJob($task),
-            TaskMode::Research => new ResearchYakJob($task),
-            TaskMode::Review => new RunYakReviewJob($task),
-            default => new RunYakJob($task),
+        $jobClass = match ($mode) {
+            TaskMode::Setup => SetupYakJob::class,
+            TaskMode::Research => ResearchYakJob::class,
+            TaskMode::Review => RunYakReviewJob::class,
+            default => RunYakJob::class,
         };
 
-        dispatch($job);
+        app(AgentJobDispatcher::class)->dispatch($task, $jobClass);
 
         return redirect()->route('tasks.show', $task)->with('success', 'Task re-queued.');
     }
@@ -159,7 +160,7 @@ class TaskActionController extends Controller
 
         $task->refresh();
 
-        RunYakReviewJob::dispatch($task);
+        app(AgentJobDispatcher::class)->dispatch($task, RunYakReviewJob::class);
 
         return redirect()->route('tasks.show', $task)->with('success', 'Re-running review for this PR.');
     }
@@ -238,12 +239,12 @@ class TaskActionController extends Controller
         /** @var TaskMode $mode */
         $mode = $task->mode;
 
-        $job = match ($mode) {
-            TaskMode::Research => new ResearchYakJob($task),
-            default => new RunYakJob($task),
+        $jobClass = match ($mode) {
+            TaskMode::Research => ResearchYakJob::class,
+            default => RunYakJob::class,
         };
 
-        dispatch($job);
+        app(AgentJobDispatcher::class)->dispatch($task, $jobClass);
 
         SendNotificationJob::dispatch(
             $task,

--- a/app/Jobs/ClarificationReplyJob.php
+++ b/app/Jobs/ClarificationReplyJob.php
@@ -94,6 +94,12 @@ class ClarificationReplyJob implements ShouldQueue
 
         $this->task->update([
             'status' => TaskStatus::Running,
+            // Recorded so a drain interruption can tell this apart from a
+            // fresh RunYakJob run — yak:resume-interrupted-tasks must never
+            // resume a clarification reply as a plain RunYakJob, since the
+            // user's reply text is a constructor argument here, not
+            // persisted on the task row.
+            'claimed_job_class' => self::class,
         ]);
 
         TaskLogger::info($this->task, 'Picked up by worker — clarification reply');

--- a/app/Jobs/Concerns/ClaimsTask.php
+++ b/app/Jobs/Concerns/ClaimsTask.php
@@ -50,6 +50,11 @@ trait ClaimsTask
                 'status' => TaskStatus::Running->value,
                 'started_at' => now(),
                 'attempts' => DB::raw('attempts + 1'),
+                // Persisted so yak:resume-interrupted-tasks can re-dispatch
+                // the exact class that was running instead of guessing from
+                // `mode` — static::class here is the job using this trait
+                // (RunYakJob, ResearchYakJob, RunYakReviewJob, SetupYakJob).
+                'claimed_job_class' => static::class,
             ]);
 
         if ($claimed === 0) {

--- a/app/Jobs/Concerns/ClaimsTask.php
+++ b/app/Jobs/Concerns/ClaimsTask.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Jobs\Concerns;
+
+use App\Enums\TaskStatus;
+use App\Models\YakTask;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Atomic, per-instance-idempotent task claim shared by every job that
+ * picks up a YakTask.
+ *
+ * `ClaimsTaskAtomically` (job middleware) calls `claimTask()` before
+ * `EnsureRepoReady`/`EnsureDailyBudget` can run, so a losing copy is
+ * deleted before it ever reaches a path that calls `$job->fail()` —
+ * which would otherwise mark the winning copy's task Failed and destroy
+ * its live sandbox.
+ *
+ * `handle()` also calls `claimTask()` itself, unconditionally, as the
+ * first thing the run does. Against the real queue that's a harmless
+ * no-op: the middleware already claimed the task and `$taskClaimed`
+ * short-circuits the second call. When a job is constructed and
+ * `->handle()` is called directly — bypassing the queue's middleware
+ * pipeline entirely, as this app's job tests do — this second call is
+ * what actually performs the claim, preserving the existing contract
+ * that `->handle()` alone drives a Pending task through to completion.
+ */
+trait ClaimsTask
+{
+    /**
+     * Set when this instance lost the claim race, so a `failed()` handler
+     * can no-op instead of treating the loss as a real failure.
+     */
+    public bool $taskClaimLost = false;
+
+    private bool $taskClaimed = false;
+
+    /**
+     * Public so `ClaimsTaskAtomically` can call it from outside the job.
+     */
+    public function claimTask(TaskStatus $from = TaskStatus::Pending): bool
+    {
+        if ($this->taskClaimed) {
+            return true;
+        }
+
+        $claimed = YakTask::where('id', $this->task->id)
+            ->where('status', $from->value)
+            ->update([
+                'status' => TaskStatus::Running->value,
+                'started_at' => now(),
+                'attempts' => DB::raw('attempts + 1'),
+            ]);
+
+        if ($claimed === 0) {
+            $this->taskClaimLost = true;
+
+            return false;
+        }
+
+        $this->task->refresh();
+        $this->taskClaimed = true;
+
+        return true;
+    }
+}

--- a/app/Jobs/Concerns/GuardsTerminalTaskStatus.php
+++ b/app/Jobs/Concerns/GuardsTerminalTaskStatus.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Jobs\Concerns;
+
+use App\Enums\TaskStatus;
+use App\Models\YakTask;
+
+/**
+ * Shared terminal-status guard for job code that writes `status` /
+ * `error_log` directly, outside `HandlesAgentJobFailure::failed()`.
+ *
+ * A task can already be terminal by the time an inline error handler
+ * runs — cancelled between dispatch and pickup, force-failed by a
+ * deploy drain, or finalised by a parallel path — and an unconditional
+ * write would overwrite an accurate message (a drain reason, a
+ * cancellation) with a misleading one (a stream-ended / SIGKILL
+ * artifact of whatever interrupted the run).
+ */
+trait GuardsTerminalTaskStatus
+{
+    /**
+     * @return array<int, TaskStatus>
+     */
+    private function terminalTaskStatuses(): array
+    {
+        return [TaskStatus::Success, TaskStatus::Failed, TaskStatus::Expired, TaskStatus::Cancelled];
+    }
+
+    private function taskIsTerminal(?YakTask $task): bool
+    {
+        return $task !== null && in_array($task->status, $this->terminalTaskStatuses(), true);
+    }
+}

--- a/app/Jobs/Concerns/HandlesAgentJobFailure.php
+++ b/app/Jobs/Concerns/HandlesAgentJobFailure.php
@@ -25,6 +25,15 @@ trait HandlesAgentJobFailure
 {
     public function failed(?Throwable $e): void
     {
+        // Set by ClaimsTaskAtomically when this copy lost the race for its
+        // task. The job never reached handle() or a middleware that could
+        // legitimately fail it, so there is nothing to report — reporting
+        // anyway would mark the winning copy's task Failed and destroy its
+        // live sandbox.
+        if ($this->taskClaimLost ?? false) {
+            return;
+        }
+
         $errorMessage = $e?->getMessage() ?? 'Job failed without exception';
 
         Log::channel('yak')->error(static::class . ' failed', [

--- a/app/Jobs/Concerns/HandlesAgentJobFailure.php
+++ b/app/Jobs/Concerns/HandlesAgentJobFailure.php
@@ -25,14 +25,25 @@ trait HandlesAgentJobFailure
 {
     use GuardsTerminalTaskStatus;
 
+    /**
+     * Set by ClaimsTaskAtomically when this copy lost the race for its task.
+     *
+     * Declared here as well as in ClaimsTask because only the four claiming
+     * jobs use that trait, while RetryYakJob, RunFollowUpJob and
+     * ClarificationReplyJob use this one without it. PHP allows both traits
+     * to declare it as long as the declarations stay identical -- keep them
+     * in sync.
+     */
+    public bool $taskClaimLost = false;
+
     public function failed(?Throwable $e): void
     {
         // Set by ClaimsTaskAtomically when this copy lost the race for its
         // task. The job never reached handle() or a middleware that could
-        // legitimately fail it, so there is nothing to report — reporting
+        // legitimately fail it, so there is nothing to report -- reporting
         // anyway would mark the winning copy's task Failed and destroy its
         // live sandbox.
-        if ($this->taskClaimLost ?? false) {
+        if ($this->taskClaimLost) {
             return;
         }
 

--- a/app/Jobs/Concerns/HandlesAgentJobFailure.php
+++ b/app/Jobs/Concerns/HandlesAgentJobFailure.php
@@ -23,6 +23,8 @@ use Throwable;
  */
 trait HandlesAgentJobFailure
 {
+    use GuardsTerminalTaskStatus;
+
     public function failed(?Throwable $e): void
     {
         // Set by ClaimsTaskAtomically when this copy lost the race for its
@@ -51,11 +53,7 @@ trait HandlesAgentJobFailure
             return;
         }
 
-        $terminal = [TaskStatus::Success, TaskStatus::Failed, TaskStatus::Expired, TaskStatus::Cancelled];
-
-        /** @var TaskStatus $currentStatus */
-        $currentStatus = $task->status;
-        if (! in_array($currentStatus, $terminal, true)) {
+        if (! $this->taskIsTerminal($task)) {
             $task->update([
                 'status' => TaskStatus::Failed,
                 'error_log' => $errorMessage,

--- a/app/Jobs/Middleware/ClaimsTaskAtomically.php
+++ b/app/Jobs/Middleware/ClaimsTaskAtomically.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Jobs\Middleware;
+
+use App\Enums\TaskStatus;
+use App\Models\YakTask;
+use Closure;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Atomically claims a job's task before any downstream middleware or
+ * `handle()` runs, so two copies of the same job — a duplicate dispatch,
+ * a redelivered queue message, a stale copy left behind by a drain
+ * release — can never both proceed.
+ *
+ * The actual claim (a single conditional `UPDATE`, not a fresh Eloquent
+ * read-then-write) lives on the job itself via the `ClaimsTask` trait,
+ * so a job constructed directly and run with `->handle()` — bypassing
+ * this middleware entirely, as this app's job tests do — still claims
+ * its task the same way.
+ *
+ * Must run before `EnsureRepoReady` and `EnsureDailyBudget` — both call
+ * `$job->fail()` on refusal, which would otherwise mark the (actually
+ * Running) task Failed and destroy the winning copy's live sandbox
+ * (`IncusSandboxManager::create()` reclaims a same-named container by
+ * destroying it). It can safely run after `PausesDuringDrain` and
+ * `HoldsForClaudeAuth`, since those only release the job back to the
+ * queue — the task is still Pending when they act, so a later retry of
+ * the same job claims normally instead of finding itself already
+ * "claimed" and deleting itself.
+ */
+class ClaimsTaskAtomically
+{
+    public function __construct(private readonly TaskStatus $from = TaskStatus::Pending) {}
+
+    /**
+     * @param  Closure(object): void  $next
+     */
+    public function handle(object $job, Closure $next): void
+    {
+        $task = $job->task ?? null;
+
+        if (! $task instanceof YakTask || ! method_exists($job, 'claimTask')) {
+            $next($job);
+
+            return;
+        }
+
+        if ($job->claimTask($this->from)) {
+            $next($job);
+
+            return;
+        }
+
+        Log::channel('yak')->info('Task claim lost — another copy already owns it', [
+            'job' => $job::class,
+            'task_id' => $task->id,
+            'expected_status' => $this->from->value,
+        ]);
+
+        if (method_exists($job, 'delete')) {
+            $job->delete();
+        }
+    }
+}

--- a/app/Jobs/Middleware/EnsureRepoReady.php
+++ b/app/Jobs/Middleware/EnsureRepoReady.php
@@ -9,6 +9,7 @@ use App\Jobs\SendNotificationJob;
 use App\Jobs\SetupYakJob;
 use App\Models\Repository;
 use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
 use App\Services\IncusSandboxManager;
 use Closure;
 use Illuminate\Support\Facades\Log;
@@ -137,7 +138,7 @@ class EnsureRepoReady
             'setup_status' => 'pending',
         ]);
 
-        SetupYakJob::dispatch($setupTask);
+        app(AgentJobDispatcher::class)->dispatch($setupTask, SetupYakJob::class);
 
         return $setupTask;
     }

--- a/app/Jobs/ResearchYakJob.php
+++ b/app/Jobs/ResearchYakJob.php
@@ -10,7 +10,9 @@ use App\DataTransferObjects\AgentRunResult;
 use App\Enums\NotificationType;
 use App\Enums\TaskStatus;
 use App\Exceptions\ClaudeAuthException;
+use App\Jobs\Concerns\ClaimsTask;
 use App\Jobs\Concerns\HandlesAgentJobFailure;
+use App\Jobs\Middleware\ClaimsTaskAtomically;
 use App\Jobs\Middleware\EnsureDailyBudget;
 use App\Jobs\Middleware\EnsureRepoReady;
 use App\Jobs\Middleware\HoldsForClaudeAuth;
@@ -25,14 +27,16 @@ use App\Services\TaskMetricsAccumulator;
 use App\Services\YakPersonality;
 use App\Support\TaskContext;
 use App\YakPromptBuilder;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
-class ResearchYakJob implements ShouldQueue
+class ResearchYakJob implements ShouldBeUnique, ShouldQueue
 {
+    use ClaimsTask;
     use HandlesAgentJobFailure;
     use Queueable;
 
@@ -59,6 +63,21 @@ class ResearchYakJob implements ShouldQueue
     }
 
     /**
+     * Dispatch-level dedupe, defence in depth against the atomic claim in
+     * ClaimsTaskAtomically. See RunYakJob::uniqueFor() for the reasoning
+     * on the 900s window.
+     */
+    public function uniqueId(): string
+    {
+        return "task:{$this->task->id}";
+    }
+
+    public function uniqueFor(): int
+    {
+        return 900;
+    }
+
+    /**
      * @return array<int, object>
      */
     public function middleware(): array
@@ -66,6 +85,7 @@ class ResearchYakJob implements ShouldQueue
         return [
             new PausesDuringDrain,
             new HoldsForClaudeAuth,
+            new ClaimsTaskAtomically,
             new EnsureRepoReady,
             new EnsureDailyBudget,
         ];
@@ -85,14 +105,17 @@ class ResearchYakJob implements ShouldQueue
     private function runResearch(AgentRunner $agent): void
     {
         $repository = Repository::where('slug', $this->task->repo)->firstOrFail();
+
+        // Normally already claimed by the ClaimsTaskAtomically middleware
+        // before this method ran; claimTask() is idempotent per instance,
+        // so this is the actual claim only when handle() is called
+        // directly (as in tests), bypassing the middleware pipeline.
+        if (! $this->claimTask()) {
+            return;
+        }
+
         $sandbox = app(IncusSandboxManager::class);
         $containerName = null;
-
-        $this->task->update([
-            'status' => TaskStatus::Running,
-            'started_at' => now(),
-            'attempts' => $this->task->attempts + 1,
-        ]);
 
         TaskLogger::info($this->task, 'Picked up by worker — research');
 

--- a/app/Jobs/ResearchYakJob.php
+++ b/app/Jobs/ResearchYakJob.php
@@ -289,8 +289,9 @@ class ResearchYakJob implements ShouldBeUnique, ShouldQueue
 
     private function handleError(string $errorMessage): void
     {
-        // Don't downgrade a user-cancelled task back to Failed.
-        if ($this->task->fresh()?->status === TaskStatus::Cancelled) {
+        // Don't overwrite a task that's already terminal — see
+        // RunYakJob::handleError() for the full reasoning.
+        if ($this->taskIsTerminal($this->task->fresh())) {
             return;
         }
 

--- a/app/Jobs/RetryYakJob.php
+++ b/app/Jobs/RetryYakJob.php
@@ -324,6 +324,12 @@ class RetryYakJob implements ShouldQueue
 
     private function handleError(string $errorMessage): void
     {
+        // Don't overwrite a task that's already terminal — see
+        // RunYakJob::handleError() for the full reasoning.
+        if ($this->taskIsTerminal($this->task->fresh())) {
+            return;
+        }
+
         $this->task->update([
             'status' => TaskStatus::Failed,
             'error_log' => $errorMessage,

--- a/app/Jobs/RunFollowUpJob.php
+++ b/app/Jobs/RunFollowUpJob.php
@@ -97,6 +97,11 @@ class RunFollowUpJob implements ShouldQueue
         $this->task->update([
             'status' => TaskStatus::Running,
             'started_at' => now(),
+            // Recorded so a drain interruption can tell this apart from a
+            // fresh RunYakJob run — yak:resume-interrupted-tasks must never
+            // resume a follow-up as a plain RunYakJob, which would get a
+            // fresh branch and lose its follow-up context.
+            'claimed_job_class' => self::class,
         ]);
         TaskLogger::info($this->task, 'Picked up by worker — follow-up');
 

--- a/app/Jobs/RunFollowUpJob.php
+++ b/app/Jobs/RunFollowUpJob.php
@@ -189,6 +189,12 @@ class RunFollowUpJob implements ShouldQueue
 
     private function handleError(string $errorMessage): void
     {
+        // Don't overwrite a task that's already terminal — see
+        // RunYakJob::handleError() for the full reasoning.
+        if ($this->taskIsTerminal($this->task->fresh())) {
+            return;
+        }
+
         $this->task->update([
             'status' => TaskStatus::Failed,
             'error_log' => $errorMessage,

--- a/app/Jobs/RunYakJob.php
+++ b/app/Jobs/RunYakJob.php
@@ -9,7 +9,9 @@ use App\Enums\NotificationType;
 use App\Enums\TaskStatus;
 use App\Exceptions\ClaudeAuthException;
 use App\GitOperations;
+use App\Jobs\Concerns\ClaimsTask;
 use App\Jobs\Concerns\HandlesAgentJobFailure;
+use App\Jobs\Middleware\ClaimsTaskAtomically;
 use App\Jobs\Middleware\EnsureDailyBudget;
 use App\Jobs\Middleware\EnsureRepoReady;
 use App\Jobs\Middleware\HoldsForClaudeAuth;
@@ -25,12 +27,14 @@ use App\Services\TaskMetricsAccumulator;
 use App\Services\YakPersonality;
 use App\Support\TaskContext;
 use App\YakPromptBuilder;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 
-class RunYakJob implements ShouldQueue
+class RunYakJob implements ShouldBeUnique, ShouldQueue
 {
+    use ClaimsTask;
     use HandlesAgentJobFailure;
     use Queueable;
 
@@ -63,6 +67,23 @@ class RunYakJob implements ShouldQueue
     }
 
     /**
+     * Dispatch-level dedupe, defence in depth against the atomic claim in
+     * ClaimsTaskAtomically. Longer than change 3's 10-minute lost-pending
+     * sweep threshold so a lock orphaned by a SIGKILLed worker still
+     * clears before the sweep would otherwise re-dispatch into a locked-out
+     * task.
+     */
+    public function uniqueId(): string
+    {
+        return "task:{$this->task->id}";
+    }
+
+    public function uniqueFor(): int
+    {
+        return 900;
+    }
+
+    /**
      * @return array<int, object>
      */
     public function middleware(): array
@@ -70,6 +91,7 @@ class RunYakJob implements ShouldQueue
         return [
             new PausesDuringDrain,
             new HoldsForClaudeAuth,
+            new ClaimsTaskAtomically,
             new EnsureRepoReady,
             new EnsureDailyBudget,
         ];
@@ -107,14 +129,16 @@ class RunYakJob implements ShouldQueue
             return;
         }
 
+        // Normally already claimed by the ClaimsTaskAtomically middleware
+        // before this method ran; claimTask() is idempotent per instance,
+        // so this is the actual claim only when handle() is called
+        // directly (as in tests), bypassing the middleware pipeline.
+        if (! $this->claimTask()) {
+            return;
+        }
+
         $sandbox = app(IncusSandboxManager::class);
         $containerName = null;
-
-        $this->task->update([
-            'status' => TaskStatus::Running,
-            'started_at' => now(),
-            'attempts' => $this->task->attempts + 1,
-        ]);
 
         TaskLogger::info($this->task, 'Picked up by worker', ['attempt' => $this->task->attempts + 1]);
 

--- a/app/Jobs/RunYakJob.php
+++ b/app/Jobs/RunYakJob.php
@@ -118,13 +118,15 @@ class RunYakJob implements ShouldBeUnique, ShouldQueue
                 ? "Could not determine which repo to use. Add `repo: <slug>` to the task description, or mark a repo as default. Active repos: {$activeSlugs}."
                 : "Repository '{$this->task->repo}' not found or not configured in Yak. Active repos: {$activeSlugs}.";
 
-            $this->task->update([
-                'status' => TaskStatus::Failed,
-                'error_log' => $message,
-                'completed_at' => now(),
-            ]);
+            if (! $this->taskIsTerminal($this->task->fresh())) {
+                $this->task->update([
+                    'status' => TaskStatus::Failed,
+                    'error_log' => $message,
+                    'completed_at' => now(),
+                ]);
 
-            TaskLogger::error($this->task, 'Task failed — repo not resolved', ['repo' => $this->task->repo]);
+                TaskLogger::error($this->task, 'Task failed — repo not resolved', ['repo' => $this->task->repo]);
+            }
 
             return;
         }
@@ -423,10 +425,13 @@ class RunYakJob implements ShouldBeUnique, ShouldQueue
 
     private function handleError(string $errorMessage): void
     {
-        // Don't downgrade a user-cancelled task back to Failed — the
-        // cancel action already set a terminal status and destroyed
-        // the sandbox; this error is the expected aftermath.
-        if ($this->task->fresh()?->status === TaskStatus::Cancelled) {
+        // Don't overwrite a task that's already terminal — cancelled
+        // mid-run, force-failed by a deploy drain with an accurate
+        // reason, or finalised by a parallel path. Overwriting it here
+        // would replace that reason with whatever this run's own error
+        // happened to be (often just the abnormal-termination artifact of
+        // whatever interrupted it).
+        if ($this->taskIsTerminal($this->task->fresh())) {
             return;
         }
 

--- a/app/Jobs/RunYakReviewJob.php
+++ b/app/Jobs/RunYakReviewJob.php
@@ -12,6 +12,8 @@ use App\DataTransferObjects\ParsedReview;
 use App\DataTransferObjects\ReviewFinding;
 use App\Enums\TaskStatus;
 use App\Exceptions\ClaudeAuthException;
+use App\Jobs\Concerns\ClaimsTask;
+use App\Jobs\Middleware\ClaimsTaskAtomically;
 use App\Jobs\Middleware\EnsureDailyBudget;
 use App\Jobs\Middleware\EnsureRepoReady;
 use App\Jobs\Middleware\HoldsForClaudeAuth;
@@ -32,12 +34,14 @@ use App\Support\GitHubDiffLines;
 use App\Support\PathMatcher;
 use App\Support\TaskContext;
 use App\YakPromptBuilder;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 
-class RunYakReviewJob implements ShouldQueue
+class RunYakReviewJob implements ShouldBeUnique, ShouldQueue
 {
+    use ClaimsTask;
     use Queueable;
 
     public int $timeout = 3600;
@@ -70,11 +74,32 @@ class RunYakReviewJob implements ShouldQueue
     }
 
     /**
+     * Dispatch-level dedupe, defence in depth against the atomic claim in
+     * ClaimsTaskAtomically. See RunYakJob::uniqueFor() for the reasoning
+     * on the 900s window.
+     */
+    public function uniqueId(): string
+    {
+        return "task:{$this->task->id}";
+    }
+
+    public function uniqueFor(): int
+    {
+        return 900;
+    }
+
+    /**
      * @return array<int, object>
      */
     public function middleware(): array
     {
-        return [new PausesDuringDrain, new HoldsForClaudeAuth, new EnsureRepoReady, new EnsureDailyBudget];
+        return [
+            new PausesDuringDrain,
+            new HoldsForClaudeAuth,
+            new ClaimsTaskAtomically,
+            new EnsureRepoReady,
+            new EnsureDailyBudget,
+        ];
     }
 
     public function handle(AgentRunner $agent): void
@@ -102,15 +127,17 @@ class RunYakReviewJob implements ShouldQueue
             return;
         }
 
+        // Normally already claimed by the ClaimsTaskAtomically middleware
+        // before this method ran; claimTask() is idempotent per instance,
+        // so this is the actual claim only when handle() is called
+        // directly (as in tests), bypassing the middleware pipeline.
+        if (! $this->claimTask()) {
+            return;
+        }
+
         $sandbox = app(IncusSandboxManager::class);
         $containerName = null;
         $metadata = $this->metadata();
-
-        $this->task->update([
-            'status' => TaskStatus::Running,
-            'started_at' => now(),
-            'attempts' => $this->task->attempts + 1,
-        ]);
 
         TaskLogger::info($this->task, 'Picked up review task', ['pr' => $this->task->pr_url]);
 

--- a/app/Jobs/RunYakReviewJob.php
+++ b/app/Jobs/RunYakReviewJob.php
@@ -13,6 +13,7 @@ use App\DataTransferObjects\ReviewFinding;
 use App\Enums\TaskStatus;
 use App\Exceptions\ClaudeAuthException;
 use App\Jobs\Concerns\ClaimsTask;
+use App\Jobs\Concerns\GuardsTerminalTaskStatus;
 use App\Jobs\Middleware\ClaimsTaskAtomically;
 use App\Jobs\Middleware\EnsureDailyBudget;
 use App\Jobs\Middleware\EnsureRepoReady;
@@ -42,6 +43,7 @@ use Illuminate\Support\Facades\Log;
 class RunYakReviewJob implements ShouldBeUnique, ShouldQueue
 {
     use ClaimsTask;
+    use GuardsTerminalTaskStatus;
     use Queueable;
 
     public int $timeout = 3600;
@@ -118,11 +120,13 @@ class RunYakReviewJob implements ShouldBeUnique, ShouldQueue
         $repository = Repository::where('slug', $this->task->repo)->first();
 
         if ($repository === null || ! $repository->pr_review_enabled) {
-            $this->task->update([
-                'status' => TaskStatus::Failed,
-                'error_log' => 'Repository missing or PR review not enabled',
-                'completed_at' => now(),
-            ]);
+            if (! $this->taskIsTerminal($this->task->fresh())) {
+                $this->task->update([
+                    'status' => TaskStatus::Failed,
+                    'error_log' => 'Repository missing or PR review not enabled',
+                    'completed_at' => now(),
+                ]);
+            }
 
             return;
         }
@@ -834,7 +838,9 @@ class RunYakReviewJob implements ShouldBeUnique, ShouldQueue
 
     private function handleError(string $message): void
     {
-        if ($this->task->fresh()?->status === TaskStatus::Cancelled) {
+        // Don't overwrite a task that's already terminal — see
+        // RunYakJob::handleError() for the full reasoning.
+        if ($this->taskIsTerminal($this->task->fresh())) {
             return;
         }
 

--- a/app/Jobs/SetupYakJob.php
+++ b/app/Jobs/SetupYakJob.php
@@ -9,7 +9,9 @@ use App\DataTransferObjects\AgentRunResult;
 use App\Enums\NotificationType;
 use App\Enums\TaskStatus;
 use App\Exceptions\ClaudeAuthException;
+use App\Jobs\Concerns\ClaimsTask;
 use App\Jobs\Concerns\HandlesAgentJobFailure;
+use App\Jobs\Middleware\ClaimsTaskAtomically;
 use App\Jobs\Middleware\EnsureDailyBudget;
 use App\Jobs\Middleware\HoldsForClaudeAuth;
 use App\Jobs\Middleware\PausesDuringDrain;
@@ -22,12 +24,14 @@ use App\Services\TaskLogger;
 use App\Services\TaskMetricsAccumulator;
 use App\Support\TaskContext;
 use App\YakPromptBuilder;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 
-class SetupYakJob implements ShouldQueue
+class SetupYakJob implements ShouldBeUnique, ShouldQueue
 {
+    use ClaimsTask;
     use HandlesAgentJobFailure {
         failed as handleAgentJobFailure;
     }
@@ -76,6 +80,21 @@ class SetupYakJob implements ShouldQueue
     }
 
     /**
+     * Dispatch-level dedupe, defence in depth against the atomic claim in
+     * ClaimsTaskAtomically. See RunYakJob::uniqueFor() for the reasoning
+     * on the 900s window.
+     */
+    public function uniqueId(): string
+    {
+        return "task:{$this->task->id}";
+    }
+
+    public function uniqueFor(): int
+    {
+        return 900;
+    }
+
+    /**
      * @return array<int, object>
      */
     public function middleware(): array
@@ -83,6 +102,7 @@ class SetupYakJob implements ShouldQueue
         return [
             new PausesDuringDrain,
             new HoldsForClaudeAuth,
+            new ClaimsTaskAtomically,
             new EnsureDailyBudget,
         ];
     }
@@ -132,14 +152,16 @@ class SetupYakJob implements ShouldQueue
             return;
         }
 
+        // Normally already claimed by the ClaimsTaskAtomically middleware
+        // before this method ran; claimTask() is idempotent per instance,
+        // so this is the actual claim only when handle() is called
+        // directly (as in tests), bypassing the middleware pipeline.
+        if (! $this->claimTask()) {
+            return;
+        }
+
         $sandbox = app(IncusSandboxManager::class);
         $containerName = null;
-
-        $this->task->update([
-            'status' => TaskStatus::Running,
-            'started_at' => now(),
-            'attempts' => $this->task->attempts + 1,
-        ]);
 
         TaskLogger::info($this->task, 'Picked up by worker — setup');
         $repository->update(['setup_status' => 'running']);

--- a/app/Jobs/SetupYakJob.php
+++ b/app/Jobs/SetupYakJob.php
@@ -324,8 +324,11 @@ class SetupYakJob implements ShouldBeUnique, ShouldQueue
 
     private function handleError(Repository $repository, string $errorMessage): void
     {
-        // Don't downgrade a user-cancelled task back to Failed.
-        if ($this->task->fresh()?->status === TaskStatus::Cancelled) {
+        // Don't overwrite a task that's already terminal — see
+        // RunYakJob::handleError() for the full reasoning. The repository
+        // still needs its setup_status cleared either way, or a later
+        // Setup dispatch would find it wedged at "running".
+        if ($this->taskIsTerminal($this->task->fresh())) {
             $repository->update(['setup_status' => 'failed']);
 
             return;

--- a/app/Models/YakTask.php
+++ b/app/Models/YakTask.php
@@ -27,6 +27,8 @@ use Illuminate\Support\Collection;
  * @property array<int, mixed>|null $screenshots
  * @property CarbonImmutable|null $clarification_expires_at
  * @property CarbonImmutable|null $started_at
+ * @property CarbonImmutable|null $dispatched_at
+ * @property string|null $queue_job_uuid
  * @property CarbonImmutable|null $completed_at
  * @property CarbonImmutable|null $pr_merged_at
  * @property CarbonImmutable|null $pr_closed_at
@@ -69,6 +71,7 @@ class YakTask extends Model
             'screenshots' => 'json',
             'cost_usd' => 'decimal:4',
             'started_at' => 'datetime',
+            'dispatched_at' => 'datetime',
             'completed_at' => 'datetime',
             'pr_merged_at' => 'datetime',
             'pr_closed_at' => 'datetime',

--- a/app/Models/YakTask.php
+++ b/app/Models/YakTask.php
@@ -30,6 +30,9 @@ use Illuminate\Support\Collection;
  * @property CarbonImmutable|null $dispatched_at
  * @property string|null $queue_job_uuid
  * @property CarbonImmutable|null $completed_at
+ * @property CarbonImmutable|null $interrupted_by_deploy_at
+ * @property int $deploy_resume_count
+ * @property string|null $claimed_job_class
  * @property CarbonImmutable|null $pr_merged_at
  * @property CarbonImmutable|null $pr_closed_at
  */
@@ -73,6 +76,7 @@ class YakTask extends Model
             'started_at' => 'datetime',
             'dispatched_at' => 'datetime',
             'completed_at' => 'datetime',
+            'interrupted_by_deploy_at' => 'datetime',
             'pr_merged_at' => 'datetime',
             'pr_closed_at' => 'datetime',
         ];

--- a/app/Services/AgentJobDispatcher.php
+++ b/app/Services/AgentJobDispatcher.php
@@ -60,6 +60,21 @@ class AgentJobDispatcher
     ];
 
     /**
+     * The four claiming job classes this dispatcher will send, as a plain
+     * list. Single source of truth for anything that needs to check
+     * whether a `claimed_job_class` value can be faithfully re-dispatched —
+     * currently DrainForDeployCommand (deciding what copy to use in its
+     * straggler message) and yak:resume-interrupted-tasks (deciding what to
+     * resume).
+     *
+     * @return array<int, class-string<RunYakJob|ResearchYakJob|RunYakReviewJob|SetupYakJob>>
+     */
+    public static function claimableJobClasses(): array
+    {
+        return array_keys(self::ALLOWED_JOBS);
+    }
+
+    /**
      * Tracks which event dispatcher instances we've already attached the
      * uuid-capturing listener to. Keyed by instance (not a plain bool)
      * because the application — and with it the event dispatcher — is

--- a/app/Services/AgentJobDispatcher.php
+++ b/app/Services/AgentJobDispatcher.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\ResearchYakJob;
+use App\Jobs\RunYakJob;
+use App\Jobs\RunYakReviewJob;
+use App\Jobs\SetupYakJob;
+use App\Models\YakTask;
+use Illuminate\Queue\Events\JobQueued;
+use Illuminate\Support\Facades\Event;
+use InvalidArgumentException;
+use SplObjectStorage;
+
+/**
+ * Single choke point for dispatching the four "claiming" agent jobs —
+ * RunYakJob, ResearchYakJob, RunYakReviewJob, SetupYakJob — the only jobs
+ * that atomically claim a Pending task via App\Jobs\Concerns\ClaimsTask
+ * (change 0). That atomicity is what makes it safe for
+ * `yak:reap-lost-pending` to re-dispatch one of these against a task that
+ * might still be legitimately queued or running: a duplicate copy loses
+ * the claim race and deletes itself instead of stomping on a live run.
+ *
+ * Owns both the dispatch AND the `dispatched_at`/`queue_job_uuid`
+ * bookkeeping the sweep depends on, so the two can never drift apart —
+ * there is no code path that stamps one without the other.
+ *
+ * RetryYakJob, RunFollowUpJob and ClarificationReplyJob deliberately do
+ * NOT go through this helper, and must never be added to it:
+ *   - RetryYakJob picks up a Retrying task, not a Pending one, and has no
+ *     atomic claim at all.
+ *   - RunFollowUpJob picks up a Pending follow-up task (created by
+ *     FollowUpTaskFactory) but — unlike the four jobs above — does not use
+ *     ClaimsTask either; it sets status => Running with a plain update().
+ *     A follow-up task therefore looks, by mode alone, identical to a
+ *     fresh RunYakJob/ResearchYakJob task. Routing it through here would
+ *     let the sweep "self-heal" it by dispatching the wrong job (a fresh
+ *     RunYakJob instead of a resumed follow-up, discarding branch/session
+ *     context) with no claim to stop a genuine duplicate run.
+ *   - ClarificationReplyJob resumes an AwaitingClarification task and
+ *     carries the user's reply as a constructor argument that isn't
+ *     stored on the task row — a re-dispatch from the sweep couldn't
+ *     reconstruct it.
+ *
+ * Leaving their tasks' `dispatched_at` untouched (permanently null, since
+ * they're never stamped) keeps them permanently outside
+ * `yak:reap-lost-pending`'s query — see that command for the read side of
+ * this contract.
+ */
+class AgentJobDispatcher
+{
+    /**
+     * @var array<class-string, true>
+     */
+    private const ALLOWED_JOBS = [
+        RunYakJob::class => true,
+        ResearchYakJob::class => true,
+        RunYakReviewJob::class => true,
+        SetupYakJob::class => true,
+    ];
+
+    /**
+     * Tracks which event dispatcher instances we've already attached the
+     * uuid-capturing listener to. Keyed by instance (not a plain bool)
+     * because the application — and with it the event dispatcher — is
+     * rebuilt between tests; a plain "have we listened yet" flag would
+     * survive that rebuild via this class's own static state and then
+     * skip registering on the new dispatcher, silently breaking uuid
+     * capture from the second test onward. In a real queue worker the
+     * dispatcher instance is stable for the process's lifetime, so this
+     * still registers exactly once there.
+     *
+     * @var SplObjectStorage<object, bool>|null
+     */
+    private static ?SplObjectStorage $listeningOn = null;
+
+    private static ?string $lastQueuedUuid = null;
+
+    /**
+     * @param  class-string<RunYakJob|ResearchYakJob|RunYakReviewJob|SetupYakJob>  $jobClass
+     */
+    public function dispatch(YakTask $task, string $jobClass): void
+    {
+        $this->send($task, $jobClass, sync: false);
+    }
+
+    /**
+     * Runs the job inline in the current process instead of queueing it —
+     * used by `yak:run --sync`. By the time this returns the task has
+     * already moved past Pending (claimed, and likely already terminal),
+     * so a stale `dispatched_at`/null `queue_job_uuid` afterwards can't
+     * make the sweep re-dispatch it.
+     *
+     * @param  class-string<RunYakJob|ResearchYakJob|RunYakReviewJob|SetupYakJob>  $jobClass
+     */
+    public function dispatchSync(YakTask $task, string $jobClass): void
+    {
+        $this->send($task, $jobClass, sync: true);
+    }
+
+    /**
+     * @param  class-string<RunYakJob|ResearchYakJob|RunYakReviewJob|SetupYakJob>  $jobClass
+     */
+    private function send(YakTask $task, string $jobClass, bool $sync): void
+    {
+        if (! isset(self::ALLOWED_JOBS[$jobClass])) {
+            throw new InvalidArgumentException("AgentJobDispatcher does not dispatch {$jobClass}.");
+        }
+
+        self::ensureListening();
+        self::$lastQueuedUuid = null;
+
+        if ($sync) {
+            $jobClass::dispatchSync($task);
+        } else {
+            // Not assigned to a variable so the returned PendingDispatch is
+            // destroyed — and therefore actually pushed — at the end of
+            // this statement, before queue_job_uuid is read below.
+            $jobClass::dispatch($task);
+        }
+
+        $task->update([
+            'dispatched_at' => now(),
+            'queue_job_uuid' => self::$lastQueuedUuid,
+        ]);
+    }
+
+    /**
+     * Registers a single process-lifetime listener that records the uuid
+     * of the most recently queued job payload. Kept as one static listener
+     * rather than added/removed per dispatch() call so a long-running
+     * queue worker doesn't accumulate listeners over its lifetime.
+     *
+     * A dispatch that never actually reaches the queue — a ShouldBeUnique
+     * lock still held by another copy, or the `sync` queue driver — leaves
+     * no JobQueued event to capture, so queue_job_uuid falls back to null
+     * and only dispatched_at is stamped. That's still a meaningful
+     * self-heal signal: either the task is genuinely still locked (safe —
+     * change 0's claim decides what happens next) or it already ran.
+     */
+    private static function ensureListening(): void
+    {
+        $dispatcher = app('events');
+
+        self::$listeningOn ??= new SplObjectStorage;
+
+        if (self::$listeningOn->contains($dispatcher)) {
+            return;
+        }
+
+        self::$listeningOn->attach($dispatcher);
+
+        Event::listen(JobQueued::class, function (JobQueued $event): void {
+            self::$lastQueuedUuid = $event->payload()['uuid'] ?? null;
+        });
+    }
+}

--- a/app/Services/RepoClarificationResolver.php
+++ b/app/Services/RepoClarificationResolver.php
@@ -105,12 +105,14 @@ class RepoClarificationResolver
 
         TaskLogger::info($task, "Repo resolved to {$repository->slug}");
 
+        $dispatcher = app(AgentJobDispatcher::class);
+
         if ($mode === TaskMode::Research) {
-            ResearchYakJob::dispatch($task);
+            $dispatcher->dispatch($task, ResearchYakJob::class);
 
             return;
         }
 
-        RunYakJob::dispatch($task);
+        $dispatcher->dispatch($task, RunYakJob::class);
     }
 }

--- a/database/migrations/2026_09_03_115155_add_dispatched_at_and_queue_job_uuid_to_tasks_table.php
+++ b/database/migrations/2026_09_03_115155_add_dispatched_at_and_queue_job_uuid_to_tasks_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            // Set by App\Services\AgentJobDispatcher on every agent-job
+            // dispatch, alongside queue_job_uuid, so the two columns can
+            // never drift. yak:reap-lost-pending uses dispatched_at as the
+            // fallback signal for "how long has this been queued" when the
+            // queue_job_uuid can't be resolved to a live job.
+            $table->timestamp('dispatched_at')->nullable()->after('started_at');
+
+            // The queue payload's uuid, captured at dispatch time. Survives
+            // release() and is an indexed column on failed_jobs, so
+            // yak:reap-lost-pending can check whether the job is still
+            // queued, reserved, or failed before falling back to elapsed
+            // time.
+            $table->string('queue_job_uuid')->nullable()->after('dispatched_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn(['dispatched_at', 'queue_job_uuid']);
+        });
+    }
+};

--- a/database/migrations/2026_09_03_120000_add_deploy_resume_columns_to_tasks_table.php
+++ b/database/migrations/2026_09_03_120000_add_deploy_resume_columns_to_tasks_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            // Set by DrainForDeployCommand alongside the existing Failed
+            // status/message when a straggler is force-failed. Status stays
+            // Failed so the audit trail and channel notification are
+            // unchanged; this column is what tells yak:resume-interrupted-tasks
+            // the failure was infrastructure, not the task's own merits.
+            $table->timestamp('interrupted_by_deploy_at')->nullable()->after('completed_at');
+
+            // Bounds how many times yak:resume-interrupted-tasks will
+            // requeue the same task, so a task that keeps getting caught by
+            // deploys doesn't retry forever.
+            $table->unsignedInteger('deploy_resume_count')->default(0)->after('interrupted_by_deploy_at');
+
+            // The job class that actually claimed the task, set by
+            // App\Jobs\Concerns\ClaimsTask::claimTask() at claim time. Resume
+            // must re-dispatch the class the task was really running, not
+            // guess from `mode` — mode alone can't distinguish, e.g., a
+            // follow-up (RunFollowUpJob) from a fresh RunYakJob.
+            $table->string('claimed_job_class')->nullable()->after('deploy_resume_count');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn(['interrupted_by_deploy_at', 'deploy_resume_count', 'claimed_job_class']);
+        });
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -18,6 +18,7 @@ Schedule::command('yak:cleanup')->daily();
 Schedule::command('yak:video:prune')->daily();
 Schedule::command('yak:cleanup-sandboxes')->hourly();
 Schedule::command('yak:reap-orphaned-tasks')->everyFiveMinutes()->withoutOverlapping();
+Schedule::command('yak:reap-lost-pending')->everyFiveMinutes()->withoutOverlapping();
 Schedule::command('yak:timeout-ci')->everyFifteenMinutes();
 Schedule::command('yak:healthcheck')->everyFifteenMinutes();
 Schedule::command('yak:scan-ci')->everyTwoHours();

--- a/tests/Feature/AgentJobDispatchArchTest.php
+++ b/tests/Feature/AgentJobDispatchArchTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Guards App\Services\AgentJobDispatcher's role as the single choke point
+ * for dispatching the four "claiming" agent jobs — RunYakJob, ResearchYakJob,
+ * RunYakReviewJob, SetupYakJob. Every dispatch of one of these must go
+ * through the helper so `dispatched_at`/`queue_job_uuid` can never drift
+ * from what was actually queued (see AgentJobDispatcher's docblock).
+ *
+ * A plain source scan rather than pest-plugin-arch's dependency matchers:
+ * arch()'s `toOnlyBeUsedIn()` treats any reference (a `use` import, a type
+ * hint, a `instanceof` check) as "used", which is far broader than what
+ * this test actually needs to catch — a direct `::dispatch(`/
+ * `::dispatchSync(` call that bypasses the helper.
+ */
+test('the claiming agent jobs are only dispatched through AgentJobDispatcher', function () {
+    $claimingJobs = ['RunYakJob', 'ResearchYakJob', 'RunYakReviewJob', 'SetupYakJob'];
+
+    $pattern = '/\b(' . implode('|', $claimingJobs) . ')::dispatch(Sync|If|Unless|AfterResponse)?\s*\(/';
+
+    $offenders = [];
+
+    $files = Finder::create()
+        ->in(app_path())
+        ->name('*.php')
+        // The helper itself is the one file allowed to call ::dispatch()
+        // directly on these classes.
+        ->notPath('Services/AgentJobDispatcher.php')
+        ->files();
+
+    foreach ($files as $file) {
+        $contents = $file->getContents();
+
+        if (preg_match($pattern, $contents, $matches)) {
+            $offenders[] = $file->getRelativePathname() . ' (' . $matches[0] . ')';
+        }
+    }
+
+    expect($offenders)->toBe([], 'Direct ::dispatch() call(s) on a claiming agent job outside AgentJobDispatcher: ' . implode(', ', $offenders));
+});

--- a/tests/Feature/AgentJobDispatcherTest.php
+++ b/tests/Feature/AgentJobDispatcherTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Jobs\ResearchYakJob;
+use App\Jobs\RetryYakJob;
+use App\Jobs\RunYakJob;
+use App\Jobs\RunYakReviewJob;
+use App\Jobs\SetupYakJob;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+
+test('dispatch stamps dispatched_at and refuses a job class it does not allow', function () {
+    Queue::fake();
+
+    $repository = Repository::factory()->create(['slug' => 'ajd-repo']);
+    $task = YakTask::factory()->pending()->create(['repo' => $repository->slug]);
+
+    app(AgentJobDispatcher::class)->dispatch($task, RunYakJob::class);
+
+    $task->refresh();
+    expect($task->dispatched_at)->not->toBeNull();
+
+    Queue::assertPushed(RunYakJob::class, fn ($job) => $job->task->id === $task->id);
+});
+
+test('dispatch rejects a job class outside the allowed four', function () {
+    $task = YakTask::factory()->pending()->create();
+
+    app(AgentJobDispatcher::class)->dispatch($task, RetryYakJob::class);
+})->throws(InvalidArgumentException::class);
+
+test('dispatch captures the queue job uuid when the job actually reaches the queue', function () {
+    config(['queue.default' => 'database']);
+
+    $repository = Repository::factory()->create(['slug' => 'ajd-uuid-repo']);
+    $task = YakTask::factory()->pending()->create(['repo' => $repository->slug]);
+
+    app(AgentJobDispatcher::class)->dispatch($task, RunYakJob::class);
+
+    $task->refresh();
+    expect($task->dispatched_at)->not->toBeNull()
+        ->and($task->queue_job_uuid)->not->toBeNull();
+
+    $stillQueued = DB::table('jobs')
+        ->where('payload', 'like', '%"uuid":"' . $task->queue_job_uuid . '"%')
+        ->exists();
+
+    expect($stillQueued)->toBeTrue();
+});
+
+dataset('claiming job classes', [
+    RunYakJob::class,
+    ResearchYakJob::class,
+    RunYakReviewJob::class,
+    SetupYakJob::class,
+]);
+
+test('dispatch accepts every claiming job class', function (string $jobClass) {
+    Queue::fake();
+
+    $attributes = ['slug' => 'ajd-' . str(str($jobClass)->afterLast('\\'))->kebab()];
+    if ($jobClass === RunYakReviewJob::class) {
+        $attributes['pr_review_enabled'] = true;
+    }
+    $repository = Repository::factory()->create($attributes);
+
+    $task = YakTask::factory()->pending()->create(['repo' => $repository->slug]);
+
+    app(AgentJobDispatcher::class)->dispatch($task, $jobClass);
+
+    Queue::assertPushed($jobClass, fn ($job) => $job->task->id === $task->id);
+})->with('claiming job classes');

--- a/tests/Feature/AtomicTaskClaimTest.php
+++ b/tests/Feature/AtomicTaskClaimTest.php
@@ -1,0 +1,194 @@
+<?php
+
+use App\Contracts\AgentRunner;
+use App\DataTransferObjects\AgentRunResult;
+use App\Enums\TaskStatus;
+use App\Jobs\ResearchYakJob;
+use App\Jobs\RunYakJob;
+use App\Jobs\RunYakReviewJob;
+use App\Jobs\SetupYakJob;
+use App\Models\DailyCost;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\IncusSandboxManager;
+use Illuminate\Support\Facades\Process;
+use Tests\Support\FakeAgentRunner;
+use Tests\Support\FakeSandboxManager;
+
+/**
+ * Change 0 (atomic task claim) exercised across all four claiming job
+ * classes: RunYakJob, ResearchYakJob, RunYakReviewJob, SetupYakJob.
+ *
+ * Every other job test in this suite calls ->handle() directly, which
+ * bypasses the queue's middleware pipeline entirely — that's fine for
+ * testing handle()'s own logic (claimTask() is idempotent and performs
+ * the claim itself when no middleware got there first), but it means the
+ * "a losing copy never reaches EnsureRepoReady/EnsureDailyBudget" — the
+ * actual point of Change 0 — has to be proven by running the real
+ * middleware() stack in order, the way CallQueuedHandler would.
+ */
+function runJobMiddlewarePipeline(array $middleware, object $job, Closure $final): void
+{
+    $next = $final;
+
+    foreach (array_reverse($middleware) as $mw) {
+        $next = fn (object $job) => $mw->handle($job, $next);
+    }
+
+    $next($job);
+}
+
+dataset('claiming job classes', [
+    'RunYakJob' => [RunYakJob::class, 'atomic-claim-run'],
+    'ResearchYakJob' => [ResearchYakJob::class, 'atomic-claim-research'],
+    'RunYakReviewJob' => [RunYakReviewJob::class, 'atomic-claim-review'],
+    'SetupYakJob' => [SetupYakJob::class, 'atomic-claim-setup'],
+]);
+
+/**
+ * @param  class-string  $jobClass
+ */
+function makeReadyRepository(string $jobClass, string $slug): Repository
+{
+    $attributes = ['slug' => $slug, 'path' => "/home/yak/repos/{$slug}"];
+
+    if ($jobClass === RunYakReviewJob::class) {
+        $attributes['pr_review_enabled'] = true;
+    }
+
+    return Repository::factory()->create($attributes);
+}
+
+test('two concurrent copies of one task produce exactly one claim', function (string $jobClass, string $slug) {
+    $repository = makeReadyRepository($jobClass, $slug);
+    $task = YakTask::factory()->pending()->create(['repo' => $repository->slug, 'attempts' => 0]);
+
+    $copyA = new $jobClass($task);
+    $copyB = new $jobClass($task->fresh());
+
+    expect($copyA->claimTask())->toBeTrue()
+        ->and($copyB->claimTask())->toBeFalse()
+        ->and($copyB->taskClaimLost)->toBeTrue();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Running)
+        ->and($task->attempts)->toBe(1);
+})->with('claiming job classes');
+
+test('a task already Running is not re-claimed', function (string $jobClass, string $slug) {
+    $repository = makeReadyRepository($jobClass, $slug);
+    $task = YakTask::factory()->running()->create(['repo' => $repository->slug, 'attempts' => 1]);
+
+    $job = new $jobClass($task);
+
+    expect($job->claimTask())->toBeFalse();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Running)
+        ->and($task->attempts)->toBe(1);
+})->with('claiming job classes');
+
+test('the losing copy never reaches EnsureDailyBudget and does not mark the task Failed', function (string $jobClass, string $slug) {
+    Process::fake(['*' => Process::result('')]);
+    config()->set('yak.daily_budget_usd', 10.0);
+    DailyCost::factory()->create(['date' => now()->toDateString(), 'total_usd' => 999.0]);
+
+    $repository = makeReadyRepository($jobClass, $slug . '-budget');
+    $task = YakTask::factory()->pending()->create(['repo' => $repository->slug]);
+
+    $winner = new $jobClass($task);
+    expect($winner->claimTask())->toBeTrue();
+
+    $loser = new $jobClass($task->fresh());
+    $reachedHandle = false;
+
+    runJobMiddlewarePipeline($loser->middleware(), $loser, function () use (&$reachedHandle) {
+        $reachedHandle = true;
+    });
+
+    $task->refresh();
+
+    expect($reachedHandle)->toBeFalse()
+        ->and($task->status)->toBe(TaskStatus::Running)
+        ->and($task->error_log)->toBeNull()
+        ->and($task->completed_at)->toBeNull();
+})->with('claiming job classes');
+
+dataset('repo-gated job classes', [
+    'RunYakJob' => [RunYakJob::class, 'atomic-claim-repogate-run'],
+    'ResearchYakJob' => [ResearchYakJob::class, 'atomic-claim-repogate-research'],
+    'RunYakReviewJob' => [RunYakReviewJob::class, 'atomic-claim-repogate-review'],
+]);
+
+test('the losing copy never reaches EnsureRepoReady and does not mark the task Failed', function (string $jobClass, string $slug) {
+    Process::fake(['*' => Process::result('')]);
+
+    // Not ready — no sandbox snapshot — is exactly what EnsureRepoReady
+    // would normally refuse the second copy for. Prove it never gets the
+    // chance: the claim middleware deletes the loser first.
+    $attributes = ['slug' => $slug, 'sandbox_snapshot' => null];
+    if ($jobClass === RunYakReviewJob::class) {
+        $attributes['pr_review_enabled'] = true;
+    }
+    $repository = Repository::factory()->create($attributes);
+
+    $task = YakTask::factory()->pending()->create(['repo' => $repository->slug]);
+
+    $winner = new $jobClass($task);
+    expect($winner->claimTask())->toBeTrue();
+
+    $loser = new $jobClass($task->fresh());
+    $reachedHandle = false;
+
+    runJobMiddlewarePipeline($loser->middleware(), $loser, function () use (&$reachedHandle) {
+        $reachedHandle = true;
+    });
+
+    $task->refresh();
+
+    expect($reachedHandle)->toBeFalse()
+        ->and($task->status)->toBe(TaskStatus::Running)
+        ->and($task->error_log)->toBeNull()
+        ->and($task->completed_at)->toBeNull();
+})->with('repo-gated job classes');
+
+test('a losing copy does not destroy the winning copy\'s sandbox', function () {
+    $fake = (new FakeAgentRunner)->queueResult(new AgentRunResult(
+        sessionId: 'sess_race',
+        resultSummary: 'Done',
+        costUsd: 0.0,
+        numTurns: 1,
+        durationMs: 1000,
+        isError: false,
+        clarificationNeeded: false,
+        clarificationOptions: [],
+        rawOutput: '{}',
+    ));
+    $this->app->instance(AgentRunner::class, $fake);
+
+    $fakeSandbox = new FakeSandboxManager;
+    $this->app->instance(IncusSandboxManager::class, $fakeSandbox);
+    Process::fake(['*' => Process::result('')]);
+
+    $repository = Repository::factory()->create(['slug' => 'race-repo', 'path' => '/home/yak/repos/race-repo']);
+    $task = YakTask::factory()->pending()->create(['repo' => 'race-repo']);
+
+    // Winner claims and runs to completion — creating and destroying its
+    // own sandbox in the process.
+    $winner = new RunYakJob($task);
+    $winner->handle($fake);
+
+    expect($fakeSandbox->createdContainers)->toHaveCount(1)
+        ->and($fakeSandbox->destroyedContainers)->toHaveCount(1);
+
+    // Loser dispatched against the same task after the winner already
+    // finished (still the dangerous case: a duplicate that shows up late
+    // must not touch the sandbox at all, let alone destroy it).
+    $loser = new RunYakJob($task->fresh());
+    $loser->handle($fake);
+
+    // No new sandbox activity from the loser.
+    expect($fakeSandbox->createdContainers)->toHaveCount(1)
+        ->and($fakeSandbox->destroyedContainers)->toHaveCount(1)
+        ->and($loser->taskClaimLost)->toBeTrue();
+});

--- a/tests/Feature/Commands/DrainForDeployCommandTest.php
+++ b/tests/Feature/Commands/DrainForDeployCommandTest.php
@@ -4,10 +4,12 @@ use App\Enums\NotificationType;
 use App\Enums\TaskStatus;
 use App\Jobs\Middleware\PausesDuringDrain;
 use App\Jobs\SendNotificationJob;
+use App\Models\TaskLog;
 use App\Models\YakTask;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Sleep;
 
 beforeEach(function () {
     Cache::forget(PausesDuringDrain::CACHE_KEY);
@@ -81,4 +83,106 @@ test('ignores AwaitingCi and AwaitingClarification tasks', function () {
         ->assertSuccessful();
 
     expect(YakTask::where('status', TaskStatus::Failed)->count())->toBe(0);
+});
+
+test('covers a Retrying task, not just Running', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->retrying()->create([
+        'source' => 'slack',
+        'slack_channel' => 'C1',
+        'slack_thread_ts' => '1.1',
+    ]);
+
+    $this->artisan('yak:drain', ['--wait' => 0, '--poll' => 1])
+        ->assertSuccessful();
+
+    expect($task->fresh()->status)->toBe(TaskStatus::Failed);
+});
+
+test('waits while a task keeps logging, then completes once it finishes', function () {
+    Queue::fake();
+    Sleep::fake(syncWithCarbon: true);
+
+    $task = YakTask::factory()->running()->create();
+
+    TaskLog::factory()->create([
+        'yak_task_id' => $task->id,
+        'created_at' => now(),
+    ]);
+
+    // On each fake sleep, refresh the task's liveness: keep it logging
+    // for the first couple of polls, then let it finish.
+    $polls = 0;
+    Sleep::whenFakingSleep(function () use ($task, &$polls) {
+        $polls++;
+
+        if ($polls < 3) {
+            TaskLog::factory()->create([
+                'yak_task_id' => $task->id,
+                'created_at' => now(),
+            ]);
+        } else {
+            $task->update(['status' => TaskStatus::Success, 'completed_at' => now()]);
+        }
+    });
+
+    $this->artisan('yak:drain', ['--wait' => 60, '--max-wait' => 2700, '--poll' => 60])
+        ->assertSuccessful();
+
+    expect($task->fresh()->status)->toBe(TaskStatus::Success);
+    // It kept waiting instead of force-failing at the first opportunity.
+    Sleep::assertSleptTimes(3);
+});
+
+test('force-fails a silent task only once --wait has elapsed, not immediately', function () {
+    Queue::fake();
+    Sleep::fake();
+
+    $task = YakTask::factory()->running()->create();
+
+    $this->artisan('yak:drain', ['--wait' => 10, '--max-wait' => 2700, '--poll' => 5])
+        ->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed)
+        ->and($task->error_log)->toContain('Deploy interrupted the task after 10s with no activity');
+
+    // Two 5s polls elapsed (0s, 5s) before the task was declared past its
+    // wait budget at 10s — it wasn't failed on the very first check.
+    Sleep::assertSleptTimes(2);
+});
+
+test('force-fails everything at --max-wait regardless of liveness', function () {
+    Queue::fake();
+    Sleep::fake();
+
+    $task = YakTask::factory()->running()->create();
+
+    TaskLog::factory()->create([
+        'yak_task_id' => $task->id,
+        'created_at' => now(),
+    ]);
+
+    $this->artisan('yak:drain', ['--wait' => 999999, '--max-wait' => 0, '--poll' => 5])
+        ->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed)
+        ->and($task->error_log)->toContain('drain ceiling');
+});
+
+test('derives the cache flag TTL from --max-wait so it outlasts the drain', function () {
+    Queue::fake();
+
+    $this->artisan('yak:drain', ['--wait' => 0, '--max-wait' => 2700, '--poll' => 1])
+        ->assertSuccessful();
+
+    // TTL is max-wait + 600 = 3300s. Just before that, the flag holds;
+    // just after, it's gone.
+    $this->travel(3299)->seconds();
+    expect(Cache::has(PausesDuringDrain::CACHE_KEY))->toBeTrue();
+
+    $this->travel(2)->seconds();
+    expect(Cache::has(PausesDuringDrain::CACHE_KEY))->toBeFalse();
 });

--- a/tests/Feature/Commands/DrainForDeployCommandTest.php
+++ b/tests/Feature/Commands/DrainForDeployCommandTest.php
@@ -3,6 +3,8 @@
 use App\Enums\NotificationType;
 use App\Enums\TaskStatus;
 use App\Jobs\Middleware\PausesDuringDrain;
+use App\Jobs\RunFollowUpJob;
+use App\Jobs\RunYakJob;
 use App\Jobs\SendNotificationJob;
 use App\Models\TaskLog;
 use App\Models\YakTask;
@@ -58,6 +60,60 @@ test('forces stragglers to Failed after the wait budget is exhausted', function 
         SendNotificationJob::class,
         fn ($job) => $job->task->id === $task->id && $job->type === NotificationType::Error,
     );
+});
+
+test('marks a straggler with interrupted_by_deploy_at', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->running()->create();
+
+    $this->artisan('yak:drain', ['--wait' => 0, '--poll' => 1])
+        ->assertSuccessful();
+
+    expect($task->fresh()->interrupted_by_deploy_at)->not->toBeNull();
+});
+
+test('promises automatic resume for a task claimed by one of the four resumable jobs', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->running()->create([
+        'claimed_job_class' => RunYakJob::class,
+    ]);
+
+    $this->artisan('yak:drain', ['--wait' => 0, '--poll' => 1])
+        ->assertSuccessful();
+
+    expect($task->fresh()->error_log)->toContain('resume automatically');
+});
+
+test('tells the operator to retry manually when the straggler is not resumable', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->running()->create([
+        'claimed_job_class' => RunFollowUpJob::class,
+    ]);
+
+    $this->artisan('yak:drain', ['--wait' => 0, '--poll' => 1])
+        ->assertSuccessful();
+
+    expect($task->fresh()->error_log)->toContain('manual retry');
+});
+
+test('a Retrying straggler always gets a manual-retry message, even with a resumable claimed_job_class', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->retrying()->create([
+        // claimed_job_class reflects the original RunYakJob claim from
+        // before the task reached AwaitingCi — RetryYakJob never touches
+        // it — so status, not claimed_job_class, must be what excludes a
+        // Retrying task from the resumable message.
+        'claimed_job_class' => RunYakJob::class,
+    ]);
+
+    $this->artisan('yak:drain', ['--wait' => 0, '--poll' => 1])
+        ->assertSuccessful();
+
+    expect($task->fresh()->error_log)->toContain('manual retry');
 });
 
 test('does not notify system-source stragglers', function () {

--- a/tests/Feature/Commands/ResumeInterruptedTasksCommandTest.php
+++ b/tests/Feature/Commands/ResumeInterruptedTasksCommandTest.php
@@ -1,0 +1,218 @@
+<?php
+
+use App\Enums\NotificationType;
+use App\Enums\TaskStatus;
+use App\Jobs\ClarificationReplyJob;
+use App\Jobs\Middleware\PausesDuringDrain;
+use App\Jobs\ResearchYakJob;
+use App\Jobs\RetryYakJob;
+use App\Jobs\RunFollowUpJob;
+use App\Jobs\RunYakJob;
+use App\Jobs\SendNotificationJob;
+use App\Models\Repository;
+use App\Models\YakTask;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    Cache::forget(PausesDuringDrain::CACHE_KEY);
+});
+
+test('requeues a marked task and clears the marker, error_log and completed_at', function () {
+    Queue::fake();
+
+    $repository = Repository::factory()->create(['slug' => 'resume-repo']);
+    $task = YakTask::factory()->failed()->create([
+        'repo' => $repository->slug,
+        'attempts' => 1,
+        'claimed_job_class' => RunYakJob::class,
+        'interrupted_by_deploy_at' => now(),
+        'error_log' => 'Deploy interrupted the task after 300s with no activity.',
+        'source' => 'slack',
+        'slack_channel' => 'C1',
+        'slack_thread_ts' => '1.1',
+    ]);
+
+    $this->artisan('yak:resume-interrupted-tasks')->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Pending)
+        ->and($task->interrupted_by_deploy_at)->toBeNull()
+        ->and($task->error_log)->toBeNull()
+        ->and($task->completed_at)->toBeNull()
+        ->and($task->deploy_resume_count)->toBe(1);
+
+    Queue::assertPushed(RunYakJob::class, fn ($job) => $job->task->id === $task->id);
+    Queue::assertPushed(
+        SendNotificationJob::class,
+        fn ($job) => $job->task->id === $task->id && $job->type === NotificationType::Retry,
+    );
+});
+
+test('dispatches the original job class, not RunYakJob by default', function () {
+    Queue::fake();
+
+    $repository = Repository::factory()->create(['slug' => 'resume-research-repo']);
+    $task = YakTask::factory()->failed()->create([
+        'repo' => $repository->slug,
+        'mode' => 'fix',
+        'attempts' => 1,
+        'claimed_job_class' => ResearchYakJob::class,
+        'interrupted_by_deploy_at' => now(),
+    ]);
+
+    $this->artisan('yak:resume-interrupted-tasks')->assertSuccessful();
+
+    Queue::assertPushed(ResearchYakJob::class, fn ($job) => $job->task->id === $task->id);
+    Queue::assertNotPushed(RunYakJob::class);
+});
+
+test('does not consume tasks.attempts and preserves the full CI-retry budget', function () {
+    Queue::fake();
+
+    $repository = Repository::factory()->create(['slug' => 'resume-attempts-repo']);
+    $task = YakTask::factory()->failed()->create([
+        'repo' => $repository->slug,
+        'attempts' => 1,
+        'claimed_job_class' => RunYakJob::class,
+        'interrupted_by_deploy_at' => now(),
+    ]);
+
+    $this->artisan('yak:resume-interrupted-tasks')->assertSuccessful();
+
+    $task->refresh();
+    // Resume decrements by one before re-dispatching so that ClaimsTask's
+    // unconditional claim increment nets back to the pre-interruption
+    // value.
+    expect($task->attempts)->toBe(0);
+
+    // Simulate the claim a re-dispatched RunYakJob would perform.
+    YakTask::where('id', $task->id)->update([
+        'status' => TaskStatus::Running->value,
+        'attempts' => DB::raw('attempts + 1'),
+    ]);
+
+    $task->refresh();
+    expect($task->attempts)->toBe(1)
+        ->and($task->attempts)->toBeLessThan((int) config('yak.max_attempts'));
+});
+
+test('does not resume a follow-up task', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->failed()->create([
+        'claimed_job_class' => RunFollowUpJob::class,
+        'interrupted_by_deploy_at' => now(),
+        'error_log' => 'Deploy interrupted the task after 300s with no activity. It needs a manual retry once the deploy is done.',
+    ]);
+
+    $this->artisan('yak:resume-interrupted-tasks')->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed)
+        ->and($task->interrupted_by_deploy_at)->toBeNull()
+        ->and($task->error_log)->toContain('manual retry');
+
+    Queue::assertNothingPushed();
+});
+
+test('does not resume a clarification reply task', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->failed()->create([
+        'claimed_job_class' => ClarificationReplyJob::class,
+        'interrupted_by_deploy_at' => now(),
+    ]);
+
+    $this->artisan('yak:resume-interrupted-tasks')->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed)
+        ->and($task->interrupted_by_deploy_at)->toBeNull();
+
+    Queue::assertNothingPushed();
+});
+
+test('does not resume a retry task', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->failed()->create([
+        // A Retrying task's claimed_job_class still reflects its original
+        // RunYakJob claim from before it ever reached AwaitingCi — RetryYakJob
+        // never touches the column — so status at interrupt time is what
+        // actually excludes it. Drain leaves claimed_job_class untouched.
+        'claimed_job_class' => RunYakJob::class,
+        'interrupted_by_deploy_at' => null,
+    ])->fresh();
+
+    // RetryYakJob never claims via ClaimsTask, so simulate what drain would
+    // have recorded for a Retrying straggler directly: no eligible class is
+    // ever promised for it.
+    $task->update([
+        'interrupted_by_deploy_at' => now(),
+        'claimed_job_class' => RetryYakJob::class,
+    ]);
+
+    $this->artisan('yak:resume-interrupted-tasks')->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed)
+        ->and($task->interrupted_by_deploy_at)->toBeNull();
+
+    Queue::assertNothingPushed();
+});
+
+test('leaves a task Failed once it is over the deploy_resume_count bound', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->failed()->create([
+        'claimed_job_class' => RunYakJob::class,
+        'interrupted_by_deploy_at' => now(),
+        'deploy_resume_count' => 3,
+    ]);
+
+    $this->artisan('yak:resume-interrupted-tasks', ['--max-resumes' => 3])->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed)
+        ->and($task->interrupted_by_deploy_at)->toBeNull()
+        ->and($task->deploy_resume_count)->toBe(3)
+        ->and($task->error_log)->toContain('manual retry');
+
+    Queue::assertNothingPushed();
+});
+
+test('is a no-op while the drain flag is set', function () {
+    Queue::fake();
+    Cache::put(PausesDuringDrain::CACHE_KEY, true, now()->addMinutes(5));
+
+    $task = YakTask::factory()->failed()->create([
+        'claimed_job_class' => RunYakJob::class,
+        'interrupted_by_deploy_at' => now(),
+    ]);
+
+    $this->artisan('yak:resume-interrupted-tasks')->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed)
+        ->and($task->interrupted_by_deploy_at)->not->toBeNull();
+
+    Queue::assertNothingPushed();
+});
+
+test('leaves tasks without the marker untouched', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->failed()->create([
+        'claimed_job_class' => RunYakJob::class,
+        'interrupted_by_deploy_at' => null,
+    ]);
+
+    $this->artisan('yak:resume-interrupted-tasks')->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed);
+
+    Queue::assertNothingPushed();
+});

--- a/tests/Feature/Jobs/ClaimsTaskAtomicallyTest.php
+++ b/tests/Feature/Jobs/ClaimsTaskAtomicallyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Enums\TaskStatus;
+use App\Jobs\Middleware\ClaimsTaskAtomically;
+use App\Jobs\RunYakJob;
+use App\Models\Repository;
+use App\Models\YakTask;
+
+test('claims a pending task and calls next', function () {
+    Repository::factory()->create(['slug' => 'claim-repo']);
+    $task = YakTask::factory()->pending()->create(['repo' => 'claim-repo', 'attempts' => 0]);
+
+    $job = new RunYakJob($task);
+
+    $called = false;
+    (new ClaimsTaskAtomically)->handle($job, function () use (&$called) {
+        $called = true;
+    });
+
+    $task->refresh();
+
+    expect($called)->toBeTrue()
+        ->and($task->status)->toBe(TaskStatus::Running)
+        ->and($task->attempts)->toBe(1)
+        ->and($task->started_at)->not->toBeNull();
+});
+
+test('deletes the job and skips next when the task is not pending', function () {
+    Repository::factory()->create(['slug' => 'claim-repo-2']);
+    $task = YakTask::factory()->running()->create(['repo' => 'claim-repo-2', 'attempts' => 1]);
+
+    $job = new RunYakJob($task);
+
+    $called = false;
+    (new ClaimsTaskAtomically)->handle($job, function () use (&$called) {
+        $called = true;
+    });
+
+    $task->refresh();
+
+    // No side effects: attempts and status are untouched, and the
+    // downstream pipeline (which could call $job->fail()) never ran.
+    expect($called)->toBeFalse()
+        ->and($task->status)->toBe(TaskStatus::Running)
+        ->and($task->attempts)->toBe(1)
+        ->and($job->taskClaimLost)->toBeTrue();
+});
+
+test('passes objects without a task property straight through', function () {
+    $job = new stdClass;
+
+    $called = false;
+    (new ClaimsTaskAtomically)->handle($job, function () use (&$called) {
+        $called = true;
+    });
+
+    expect($called)->toBeTrue();
+});
+
+test('passes through jobs that do not support claimTask', function () {
+    Repository::factory()->create(['slug' => 'claim-repo-3']);
+    $task = YakTask::factory()->pending()->create(['repo' => 'claim-repo-3']);
+
+    $job = new class($task)
+    {
+        public function __construct(public YakTask $task) {}
+    };
+
+    $called = false;
+    (new ClaimsTaskAtomically)->handle($job, function () use (&$called) {
+        $called = true;
+    });
+
+    expect($called)->toBeTrue();
+});

--- a/tests/Feature/ReapLostPendingCommandTest.php
+++ b/tests/Feature/ReapLostPendingCommandTest.php
@@ -1,0 +1,190 @@
+<?php
+
+use App\Enums\TaskStatus;
+use App\Jobs\Middleware\PausesDuringDrain;
+use App\Jobs\RunYakJob;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\AgentJobDispatcher;
+use App\Services\HealthCheck\ClaudeAuthCheck;
+use Illuminate\Bus\UniqueLock;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+
+test('re-dispatches a stale pending task whose dispatched job has vanished', function () {
+    Queue::fake();
+
+    $repository = Repository::factory()->create(['slug' => 'lost-pending-repo']);
+    $task = YakTask::factory()->pending()->create([
+        'repo' => $repository->slug,
+        'dispatched_at' => now()->subMinutes(15),
+        'queue_job_uuid' => (string) Str::uuid(),
+    ]);
+
+    $this->artisan('yak:reap-lost-pending', ['--minutes' => 10])
+        ->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Pending)
+        ->and($task->dispatched_at)->toBeGreaterThan(now()->subMinute());
+
+    Queue::assertPushed(RunYakJob::class, fn ($job) => $job->task->id === $task->id);
+});
+
+test('does not touch a recently dispatched pending task', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->pending()->create([
+        'dispatched_at' => now()->subMinutes(2),
+        'queue_job_uuid' => (string) Str::uuid(),
+    ]);
+    // Round-trips through the DB's second-precision timestamp column so
+    // the comparison below isn't thrown off by microseconds the column
+    // can't store.
+    $originalDispatchedAt = $task->fresh()->dispatched_at;
+
+    $this->artisan('yak:reap-lost-pending', ['--minutes' => 10])
+        ->assertSuccessful();
+
+    $task->refresh();
+    expect($task->dispatched_at->eq($originalDispatchedAt))->toBeTrue();
+
+    Queue::assertNothingPushed();
+});
+
+test('does not touch a pending task that was never dispatched (no dispatched_at)', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->pending()->create(['dispatched_at' => null]);
+
+    $this->artisan('yak:reap-lost-pending', ['--minutes' => 10])
+        ->assertSuccessful();
+
+    expect($task->fresh()->dispatched_at)->toBeNull();
+    Queue::assertNothingPushed();
+});
+
+test('does not touch a task that has already started', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->pending()->create([
+        'started_at' => now()->subMinutes(30),
+        'dispatched_at' => now()->subMinutes(30),
+        'queue_job_uuid' => (string) Str::uuid(),
+    ]);
+
+    $this->artisan('yak:reap-lost-pending', ['--minutes' => 10])
+        ->assertSuccessful();
+
+    Queue::assertNothingPushed();
+});
+
+test('never touches Running, AwaitingCi, Retrying or terminal tasks', function () {
+    Queue::fake();
+
+    $factory = fn () => ['dispatched_at' => now()->subHours(2), 'queue_job_uuid' => (string) Str::uuid()];
+
+    YakTask::factory()->running()->create($factory());
+    YakTask::factory()->awaitingCi()->create($factory());
+    YakTask::factory()->retrying()->create($factory());
+    YakTask::factory()->success()->create($factory());
+    YakTask::factory()->failed()->create($factory());
+    YakTask::factory()->expired()->create($factory());
+
+    $this->artisan('yak:reap-lost-pending', ['--minutes' => 10])
+        ->assertSuccessful();
+
+    Queue::assertNothingPushed();
+});
+
+test('does not re-dispatch a task whose job is still sitting in the jobs table', function () {
+    config(['queue.default' => 'database']);
+
+    $repository = Repository::factory()->create(['slug' => 'still-queued-repo']);
+    $task = YakTask::factory()->pending()->create(['repo' => $repository->slug]);
+
+    // Dispatch for real against the database queue so a row lands in
+    // `jobs` carrying this task's queue_job_uuid — then wind the
+    // timestamp back so it looks stale to the sweep, without the job
+    // actually having vanished.
+    app(AgentJobDispatcher::class)->dispatch($task, RunYakJob::class);
+    $task->refresh();
+    $originalUuid = $task->queue_job_uuid;
+    expect($originalUuid)->not->toBeNull();
+
+    $task->forceFill(['dispatched_at' => now()->subMinutes(30)])->save();
+
+    $this->artisan('yak:reap-lost-pending', ['--minutes' => 10])
+        ->assertSuccessful();
+
+    $task->refresh();
+    // Untouched — the sweep found the original job still queued and
+    // skipped re-dispatching it.
+    expect($task->queue_job_uuid)->toBe($originalUuid);
+    expect(DB::table('jobs')->count())->toBe(1);
+});
+
+test('re-dispatches a task whose queue_job_uuid no longer matches anything queued', function () {
+    config(['queue.default' => 'database']);
+
+    $repository = Repository::factory()->create(['slug' => 'vanished-repo']);
+    $task = YakTask::factory()->pending()->create(['repo' => $repository->slug]);
+
+    app(AgentJobDispatcher::class)->dispatch($task, RunYakJob::class);
+    $task->refresh();
+
+    // Simulate the original job vanishing from the queue entirely (the
+    // actual 2026-09-03 incident) while queue_job_uuid still points at it.
+    DB::table('jobs')->truncate();
+
+    $task->forceFill(['dispatched_at' => now()->subMinutes(30)])->save();
+
+    // The original dispatch's ShouldBeUnique lock (uniqueFor: 900s) is
+    // deliberately longer than the sweep's default threshold — by design,
+    // see RunYakJob::uniqueFor() — so it would still be held at this
+    // point in a real 30-minutes-stale scenario too. But 900s has long
+    // since expired by 30 real minutes out; release it here to reflect
+    // that instead of leaving the test relying on the lock's TTL not
+    // having ticked during the test run.
+    (new UniqueLock(app(Illuminate\Contracts\Cache\Repository::class)))
+        ->release(new RunYakJob($task));
+
+    Queue::fake();
+
+    $this->artisan('yak:reap-lost-pending', ['--minutes' => 10])
+        ->assertSuccessful();
+
+    Queue::assertPushed(RunYakJob::class, fn ($job) => $job->task->id === $task->id);
+});
+
+test('is a no-op while the drain flag is set', function () {
+    Queue::fake();
+    Cache::put(PausesDuringDrain::CACHE_KEY, true, now()->addMinutes(5));
+
+    YakTask::factory()->pending()->create([
+        'dispatched_at' => now()->subHours(2),
+        'queue_job_uuid' => (string) Str::uuid(),
+    ]);
+
+    $this->artisan('yak:reap-lost-pending', ['--minutes' => 10])
+        ->assertSuccessful();
+
+    Queue::assertNothingPushed();
+});
+
+test('is a no-op while the Claude auth session is unusable', function () {
+    Queue::fake();
+    Cache::put(ClaudeAuthCheck::UNUSABLE_CACHE_KEY, true, now()->addMinutes(5));
+
+    YakTask::factory()->pending()->create([
+        'dispatched_at' => now()->subHours(2),
+        'queue_job_uuid' => (string) Str::uuid(),
+    ]);
+
+    $this->artisan('yak:reap-lost-pending', ['--minutes' => 10])
+        ->assertSuccessful();
+
+    Queue::assertNothingPushed();
+});

--- a/tests/Feature/ReapLostPendingNoDoubleRunTest.php
+++ b/tests/Feature/ReapLostPendingNoDoubleRunTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Contracts\AgentRunner;
+use App\DataTransferObjects\AgentRunResult;
+use App\Jobs\RunYakJob;
+use App\Models\Repository;
+use App\Models\YakTask;
+use App\Services\IncusSandboxManager;
+use Illuminate\Support\Facades\Process;
+use Tests\Support\FakeAgentRunner;
+use Tests\Support\FakeSandboxManager;
+
+/**
+ * Proves the actual point of routing yak:reap-lost-pending through
+ * AgentJobDispatcher: when the sweep's "is it still queued?" check is
+ * wrong — queue_job_uuid capture missed, or the original job is still
+ * genuinely in flight — and it re-dispatches a task whose original job is
+ * still alive, the result is at most one real run, never two.
+ *
+ * The two copies here are NOT dispatched through AgentJobDispatcher's
+ * real ::dispatch() calls, deliberately: RunYakJob's ShouldBeUnique lock
+ * (uniqueFor 900s, see RunYakJob::uniqueFor()) would itself silently
+ * block a second PendingDispatch and the test would pass without ever
+ * exercising the claim. That lock is defence in depth, not the real
+ * guarantee — change 0's spec is explicit that it exists to catch a lock
+ * "orphaned by a SIGKILLed worker", i.e. it can legitimately be gone by
+ * the time a duplicate shows up. Constructing both copies directly, as
+ * change 0's own AtomicTaskClaimTest does, exercises the actual guarantee
+ * this sweep depends on: the atomic UPDATE in App\Jobs\Concerns\ClaimsTask,
+ * which works regardless of whether the unique lock is still held.
+ */
+test('re-dispatching a task that is actually still queued does not produce two runs', function () {
+    $fake = (new FakeAgentRunner)->queueResult(new AgentRunResult(
+        sessionId: 'sess_no_double_run',
+        resultSummary: 'Done',
+        costUsd: 0.0,
+        numTurns: 1,
+        durationMs: 1000,
+        isError: false,
+        clarificationNeeded: false,
+        clarificationOptions: [],
+        rawOutput: '{}',
+    ));
+    app()->instance(AgentRunner::class, $fake);
+
+    $fakeSandbox = new FakeSandboxManager;
+    app()->instance(IncusSandboxManager::class, $fakeSandbox);
+    Process::fake(['*' => Process::result('')]);
+
+    $repository = Repository::factory()->create([
+        'slug' => 'no-double-run-repo',
+        'path' => '/home/yak/repos/no-double-run-repo',
+    ]);
+    $task = YakTask::factory()->pending()->create(['repo' => $repository->slug]);
+
+    // The "original" copy — still genuinely queued when the sweep decides
+    // (wrongly, for this test) that the task looks lost.
+    $original = new RunYakJob($task);
+
+    // The sweep's re-dispatch, resolved the same way
+    // ReapLostPendingCommand::jobClassFor() would for a Fix-mode task.
+    $resweep = new RunYakJob($task->fresh());
+
+    $original->handle($fake);
+    $resweep->handle($fake);
+
+    // Exactly one real run happened: one sandbox created, one destroyed —
+    // not two.
+    expect($fakeSandbox->createdContainers)->toHaveCount(1)
+        ->and($fakeSandbox->destroyedContainers)->toHaveCount(1)
+        ->and($resweep->taskClaimLost)->toBeTrue();
+
+    // The one real run advanced the task past Pending exactly once —
+    // there's no sign of a second run having touched it.
+    expect($task->fresh()->status->value)->not->toBe('pending')
+        ->and($task->fresh()->attempts)->toBe(1);
+});

--- a/tests/Feature/ReapOrphanedTasksCommandTest.php
+++ b/tests/Feature/ReapOrphanedTasksCommandTest.php
@@ -65,10 +65,10 @@ test('spares a task still being updated (updated_at within threshold)', function
     expect($task->fresh()->status)->toBe(TaskStatus::Running);
 });
 
-test('ignores non-Running statuses', function () {
+test('ignores non-Running, non-Retrying statuses', function () {
     Queue::fake();
 
-    foreach ([TaskStatus::AwaitingCi, TaskStatus::AwaitingClarification, TaskStatus::Retrying, TaskStatus::Pending] as $status) {
+    foreach ([TaskStatus::AwaitingCi, TaskStatus::AwaitingClarification, TaskStatus::Pending] as $status) {
         YakTask::factory()->create([
             'status' => $status,
             'updated_at' => now()->subHours(2),
@@ -80,6 +80,46 @@ test('ignores non-Running statuses', function () {
 
     // None of them flipped to Failed.
     expect(YakTask::where('status', TaskStatus::Failed)->count())->toBe(0);
+});
+
+test('reaps a Retrying task with no log activity past the threshold', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->retrying()->create([
+        'source' => 'slack',
+        'slack_channel' => 'C1',
+        'slack_thread_ts' => '1.1',
+        'updated_at' => now()->subMinutes(30),
+    ]);
+
+    $this->artisan('yak:reap-orphaned-tasks', ['--minutes' => 15])
+        ->assertSuccessful();
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed);
+    expect($task->error_log)->toContain('Worker crashed mid-run');
+    expect($task->completed_at)->not->toBeNull();
+
+    Queue::assertPushed(SendNotificationJob::class, fn ($job) => $job->task->id === $task->id && $job->type === NotificationType::Error);
+});
+
+test('spares a Retrying task that had log activity within the threshold', function () {
+    Queue::fake();
+
+    $task = YakTask::factory()->retrying()->create([
+        'updated_at' => now()->subMinutes(30),
+    ]);
+
+    TaskLog::factory()->create([
+        'yak_task_id' => $task->id,
+        'created_at' => now()->subMinutes(5),
+    ]);
+
+    $this->artisan('yak:reap-orphaned-tasks', ['--minutes' => 15])
+        ->assertSuccessful();
+
+    expect($task->fresh()->status)->toBe(TaskStatus::Retrying);
+    Queue::assertNothingPushed();
 });
 
 test('does not notify system-source tasks', function () {

--- a/tests/Feature/SetupYakJobTest.php
+++ b/tests/Feature/SetupYakJobTest.php
@@ -4,6 +4,7 @@ use App\Contracts\AgentRunner;
 use App\DataTransferObjects\AgentRunResult;
 use App\Enums\TaskMode;
 use App\Enums\TaskStatus;
+use App\Jobs\Middleware\ClaimsTaskAtomically;
 use App\Jobs\Middleware\EnsureDailyBudget;
 use App\Jobs\Middleware\HoldsForClaudeAuth;
 use App\Jobs\Middleware\PausesDuringDrain;
@@ -425,7 +426,7 @@ test('SetupYakJob dispatches to yak-claude queue', function () {
 |--------------------------------------------------------------------------
 */
 
-test('SetupYakJob has PausesDuringDrain, HoldsForClaudeAuth, and EnsureDailyBudget middleware', function () {
+test('SetupYakJob has PausesDuringDrain, HoldsForClaudeAuth, ClaimsTaskAtomically, and EnsureDailyBudget middleware', function () {
     Process::fake();
 
     $repository = Repository::factory()->create(['slug' => 'mw-repo', 'path' => '/home/yak/repos/mw-repo']);
@@ -434,10 +435,11 @@ test('SetupYakJob has PausesDuringDrain, HoldsForClaudeAuth, and EnsureDailyBudg
     $job = new SetupYakJob($task);
     $middleware = $job->middleware();
 
-    expect($middleware)->toHaveCount(3)
+    expect($middleware)->toHaveCount(4)
         ->and($middleware[0])->toBeInstanceOf(PausesDuringDrain::class)
         ->and($middleware[1])->toBeInstanceOf(HoldsForClaudeAuth::class)
-        ->and($middleware[2])->toBeInstanceOf(EnsureDailyBudget::class);
+        ->and($middleware[2])->toBeInstanceOf(ClaimsTaskAtomically::class)
+        ->and($middleware[3])->toBeInstanceOf(EnsureDailyBudget::class);
 });
 
 /*

--- a/tests/Feature/Tasks/TaskActionControllerTest.php
+++ b/tests/Feature/Tasks/TaskActionControllerTest.php
@@ -49,6 +49,21 @@ test('retry dispatches ResearchYakJob for research tasks', function () {
     Queue::assertPushed(ResearchYakJob::class);
 });
 
+test('retry restamps dispatched_at through AgentJobDispatcher', function () {
+    Queue::fake();
+    $task = YakTask::factory()->create([
+        'status' => TaskStatus::Failed,
+        'dispatched_at' => now()->subDays(3),
+        'queue_job_uuid' => 'stale-uuid',
+    ]);
+
+    $this->post(route('tasks.retry', $task));
+
+    $task->refresh();
+    expect($task->dispatched_at)->not->toBeNull()
+        ->and($task->dispatched_at->greaterThan(now()->subMinute()))->toBeTrue();
+});
+
 test('cancel destroys the sandbox and marks the task cancelled', function () {
     Queue::fake();
     Process::fake(['*' => Process::result(exitCode: 0)]);
@@ -145,6 +160,27 @@ test('reroute moves the task to a new repo and restarts it', function () {
     Queue::assertPushed(RunYakJob::class);
     expect($task->fresh()->repo)->toBe('api');
     expect($task->fresh()->status)->toBe(TaskStatus::Pending);
+});
+
+test('reroute restamps dispatched_at through AgentJobDispatcher', function () {
+    Queue::fake();
+    Repository::factory()->create(['slug' => 'web', 'is_active' => true]);
+    Repository::factory()->create(['slug' => 'api', 'is_active' => true]);
+
+    $task = YakTask::factory()->create([
+        'mode' => TaskMode::Fix,
+        'repo' => 'web',
+        'pr_url' => null,
+        'dispatched_at' => now()->subDays(3),
+        'queue_job_uuid' => 'stale-uuid',
+    ]);
+
+    $this->post(route('tasks.reroute', $task), ['repo' => 'api'])
+        ->assertRedirect(route('tasks.show', $task));
+
+    $task->refresh();
+    expect($task->dispatched_at)->not->toBeNull()
+        ->and($task->dispatched_at->greaterThan(now()->subMinute()))->toBeTrue();
 });
 
 test('reroute is rejected for a review task', function () {

--- a/tests/Feature/TerminalTaskStatusGuardTest.php
+++ b/tests/Feature/TerminalTaskStatusGuardTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use App\Enums\TaskStatus;
+use App\Jobs\ResearchYakJob;
+use App\Jobs\RetryYakJob;
+use App\Jobs\RunFollowUpJob;
+use App\Jobs\RunYakJob;
+use App\Jobs\RunYakReviewJob;
+use App\Jobs\SetupYakJob;
+use App\Models\Repository;
+use App\Models\YakTask;
+use Tests\Support\FakeAgentRunner;
+
+/**
+ * Change 1: every inline error handler must preserve an already-terminal
+ * task's status/error_log instead of overwriting it with whatever this
+ * run's own error happened to be — the exact failure mode from the
+ * incident, where a drain's accurate "interrupted after 300s wait"
+ * message was clobbered by "stream ended without result event (exit=137)",
+ * the abnormal-termination artifact of the interruption itself.
+ *
+ * @param  class-string  $jobClass
+ */
+function invokeHandleError(string $jobClass, YakTask $task, string $message): void
+{
+    $job = new $jobClass($task);
+    $method = new ReflectionMethod($job, 'handleError');
+
+    if ($jobClass === SetupYakJob::class) {
+        $repository = Repository::where('slug', $task->repo)->first()
+            ?? Repository::factory()->create(['slug' => $task->repo]);
+        $method->invoke($job, $repository, $message);
+
+        return;
+    }
+
+    $method->invoke($job, $message);
+}
+
+dataset('job classes with an inline error handler', [
+    'RunYakJob' => [RunYakJob::class],
+    'ResearchYakJob' => [ResearchYakJob::class],
+    'RunYakReviewJob' => [RunYakReviewJob::class],
+    'SetupYakJob' => [SetupYakJob::class],
+    'RetryYakJob' => [RetryYakJob::class],
+    'RunFollowUpJob' => [RunFollowUpJob::class],
+]);
+
+test('a task already Failed with a drain message keeps it', function (string $jobClass) {
+    $task = YakTask::factory()->failed()->create([
+        'error_log' => 'Deploy interrupted the task after 300s wait. Retry it once the deploy is done.',
+    ]);
+
+    invokeHandleError($jobClass, $task, 'Claude Code stream ended without result event (lines=418, exit=137)');
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed)
+        ->and($task->error_log)->toBe('Deploy interrupted the task after 300s wait. Retry it once the deploy is done.');
+})->with('job classes with an inline error handler');
+
+test('a non-terminal task is still finalised', function (string $jobClass) {
+    $task = YakTask::factory()->running()->create(['error_log' => null]);
+
+    invokeHandleError($jobClass, $task, 'Rate limited by API');
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed)
+        ->and($task->error_log)->toBe('Rate limited by API')
+        ->and($task->completed_at)->not->toBeNull();
+})->with('job classes with an inline error handler');
+
+test('cancellation behaviour is unchanged', function (string $jobClass) {
+    $task = YakTask::factory()->running()->create();
+    $task->update(['status' => TaskStatus::Cancelled, 'error_log' => 'Cancelled by user']);
+
+    invokeHandleError($jobClass, $task, 'stream ended abnormally');
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Cancelled)
+        ->and($task->error_log)->toBe('Cancelled by user');
+})->with('job classes with an inline error handler');
+
+/*
+|--------------------------------------------------------------------------
+| Early writes (RunYakJob repo-missing, RunYakReviewJob PR-review-disabled)
+|--------------------------------------------------------------------------
+|
+| These run before the atomic claim (Change 0) has a chance to happen —
+| checking the repo is the very first thing runTask() does — so they're
+| exactly the residual race window described in the spec: a task
+| cancelled between dispatch and pickup can still reach here with a
+| terminal status by the time the job actually executes.
+*/
+
+test('RunYakJob does not overwrite a terminal task when the repo cannot be resolved', function () {
+    $task = YakTask::factory()->create([
+        'repo' => 'totally-unknown-repo',
+        'status' => TaskStatus::Failed,
+        'error_log' => 'Deploy interrupted the task after 300s wait.',
+        'completed_at' => now(),
+    ]);
+
+    (new RunYakJob($task))->handle(new FakeAgentRunner);
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Failed)
+        ->and($task->error_log)->toBe('Deploy interrupted the task after 300s wait.');
+});
+
+test('RunYakReviewJob does not overwrite a terminal task when PR review is not enabled', function () {
+    $repository = Repository::factory()->create(['slug' => 'not-review-enabled', 'pr_review_enabled' => false]);
+    $task = YakTask::factory()->create([
+        'repo' => $repository->slug,
+        'status' => TaskStatus::Cancelled,
+        'error_log' => 'Cancelled by user',
+    ]);
+
+    (new RunYakReviewJob($task))->handle(new FakeAgentRunner);
+
+    $task->refresh();
+    expect($task->status)->toBe(TaskStatus::Cancelled)
+        ->and($task->error_log)->toBe('Cancelled by user');
+});


### PR DESCRIPTION
## Summary

A routine deploy on 2026-09-03 left two tasks failed and two stuck pending, and diagnosing it was slow because the system destroyed its own evidence at three points. This fixes the causes and makes the class of failure recoverable.

The drain worked as designed: it waited 300s for two tasks that had been running 37 minutes, force-failed them, and destroyed their sandboxes. But destroying the sandbox kills the Claude process, and the job's inline error handler then overwrote the drain's message with a cryptic `Claude Code stream ended without result event (exit=137)` — so a deploy casualty looked identical to a Claude crash.

The two pending tasks are a separate story. Their queued jobs vanished, they had no `started_at`, and nothing watches for that. They would have sat there forever. The original cause is unknowable: `storage/logs` lived inside the container, so the recreate truncated every log file. Rather than guess, this makes the class detectable, recoverable, and diagnosable next time.

Design: `docs/superpowers/specs/2026-09-03-deploy-resilience-design.md`.

## Changes

**Atomic task pickup.** Jobs claimed their task with an unconditional update, so two copies of one job both proceeded — and that was destructive, not just wasteful: the sandbox manager reclaims a same-named container by destroying it, killing the live run, and a duplicate refused by `EnsureRepoReady` or `EnsureDailyBudget` destroyed the sandbox without ever reaching `handle()`. Pickup is now a single conditional `UPDATE ... WHERE status = Pending` with an affected-row check, run as middleware ahead of anything that calls `fail()`, plus `ShouldBeUnique` at dispatch. Covers `RunYakJob`, `ResearchYakJob`, `RunYakReviewJob`, `SetupYakJob`.

**Accurate failure reasons.** Six job classes overwrote `error_log` on already-terminal tasks; `RetryYakJob` and `RunFollowUpJob` had no guard at all. All six now share one terminal-status guard.

**Self-healing for stranded pending tasks.** New `yak:reap-lost-pending`, every five minutes: re-dispatches `Pending` tasks with no `started_at` whose job has vanished, detected via a stored queue job uuid checked against the live `jobs` table, falling back to `dispatched_at` age. All agent dispatches now route through `AgentJobDispatcher`, enforced by an architecture test. The sweep skips entirely while draining or while Claude auth is unusable, so it cannot storm.

**Drain no longer blind to CI retries.** `ProcessCIResultJob` sets tasks to `Retrying` and `RetryYakJob` never sets `Running`, so drain reported "no running tasks" and recreated the container on top of live agent runs. Drain and the orphan reaper now both cover `Running` and `Retrying`.

**Adaptive drain.** Waits while a task is still producing log output (15 minute silence window, matching the reaper) up to a `--max-wait` ceiling, instead of a flat 300s that guaranteed casualties. The cache flag's TTL now derives from the ceiling rather than `--wait`, which would otherwise have expired mid-drain. Raw `sleep()` replaced with `Illuminate\Support\Sleep` so the wait logic is testable for the first time.

**Deploy-interrupted tasks resume themselves.** Drain marks stragglers, and a post-deploy step re-dispatches them as the job class that was actually running. Only the four claiming classes are resumed; follow-ups, clarification replies and CI retries carry context that cannot be rebuilt, so they stay failed with an accurate message. Resume does not consume the CI-retry budget, which is gated on the same `attempts` counter with a default of 2.

**Logs survive deploys.** `storage/logs` is bind-mounted to the host with logrotate (`copytruncate`, because both the `single` driver and supervisord hold their handles open).

## Notes for review

- A deploy can now block for up to 45 minutes waiting out a live task. That is deliberate and tunable via `yak_drain_max_wait_seconds`.
- `uniqueFor` (900s) and the sweep threshold (600s) are coupled: if `uniqueFor` ever exceeds twice the threshold, a lost task could be deferred indefinitely.
- The log mount and rotation cannot be verified without a real deploy.

Feature 1802, Unit 284, Browser 40, all passing. Ansible syntax checked.

https://claude.ai/code/session_01873wPyFwSPY6WenZZgFXKV