### PR TITLE
Skills discovery, MCP servers page, and repository form help

### DIFF
--- a/ansible/roles/claude-code-config/tasks/main.yml
+++ b/ansible/roles/claude-code-config/tasks/main.yml
@@ -7,6 +7,14 @@
     group: root
     mode: "0755"
 
+- name: Install yak-mcp helper
+  ansible.builtin.template:
+    src: yak-mcp.j2
+    dest: /usr/local/bin/yak-mcp
+    owner: root
+    group: root
+    mode: "0755"
+
 # The shared config dir is read/write for the sandbox (raw.idmap maps only
 # host uid 33/www-data <-> container yak uid 1001) and the health probe
 # runs `claude` against it from the app container every 15 minutes. Claude

--- a/ansible/roles/claude-code-config/templates/yak-mcp.j2
+++ b/ansible/roles/claude-code-config/templates/yak-mcp.j2
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Manage the MCP servers Yak's agents can reach.
+#
+# Thin wrapper around `claude mcp` run inside the Yak container against the
+# shared config directory, the same way yak-claude-login wraps `claude`.
+# Every sandbox bind-mounts that directory, so a server added or logged in
+# here is visible to the next task without a restart.
+#
+#   yak-mcp list                                   # health-check every server
+#   yak-mcp login <name>                           # OAuth login (prints a URL,
+#                                                  #   then asks for the redirect)
+#   yak-mcp add --transport http <name> <url>      # add a remote server
+#   yak-mcp remove <name>                          # remove a server added here
+#
+# The dashboard's Settings > MCP servers page does the same things; this
+# script is the terminal fallback.
+#
+# Managed by Ansible (roles/claude-code-config). Do not edit on the host.
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    set -- list
+fi
+
+# `login` needs --no-browser because there is no display in the container;
+# the CLI prints the authorization URL and waits for the redirect URL.
+if [[ "$1" == "login" ]]; then
+    case " $* " in
+        *" --no-browser "*) ;;
+        *) set -- "$@" --no-browser ;;
+    esac
+fi
+
+exec /usr/local/bin/yak-claude-login mcp "$@"

--- a/ansible/roles/yak-container/templates/env.j2
+++ b/ansible/roles/yak-container/templates/env.j2
@@ -3,6 +3,9 @@ APP_ENV=production
 APP_KEY=base64:{{ yak_app_key }}
 APP_DEBUG=false
 APP_URL=https://{{ yak_domain }}
+# Shown on Settings > MCP servers so the terminal fallback is a copyable one-liner.
+YAK_SSH_HOST={{ yak_ssh_host | default(yak_domain) }}
+YAK_CONTAINER_NAME={{ yak_container_name }}
 YAK_DEPLOYMENTS_HOSTNAME_SUFFIX={{ yak_domain }}
 # Cold start has to wait for dockerd inside the freshly-woken container
 # and then boot the full compose stack (clickhouse is slow); 60s default

--- a/app/ClaudeCli.php
+++ b/app/ClaudeCli.php
@@ -21,17 +21,28 @@ class ClaudeCli
 {
     public function exec(string $args, int $timeout = 60): ProcessResult
     {
-        $command = sprintf(
-            'env HOME=/home/yak CLAUDE_CONFIG_DIR=/home/yak/.claude %sclaude %s',
-            $this->gitCredentialEnv(),
-            $args,
-        );
+        $command = $this->interactiveCommand($args);
 
         try {
             return Process::timeout($timeout)->run($command);
         } catch (ProcessTimedOutException|SymfonyProcessTimedOutException $e) {
             throw new ClaudeCliException("claude {$args} timed out after {$timeout}s", previous: $e);
         }
+    }
+
+    /**
+     * Builds the same shell command string `exec()` runs, without running
+     * it. Used by callers that need to drive the process themselves (e.g.
+     * McpLoginJob, which needs a PTY and an interactive stdin) instead of
+     * going through Process::run().
+     */
+    public function interactiveCommand(string $args): string
+    {
+        return sprintf(
+            'env HOME=/home/yak CLAUDE_CONFIG_DIR=/home/yak/.claude %sclaude %s',
+            $this->gitCredentialEnv(),
+            $args,
+        );
     }
 
     /**

--- a/app/DataTransferObjects/McpServer.php
+++ b/app/DataTransferObjects/McpServer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+/**
+ * One row of the Settings > MCP servers table. Mirrors the `McpServerRow`
+ * TypeScript type in resources/js/types/settings.ts.
+ */
+final readonly class McpServer
+{
+    public function __construct(
+        public string $name,
+        public string $displayName,
+        public string $target,
+        public string $transport,
+        public string $source,
+        public ?string $pluginName,
+        public string $status,
+        public ?string $detail,
+        public bool $canConnect,
+        public bool $canLogout,
+        public bool $canRemove,
+        public string $loginCommand,
+    ) {}
+
+    /**
+     * @return array{name: string, displayName: string, target: string, transport: string, source: string, pluginName: ?string, status: string, detail: ?string, canConnect: bool, canLogout: bool, canRemove: bool, loginCommand: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'displayName' => $this->displayName,
+            'target' => $this->target,
+            'transport' => $this->transport,
+            'source' => $this->source,
+            'pluginName' => $this->pluginName,
+            'status' => $this->status,
+            'detail' => $this->detail,
+            'canConnect' => $this->canConnect,
+            'canLogout' => $this->canLogout,
+            'canRemove' => $this->canRemove,
+            'loginCommand' => $this->loginCommand,
+        ];
+    }
+}

--- a/app/DataTransferObjects/PluginUpdateResult.php
+++ b/app/DataTransferObjects/PluginUpdateResult.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\DataTransferObjects;
+
+/**
+ * Outcome of `claude plugin update <plugin>`. The CLI exits 0 both when it
+ * installed a newer version and when the plugin was already current, so the
+ * caller needs to know which happened to describe it honestly.
+ */
+final readonly class PluginUpdateResult
+{
+    public function __construct(
+        public bool $updated,
+        public ?string $version,
+    ) {}
+
+    public static function fromCliOutput(string $output): self
+    {
+        $version = preg_match('/\(([^()]+)\)\s*\.?\s*$/m', trim($output), $matches) === 1
+            ? trim($matches[1])
+            : null;
+
+        if (preg_match('/already (?:at|on) the latest version/i', $output) === 1) {
+            return new self(updated: false, version: $version);
+        }
+
+        return new self(updated: true, version: $version);
+    }
+}

--- a/app/Http/Controllers/Repositories/RepositoryController.php
+++ b/app/Http/Controllers/Repositories/RepositoryController.php
@@ -38,7 +38,7 @@ class RepositoryController extends Controller
             'stats' => null,
             'canDelete' => false,
             'deleteBlockedReason' => null,
-            'docsUrl' => Docs::url('repositories'),
+            'docsLinks' => $this->docsLinks(),
         ]);
     }
 
@@ -86,8 +86,25 @@ class RepositoryController extends Controller
             'deleteBlockedReason' => fn () => $this->canDelete($repository)
                 ? null
                 : 'This repository has tasks and cannot be deleted. Deactivate it instead.',
-            'docsUrl' => Docs::url('repositories'),
+            'docsLinks' => $this->docsLinks(),
         ]);
+    }
+
+    /**
+     * @return array{guide: string, adding: string, setup: string, claudeMd: string, routing: string, prReview: string, refresh: string, rerunSetup: string}
+     */
+    private function docsLinks(): array
+    {
+        return [
+            'guide' => Docs::url('repositories'),
+            'adding' => Docs::url('repositories.adding'),
+            'setup' => Docs::url('repositories.setup'),
+            'claudeMd' => Docs::url('repositories.claude-md'),
+            'routing' => Docs::url('repositories.routing'),
+            'prReview' => Docs::url('repositories.pr-review'),
+            'refresh' => Docs::url('repositories.refresh'),
+            'rerunSetup' => Docs::url('repositories.rerun-setup'),
+        ];
     }
 
     public function update(SaveRepositoryRequest $request, Repository $repository, ApplyPrReviewToOpenPulls $applyPrReview): RedirectResponse

--- a/app/Http/Controllers/Settings/McpLoginController.php
+++ b/app/Http/Controllers/Settings/McpLoginController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\McpLoginJob;
+use App\Support\McpLoginSession;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class McpLoginController extends Controller
+{
+    public function start(string $name): RedirectResponse
+    {
+        $existing = McpLoginSession::find($name);
+
+        if ($existing !== null && in_array($existing->status, McpLoginSession::ACTIVE_STATUSES, true)) {
+            return back()->with('error', "A login for {$name} is already in progress.");
+        }
+
+        McpLoginSession::start($name);
+
+        McpLoginJob::dispatch($name);
+
+        return back();
+    }
+
+    public function redirect(Request $request, string $name): RedirectResponse
+    {
+        $validated = $request->validate([
+            'redirectUrl' => ['required', 'url', 'max:4000'],
+        ]);
+
+        $redirectUrl = (string) $validated['redirectUrl'];
+
+        if (! str_starts_with($redirectUrl, 'http://localhost') && ! str_starts_with($redirectUrl, 'http://127.0.0.1')) {
+            return back()->with('error', 'That does not look like the redirect URL from the login page — it should start with http://localhost or http://127.0.0.1.');
+        }
+
+        $session = McpLoginSession::find($name);
+
+        if ($session === null || $session->status !== 'awaiting_redirect') {
+            return back()->with('error', "There is no login in progress for {$name}.");
+        }
+
+        $session->redirectUrl = $redirectUrl;
+        $session->status = 'finishing';
+        $session->save();
+
+        return back();
+    }
+
+    public function cancel(string $name): RedirectResponse
+    {
+        $session = McpLoginSession::find($name);
+
+        if ($session !== null) {
+            $session->status = 'cancelled';
+            $session->save();
+        }
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Settings/McpServerController.php
+++ b/app/Http/Controllers/Settings/McpServerController.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\ClaudeCli;
+use App\DataTransferObjects\McpServer;
+use App\Exceptions\ClaudeCliException;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\StoreMcpServerRequest;
+use App\Services\McpServerReader;
+use App\Support\Docs;
+use App\Support\McpLoginSession;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class McpServerController extends Controller
+{
+    public function __construct(
+        private readonly ClaudeCli $cli,
+        private readonly McpServerReader $reader,
+    ) {}
+
+    public function index(Request $request): Response
+    {
+        $partialData = (string) $request->header('X-Inertia-Partial-Data', '');
+        $requestedProps = $partialData !== '' ? explode(',', $partialData) : [];
+        $resolvingServers = in_array('servers', $requestedProps, true);
+
+        return Inertia::render('Settings/McpServers', [
+            'servers' => Inertia::defer(fn () => $this->serversData(), 'servers'),
+            'loginSessions' => fn () => $this->loginSessionsData(),
+            'checkedAgo' => $resolvingServers ? 'just now' : null,
+            'sshHost' => config('yak.ssh_host'),
+            'docsUrl' => Docs::url('prompting.mcp'),
+        ]);
+    }
+
+    public function store(StoreMcpServerRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        return $this->runSafely(function () use ($validated) {
+            $name = (string) $validated['name'];
+            $transport = (string) $validated['transport'];
+            $target = trim((string) $validated['target']);
+            $headers = (string) ($validated['headers'] ?? '');
+
+            $tokens = ['mcp', 'add', '--scope', 'user', '--transport', $transport];
+
+            foreach ($this->parseHeaderLines($headers, $transport) as [$key, $value]) {
+                if ($transport === 'stdio') {
+                    $tokens[] = '-e';
+                    $tokens[] = escapeshellarg("{$key}={$value}");
+                } else {
+                    $tokens[] = '-H';
+                    $tokens[] = escapeshellarg("{$key}: {$value}");
+                }
+            }
+
+            $tokens[] = escapeshellarg($name);
+
+            if ($transport === 'stdio') {
+                $tokens[] = '--';
+
+                foreach (preg_split('/\s+/', $target, -1, PREG_SPLIT_NO_EMPTY) ?: [] as $part) {
+                    $tokens[] = escapeshellarg($part);
+                }
+            } else {
+                $tokens[] = escapeshellarg($target);
+            }
+
+            $this->runCli(implode(' ', $tokens));
+
+            return "Added {$name}.";
+        });
+    }
+
+    public function destroy(string $name): RedirectResponse
+    {
+        return $this->runSafely(function () use ($name) {
+            $server = $this->reader->all()->first(fn (McpServer $s) => $s->name === $name);
+
+            if ($server === null) {
+                throw new ClaudeCliException("{$name} was not found.");
+            }
+
+            if ($server->source === 'deploy') {
+                throw new ClaudeCliException("{$name} is managed by Ansible.");
+            }
+
+            if ($server->source === 'plugin') {
+                throw new ClaudeCliException("{$name} comes from the {$server->pluginName} plugin; remove it from Skills.");
+            }
+
+            // Best-effort: a server may not be logged in, and `mcp remove`
+            // below is what actually matters for this action to succeed.
+            $this->cli->exec('mcp logout ' . escapeshellarg($name));
+
+            $this->runCli('mcp remove --scope user ' . escapeshellarg($name));
+
+            return "Removed {$name}.";
+        });
+    }
+
+    public function logout(string $name): RedirectResponse
+    {
+        return $this->runSafely(function () use ($name) {
+            $this->runCli('mcp logout ' . escapeshellarg($name));
+
+            return "Logged out of {$name}.";
+        });
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function serversData(): array
+    {
+        $deploy = $this->reader->deployServers();
+
+        try {
+            $user = $this->reader->userServers();
+        } catch (ClaudeCliException $e) {
+            session()->flash('error', $e->getMessage());
+            $user = collect();
+        }
+
+        return $deploy->concat($user)->map(fn (McpServer $s) => $s->toArray())->all();
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function loginSessionsData(): array
+    {
+        return collect(McpLoginSession::activeNames())
+            ->mapWithKeys(fn (string $name) => [$name => McpLoginSession::find($name)])
+            ->filter()
+            ->map(fn (McpLoginSession $session) => $session->toArray())
+            ->all();
+    }
+
+    /**
+     * Splits the headers/env textarea into key/value pairs. `Key: value`
+     * lines for http/sse transports, `KEY=value` lines for stdio (passed
+     * to the CLI as -e env vars instead of -H headers).
+     *
+     * @return array<int, array{0: string, 1: string}>
+     */
+    private function parseHeaderLines(string $raw, string $transport): array
+    {
+        $delimiter = $transport === 'stdio' ? '=' : ':';
+
+        $pairs = [];
+
+        foreach (preg_split('/\R/', $raw) ?: [] as $line) {
+            $line = trim($line);
+
+            if ($line === '') {
+                continue;
+            }
+
+            $pos = mb_strpos($line, $delimiter);
+
+            if ($pos === false) {
+                continue;
+            }
+
+            $key = trim(mb_substr($line, 0, $pos));
+            $value = trim(mb_substr($line, $pos + 1));
+
+            if ($key === '') {
+                continue;
+            }
+
+            $pairs[] = [$key, $value];
+        }
+
+        return $pairs;
+    }
+
+    private function runCli(string $args, int $timeout = 60): void
+    {
+        $result = $this->cli->exec($args, $timeout);
+
+        if (! $result->successful()) {
+            $message = trim($result->errorOutput() ?: $result->output());
+
+            throw new ClaudeCliException("claude {$args} failed: {$message}");
+        }
+    }
+
+    private function runSafely(\Closure $action): RedirectResponse
+    {
+        try {
+            $message = $action();
+        } catch (ClaudeCliException $e) {
+            return back()->with('error', $e->getMessage());
+        }
+
+        return back()->with('success', $message);
+    }
+}

--- a/app/Http/Controllers/SkillController.php
+++ b/app/Http/Controllers/SkillController.php
@@ -90,9 +90,12 @@ class SkillController extends Controller
     public function upgrade(string $name): RedirectResponse
     {
         return $this->runSafely(function () use ($name) {
-            $this->skills->update($name);
+            $result = $this->skills->update($name);
+            $version = $result->version !== null ? " ({$result->version})" : '';
 
-            return "Updated {$name}.";
+            return $result->updated
+                ? "Updated {$name}{$version}."
+                : "{$name} is already at the latest version{$version}.";
         });
     }
 

--- a/app/Http/Controllers/SkillController.php
+++ b/app/Http/Controllers/SkillController.php
@@ -18,7 +18,7 @@ use Inertia\Response;
 
 class SkillController extends Controller
 {
-    private const AVAILABLE_LIMIT = 60;
+    private const AVAILABLE_PER_PAGE = 24;
 
     public function __construct(
         private readonly SkillManager $skills,
@@ -29,16 +29,20 @@ class SkillController extends Controller
     {
         $search = $request->string('search')->toString();
         $filter = $request->string('filter', 'all')->toString();
+        $category = $request->string('category')->toString();
+        $page = max(1, $request->integer('page', 1));
 
         return Inertia::render('Skills/Index', [
             'installed' => fn () => $this->installedData($search),
             'bundled' => fn () => $this->bundledData($search),
-            'available' => fn () => $this->availableData($search),
-            'availableTotal' => fn () => $this->availableItems($search)->count(),
+            'available' => fn () => $this->availableData($search, $category, $page),
+            'categories' => fn () => $this->categoriesData($search),
+            'recommended' => fn () => $this->recommendedData($search, $filter),
             'marketplaces' => fn () => $this->marketplacesData(),
             'filters' => [
                 'search' => $search,
                 'filter' => $filter,
+                'category' => $category,
             ],
         ]);
     }
@@ -131,21 +135,137 @@ class SkillController extends Controller
     }
 
     /**
-     * @return array<int, array{key: string, name: string, description: string, marketplace: string, category: ?string, link: ?string}>
+     * @return array{items: array<int, array{key: string, name: string, description: string, marketplace: string, category: ?string, link: ?string}>, page: int, lastPage: int, total: int, perPage: int}
      */
-    private function availableData(string $search): array
+    private function availableData(string $search, string $category, int $page): array
     {
-        return $this->availableItems($search)
-            ->take(self::AVAILABLE_LIMIT)
-            ->map(fn (MarketplacePlugin $p) => [
-                'key' => $p->key(),
-                'name' => $p->name,
-                'description' => $p->description,
-                'marketplace' => $p->marketplace,
-                'category' => $p->category,
-                'link' => $p->link(),
-            ])
+        $items = $this->sortedAvailableItems($search);
+
+        if ($category !== '') {
+            $items = $items->filter(fn (MarketplacePlugin $p) => $this->categoryValue($p) === $category)->values();
+        }
+
+        $total = $items->count();
+        $lastPage = max(1, (int) ceil($total / self::AVAILABLE_PER_PAGE));
+        $page = max(1, min($page, $lastPage));
+
+        $pageItems = $items->slice(($page - 1) * self::AVAILABLE_PER_PAGE, self::AVAILABLE_PER_PAGE)->values();
+
+        return [
+            'items' => $pageItems->map(fn (MarketplacePlugin $p) => $this->toRow($p))->all(),
+            'page' => $page,
+            'lastPage' => $lastPage,
+            'total' => $total,
+            'perPage' => self::AVAILABLE_PER_PAGE,
+        ];
+    }
+
+    /**
+     * @return array<int, array{value: string, label: string, count: int}>
+     */
+    private function categoriesData(string $search): array
+    {
+        $counts = [];
+
+        foreach ($this->availableItems($search) as $plugin) {
+            $value = $this->categoryValue($plugin);
+            $counts[$value] = ($counts[$value] ?? 0) + 1;
+        }
+
+        $otherCount = $counts['other'] ?? null;
+        unset($counts['other']);
+
+        $rows = [];
+
+        foreach ($counts as $value => $count) {
+            $rows[] = ['value' => $value, 'label' => ucfirst($value), 'count' => $count];
+        }
+
+        usort($rows, fn (array $a, array $b) => $b['count'] <=> $a['count'] ?: strcasecmp($a['label'], $b['label']));
+
+        if ($otherCount !== null) {
+            $rows[] = ['value' => 'other', 'label' => 'Other', 'count' => $otherCount];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<int, array{key: string, name: string, description: string, marketplace: string, category: ?string, link: ?string, recommendedReason: string}>
+     */
+    private function recommendedData(string $search, string $filter): array
+    {
+        if ($search !== '' || ! in_array($filter, ['all', 'available'], true)) {
+            return [];
+        }
+
+        $installed = $this->skills->listInstalled();
+        $installedKeys = $installed->map->key()->all();
+
+        $available = $this->marketplaceReader->listAll()
+            ->reject(fn (MarketplacePlugin $p) => in_array($p->key(), $installedKeys, true))
+            ->values();
+
+        /** @var array<int, string> $popularNames */
+        $popularNames = config('yak.recommended_plugins', []);
+
+        $popular = $available
+            ->filter(fn (MarketplacePlugin $p) => in_array($p->name, $popularNames, true))
+            ->sortBy(fn (MarketplacePlugin $p) => array_search($p->name, $popularNames, true))
+            ->values();
+
+        $popularKeys = $popular->map->key()->all();
+
+        $installedCategories = $this->installedCategories($installed);
+
+        $similar = $available
+            ->reject(fn (MarketplacePlugin $p) => in_array($p->key(), $popularKeys, true))
+            ->filter(fn (MarketplacePlugin $p) => $p->category !== null && in_array(mb_strtolower($p->category), $installedCategories, true))
+            ->sortBy(fn (MarketplacePlugin $p) => mb_strtolower($p->name))
+            ->values();
+
+        return $popular->map(fn (MarketplacePlugin $p) => $this->toRow($p) + ['recommendedReason' => 'popular'])
+            ->concat($similar->map(fn (MarketplacePlugin $p) => $this->toRow($p) + ['recommendedReason' => 'similar']))
+            ->unique('key')
+            ->take(6)
+            ->values()
             ->all();
+    }
+
+    /**
+     * @param  Collection<int, InstalledPlugin>  $installed
+     * @return array<int, string>
+     */
+    private function installedCategories(Collection $installed): array
+    {
+        $installedKeys = $installed->map->key()->all();
+
+        return $this->marketplaceReader->listAll()
+            ->filter(fn (MarketplacePlugin $p) => $p->category !== null && in_array($p->key(), $installedKeys, true))
+            ->map(fn (MarketplacePlugin $p) => mb_strtolower((string) $p->category))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array{key: string, name: string, description: string, marketplace: string, category: ?string, link: ?string}
+     */
+    private function toRow(MarketplacePlugin $p): array
+    {
+        return [
+            'key' => $p->key(),
+            'name' => $p->name,
+            'description' => $p->description,
+            'marketplace' => $p->marketplace,
+            'category' => $p->category,
+            'link' => $p->link(),
+        ];
+    }
+
+    private function categoryValue(MarketplacePlugin $p): string
+    {
+        return $p->category !== null ? mb_strtolower($p->category) : 'other';
     }
 
     /**
@@ -160,6 +280,21 @@ class SkillController extends Controller
             ->values();
 
         return $this->filterBySearch($available, fn (MarketplacePlugin $p) => $p->name . ' ' . $p->description, $search);
+    }
+
+    /**
+     * @return Collection<int, MarketplacePlugin>
+     */
+    private function sortedAvailableItems(string $search): Collection
+    {
+        return $this->availableItems($search)
+            ->sort(function (MarketplacePlugin $a, MarketplacePlugin $b) {
+                $aCategory = $a->category !== null ? mb_strtolower($a->category) : "\u{10FFFF}";
+                $bCategory = $b->category !== null ? mb_strtolower($b->category) : "\u{10FFFF}";
+
+                return [$aCategory, mb_strtolower($a->name)] <=> [$bCategory, mb_strtolower($b->name)];
+            })
+            ->values();
     }
 
     /**

--- a/app/Http/Controllers/SkillController.php
+++ b/app/Http/Controllers/SkillController.php
@@ -200,10 +200,13 @@ class SkillController extends Controller
         }
 
         $installed = $this->skills->listInstalled();
-        $installedKeys = $installed->map->key()->all();
+        $installedNames = $installed->map(fn (InstalledPlugin $p) => $p->name)->all();
 
+        // The same plugin is often published in more than one marketplace, so
+        // recommendations exclude and dedupe by name rather than by key.
         $available = $this->marketplaceReader->listAll()
-            ->reject(fn (MarketplacePlugin $p) => in_array($p->key(), $installedKeys, true))
+            ->reject(fn (MarketplacePlugin $p) => in_array($p->name, $installedNames, true))
+            ->unique(fn (MarketplacePlugin $p) => $p->name)
             ->values();
 
         /** @var array<int, string> $popularNames */
@@ -226,7 +229,7 @@ class SkillController extends Controller
 
         return $popular->map(fn (MarketplacePlugin $p) => $this->toRow($p) + ['recommendedReason' => 'popular'])
             ->concat($similar->map(fn (MarketplacePlugin $p) => $this->toRow($p) + ['recommendedReason' => 'similar']))
-            ->unique('key')
+            ->unique('name')
             ->take(6)
             ->values()
             ->all();

--- a/app/Http/Requests/Settings/StoreMcpServerRequest.php
+++ b/app/Http/Requests/Settings/StoreMcpServerRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreMcpServerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, array<int, mixed>> */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'regex:/^[A-Za-z0-9][A-Za-z0-9_.-]*$/', 'max:64'],
+            'transport' => ['required', Rule::in(['http', 'sse', 'stdio'])],
+            'target' => [
+                'required',
+                'string',
+                'max:2000',
+                Rule::when($this->input('transport') !== 'stdio', ['url']),
+            ],
+            'headers' => ['nullable', 'string', 'max:4000'],
+        ];
+    }
+}

--- a/app/Jobs/McpLoginJob.php
+++ b/app/Jobs/McpLoginJob.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace App\Jobs;
+
+use App\ClaudeCli;
+use App\Services\InteractiveProcess;
+use App\Services\InteractiveProcessFactory;
+use App\Support\McpLoginSession;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Sleep;
+
+/**
+ * Drives `claude mcp login <name> --no-browser` under a PTY (via `script`,
+ * since the CLI refuses to print its authorization URL without one) and
+ * keeps the shared McpLoginSession record in the cache updated so the
+ * Settings > MCP servers page can poll it across requests.
+ *
+ * The CLI's own auth flow spawns a local callback server and waits for a
+ * browser redirect that can never reach it from inside the container, so
+ * this job intercepts the printed authorization URL, waits for the user to
+ * paste back the (unreachable) localhost redirect URL via
+ * McpLoginController@redirect, then feeds that URL to the CLI's stdin as
+ * if it had been the browser.
+ */
+class McpLoginJob implements ShouldBeUnique, ShouldQueue
+{
+    use Queueable;
+
+    public int $timeout = 660;
+
+    public int $tries = 1;
+
+    /** Overall session lifetime — mirrors McpLoginSession::start()'s expiresAt. */
+    private const SESSION_MINUTES = 10;
+
+    /** How long to wait for the CLI to exit once the redirect URL is sent. */
+    private const EXIT_GRACE_SECONDS = 60;
+
+    public function __construct(public readonly string $server)
+    {
+        $this->onQueue('default');
+    }
+
+    public function uniqueId(): string
+    {
+        return $this->server;
+    }
+
+    public function uniqueFor(): int
+    {
+        return 660;
+    }
+
+    public function handle(ClaudeCli $cli, InteractiveProcessFactory $factory): void
+    {
+        $session = McpLoginSession::find($this->server);
+
+        if ($session === null || $session->status === 'cancelled') {
+            return;
+        }
+
+        $args = 'mcp login ' . escapeshellarg($this->server) . ' --no-browser';
+        $command = 'script -qec ' . escapeshellarg($cli->interactiveCommand($args)) . ' /dev/null';
+
+        Log::info('McpLoginJob: starting login', ['server' => $this->server]);
+
+        $process = $factory->start($command, $this->timeout);
+
+        $this->run($process, $session);
+    }
+
+    private function run(InteractiveProcess $process, McpLoginSession $session): void
+    {
+        $deadline = $session->startedAt->clone()->addMinutes(self::SESSION_MINUTES);
+
+        $buffer = '';
+        $foundUrl = false;
+        $redirectSent = false;
+        $redirectSentAt = null;
+
+        while (true) {
+            $session = McpLoginSession::find($this->server);
+
+            if ($session === null || $session->status === 'cancelled') {
+                $process->stop();
+                $this->conclude('cancelled');
+
+                return;
+            }
+
+            if (now()->greaterThan($deadline)) {
+                $process->stop();
+                $this->conclude('expired');
+
+                return;
+            }
+
+            $buffer .= $process->incrementalOutput();
+            $stripped = $this->stripAnsi($buffer);
+
+            if (! $foundUrl) {
+                $url = $this->extractAuthorizationUrl($stripped);
+
+                if ($url !== null) {
+                    $foundUrl = true;
+                    $session->authorizationUrl = $url;
+                    $session->status = 'awaiting_redirect';
+                    $session->save();
+                    Log::info('McpLoginJob: awaiting redirect', ['server' => $this->server]);
+                }
+            }
+
+            if ($foundUrl && ! $redirectSent && $session->status === 'finishing' && $session->redirectUrl !== null) {
+                $process->write($session->redirectUrl . "\n");
+                $process->closeInput();
+                $redirectSent = true;
+                $redirectSentAt = now();
+                Log::info('McpLoginJob: sent redirect url', ['server' => $this->server]);
+            }
+
+            if (! $process->isRunning()) {
+                break;
+            }
+
+            if ($redirectSent && $redirectSentAt !== null && $redirectSentAt->diffInSeconds(now()) > self::EXIT_GRACE_SECONDS) {
+                $process->stop();
+                break;
+            }
+
+            Sleep::for($foundUrl ? 500 : 200)->milliseconds();
+        }
+
+        $buffer .= $process->incrementalOutput();
+        $exitCode = $process->wait();
+        $stripped = $this->stripAnsi($buffer);
+
+        $failed = $exitCode !== 0 || preg_match("/(couldn't complete|failed)/i", $stripped) === 1;
+
+        $failed
+            ? $this->conclude('failed', $this->lastNonEmptyLine($stripped))
+            : $this->conclude('succeeded');
+    }
+
+    private function conclude(string $status, ?string $error = null): void
+    {
+        $session = McpLoginSession::find($this->server) ?? McpLoginSession::start($this->server);
+        $session->status = $status;
+        $session->error = $error;
+        $session->save();
+
+        Log::info('McpLoginJob: finished', ['server' => $this->server, 'status' => $status]);
+    }
+
+    private function extractAuthorizationUrl(string $strippedText): ?string
+    {
+        if (preg_match('/Visit this URL to authorize.*?(https?:\/\/\S+)/is', $strippedText, $matches) !== 1) {
+            return null;
+        }
+
+        return trim($matches[1]);
+    }
+
+    /**
+     * Strips ANSI CSI sequences and OSC 8 hyperlink wrappers from CLI
+     * output run under a PTY. OSC 8 sequences are stripped whole
+     * (including their URI parameter), not just their prefix — the
+     * visible link text usually repeats the URL, so leaving the URI
+     * parameter in place would duplicate it.
+     */
+    private function stripAnsi(string $text): string
+    {
+        $text = preg_replace('/\x1b\]8;;[^\x07\x1b]*(?:\x1b\\\\|\x07)/', '', $text) ?? $text;
+        $text = preg_replace('/\x1b\[[0-9;]*[a-zA-Z]/', '', $text) ?? $text;
+
+        return str_replace(["\x1b\\", "\x07"], '', $text);
+    }
+
+    private function lastNonEmptyLine(string $text): string
+    {
+        $lines = array_values(array_filter(
+            array_map('trim', explode("\n", $text)),
+            fn (string $line) => $line !== '',
+        ));
+
+        return $lines === [] ? 'claude mcp login failed' : (string) end($lines);
+    }
+
+    public function failed(\Throwable $e): void
+    {
+        Log::channel('yak')->error('McpLoginJob: failed after retries', [
+            'server' => $this->server,
+            'error' => $e->getMessage(),
+        ]);
+
+        $session = McpLoginSession::find($this->server);
+
+        if ($session !== null && ! $session->isTerminal()) {
+            $session->status = 'failed';
+            $session->error = $e->getMessage();
+            $session->save();
+        }
+    }
+}

--- a/app/Services/InteractiveProcess.php
+++ b/app/Services/InteractiveProcess.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * A running, interactively-driven process: output is read incrementally
+ * and input can be written while it is still running. Abstracts Symfony's
+ * Process + InputStream pairing so McpLoginJob can be tested against a
+ * scripted fake instead of spawning a real `script`/`claude` process.
+ */
+interface InteractiveProcess
+{
+    /**
+     * Output (stdout + stderr) produced since the last call to this
+     * method.
+     */
+    public function incrementalOutput(): string;
+
+    public function isRunning(): bool;
+
+    /**
+     * Write to the process's stdin. Only meaningful while the input stream
+     * is still open (see closeInput()).
+     */
+    public function write(string $data): void;
+
+    /** Closes stdin, signalling no more input is coming. */
+    public function closeInput(): void;
+
+    /** Sends a termination signal and gives the process a moment to exit. */
+    public function stop(): void;
+
+    /** Blocks until the process exits, returning its exit code. */
+    public function wait(): int;
+
+    public function isSuccessful(): bool;
+}

--- a/app/Services/InteractiveProcessFactory.php
+++ b/app/Services/InteractiveProcessFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * Starts InteractiveProcess instances. Swap this in the container (e.g.
+ * `$this->app->instance(InteractiveProcessFactory::class, $fake)` with a
+ * subclass overriding start()) to test McpLoginJob without spawning a real
+ * `script`/`claude` process.
+ */
+class InteractiveProcessFactory
+{
+    public function start(string $shellCommand, int $timeout): InteractiveProcess
+    {
+        return new SymfonyInteractiveProcess($shellCommand, $timeout);
+    }
+}

--- a/app/Services/McpServerReader.php
+++ b/app/Services/McpServerReader.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace App\Services;
+
+use App\ClaudeCli;
+use App\DataTransferObjects\McpServer;
+use App\Exceptions\ClaudeCliException;
+use Illuminate\Support\Collection;
+
+/**
+ * Reads the MCP servers Yak agents can reach: Ansible-provisioned "deploy"
+ * servers (read from the JSON file the deploy pipeline writes) and the
+ * "user"/"plugin" servers the `claude` CLI itself tracks (via `claude mcp
+ * list`, which also health-checks each one).
+ */
+class McpServerReader
+{
+    public function __construct(private readonly ClaudeCli $cli) {}
+
+    /**
+     * @return Collection<int, McpServer>
+     */
+    public function all(): Collection
+    {
+        return $this->deployServers()->concat($this->userServers());
+    }
+
+    /**
+     * @return Collection<int, McpServer>
+     */
+    public function deployServers(): Collection
+    {
+        $path = config('yak.mcp_config_path');
+
+        if (! is_string($path) || $path === '' || ! is_file($path)) {
+            return collect();
+        }
+
+        $data = json_decode((string) file_get_contents($path), true);
+
+        if (! is_array($data) || ! isset($data['mcpServers']) || ! is_array($data['mcpServers'])) {
+            return collect();
+        }
+
+        /** @var array<string, array<string, mixed>> $servers */
+        $servers = $data['mcpServers'];
+
+        return collect($servers)
+            ->map(function (array $config, string $name) {
+                $transport = $this->deployTransport($config);
+                $target = $this->deployTarget($config, $transport);
+
+                return new McpServer(
+                    name: $name,
+                    displayName: $this->displayName($name),
+                    target: $target,
+                    transport: $transport,
+                    source: 'deploy',
+                    pluginName: null,
+                    status: 'token',
+                    detail: null,
+                    canConnect: false,
+                    canLogout: false,
+                    canRemove: false,
+                    loginCommand: $this->loginCommand($name),
+                );
+            })
+            ->values();
+    }
+
+    /**
+     * @return Collection<int, McpServer>
+     */
+    public function userServers(): Collection
+    {
+        $result = $this->cli->exec('mcp list', timeout: 90);
+
+        if (! $result->successful()) {
+            $message = trim($result->errorOutput() ?: $result->output());
+
+            throw new ClaudeCliException("claude mcp list failed: {$message}");
+        }
+
+        $lines = preg_split('/\R/u', $result->output()) ?: [];
+
+        return collect($lines)
+            ->map(fn (string $line) => $this->parseLine($line))
+            ->filter()
+            ->values();
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function deployTransport(array $config): string
+    {
+        $type = is_string($config['type'] ?? null) ? $config['type'] : null;
+
+        if ($type !== null) {
+            return in_array($type, ['http', 'sse', 'stdio'], true) ? $type : 'unknown';
+        }
+
+        return isset($config['command']) ? 'stdio' : (isset($config['url']) ? 'http' : 'unknown');
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function deployTarget(array $config, string $transport): string
+    {
+        if ($transport === 'stdio') {
+            $command = is_string($config['command'] ?? null) ? $config['command'] : '';
+            $args = is_array($config['args'] ?? null) ? array_map('strval', $config['args']) : [];
+
+            return trim($command . ' ' . implode(' ', $args));
+        }
+
+        return is_string($config['url'] ?? null) ? $config['url'] : '';
+    }
+
+    private function parseLine(string $line): ?McpServer
+    {
+        $line = trim($line);
+
+        if ($line === '') {
+            return null;
+        }
+
+        $pattern = '/^(?<name>.+?): (?<target>.+?)(?: \((?<transport>HTTP|SSE|stdio)\))? - (?<mark>[✔!✘⏸]) (?<status>.+)$/u';
+
+        if (preg_match($pattern, $line, $matches) !== 1) {
+            return null;
+        }
+
+        $name = $matches['name'];
+        $target = $matches['target'];
+        $statusText = trim($matches['status']);
+
+        $isPlugin = str_starts_with($name, 'plugin:');
+        $pluginName = null;
+
+        if ($isPlugin) {
+            $segments = explode(':', $name, 3);
+            $pluginName = $segments[1] ?? null;
+        }
+
+        $status = $this->mapStatus($matches['mark'], $statusText);
+        $transportHint = ! empty($matches['transport']) ? $matches['transport'] : null;
+        $transport = $this->userTransport($transportHint, $target);
+
+        return new McpServer(
+            name: $name,
+            displayName: $this->displayName($name),
+            target: $target,
+            transport: $transport,
+            source: $isPlugin ? 'plugin' : 'user',
+            pluginName: $pluginName,
+            status: $status,
+            detail: $status === 'failed' ? $statusText : null,
+            canConnect: $status === 'needs_auth',
+            canLogout: $status === 'connected' && $transport !== 'stdio',
+            canRemove: ! $isPlugin,
+            loginCommand: $this->loginCommand($name),
+        );
+    }
+
+    private function mapStatus(string $mark, string $statusText): string
+    {
+        return match (true) {
+            $mark === '✔' => 'connected',
+            str_contains($statusText, 'Needs authentication') => 'needs_auth',
+            $mark === '✘' || str_contains($statusText, 'Failed to connect') => 'failed',
+            $mark === '⏸' || str_contains($statusText, 'Pending approval') => 'pending_approval',
+            default => 'unknown',
+        };
+    }
+
+    private function userTransport(?string $hint, string $target): string
+    {
+        if ($hint !== null) {
+            return mb_strtolower($hint);
+        }
+
+        return str_starts_with($target, 'http://') || str_starts_with($target, 'https://') ? 'http' : 'stdio';
+    }
+
+    private function displayName(string $name): string
+    {
+        if (! str_starts_with($name, 'plugin:')) {
+            return $name;
+        }
+
+        $segments = explode(':', $name);
+
+        return end($segments);
+    }
+
+    private function loginCommand(string $name): string
+    {
+        $arg = str_contains($name, ' ') ? '"' . str_replace('"', '\\"', $name) . '"' : $name;
+
+        return "yak-mcp login {$arg}";
+    }
+}

--- a/app/Services/SkillManager.php
+++ b/app/Services/SkillManager.php
@@ -6,8 +6,10 @@ use App\ClaudeCli;
 use App\DataTransferObjects\BundledSkill;
 use App\DataTransferObjects\InstalledPlugin;
 use App\DataTransferObjects\Marketplace;
+use App\DataTransferObjects\PluginUpdateResult;
 use App\Exceptions\ClaudeCliException;
 use Carbon\Carbon;
+use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Support\Collection;
 
 class SkillManager
@@ -154,9 +156,16 @@ class SkillManager
         $this->runOrThrow('plugins disable ' . escapeshellarg($plugin));
     }
 
-    public function update(string $plugin): void
+    /**
+     * `--yes` is required when stdin is not a TTY, which is always the case
+     * here; without it the CLI cannot confirm a marketplace-declared install
+     * command and aborts.
+     */
+    public function update(string $plugin): PluginUpdateResult
     {
-        $this->runOrThrow('plugins update ' . escapeshellarg($plugin), timeout: 180);
+        $result = $this->runOrThrow('plugins update ' . escapeshellarg($plugin) . ' --yes', timeout: 180);
+
+        return PluginUpdateResult::fromCliOutput($result->output());
     }
 
     public function addMarketplace(string $source): void
@@ -174,7 +183,7 @@ class SkillManager
         $this->runOrThrow('plugins marketplace update', timeout: 120);
     }
 
-    private function runOrThrow(string $args, int $timeout = 60): void
+    private function runOrThrow(string $args, int $timeout = 60): ProcessResult
     {
         $result = $this->cli->exec($args, $timeout);
 
@@ -183,6 +192,8 @@ class SkillManager
 
             throw new ClaudeCliException("claude {$args} failed: {$message}");
         }
+
+        return $result;
     }
 
     private function extractFrontMatterField(string $markdown, string $field): ?string

--- a/app/Services/SymfonyInteractiveProcess.php
+++ b/app/Services/SymfonyInteractiveProcess.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Services;
+
+use Symfony\Component\Process\InputStream;
+use Symfony\Component\Process\Process as SymfonyProcess;
+
+/**
+ * Real InteractiveProcess backed by Symfony Process + InputStream. Started
+ * eagerly in the constructor so InteractiveProcessFactory::start() hands
+ * back an already-running process.
+ */
+class SymfonyInteractiveProcess implements InteractiveProcess
+{
+    private readonly InputStream $input;
+
+    private readonly SymfonyProcess $process;
+
+    public function __construct(string $shellCommand, int $timeout)
+    {
+        $this->input = new InputStream;
+        $this->process = SymfonyProcess::fromShellCommandline($shellCommand);
+        $this->process->setTimeout($timeout);
+        $this->process->setInput($this->input);
+        $this->process->start();
+    }
+
+    public function incrementalOutput(): string
+    {
+        $this->process->checkTimeout();
+
+        return $this->process->getIncrementalOutput() . $this->process->getIncrementalErrorOutput();
+    }
+
+    public function isRunning(): bool
+    {
+        return $this->process->isRunning();
+    }
+
+    public function write(string $data): void
+    {
+        $this->input->write($data);
+    }
+
+    public function closeInput(): void
+    {
+        $this->input->close();
+    }
+
+    public function stop(): void
+    {
+        $this->process->stop(5);
+    }
+
+    public function wait(): int
+    {
+        return $this->process->wait();
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->process->isSuccessful();
+    }
+}

--- a/app/Support/McpLoginSession.php
+++ b/app/Support/McpLoginSession.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Cache-backed record of an in-progress `claude mcp login` run, driven by
+ * McpLoginController and McpLoginJob. Lives entirely in the cache (not the
+ * database) so a login started on one request and polled/finished across
+ * several others just needs a shared cache store — see
+ * config('yak.mcp_config_path') sibling behaviour for why this whole
+ * feature stays filesystem/CLI-backed rather than modeled.
+ *
+ * A small secondary index (`mcp-login:index`) tracks which server names
+ * currently have a session worth showing on the Settings > MCP servers
+ * page, since `servers` is an Inertia::defer'd prop and `loginSessions`
+ * is not — the index lets the controller build `loginSessions` without
+ * scanning every possible server name. Terminal sessions (succeeded,
+ * failed, expired, cancelled) stay in the index for two minutes after
+ * they finish so the UI has a chance to show the outcome, then age out.
+ */
+class McpLoginSession
+{
+    private const TTL_MINUTES = 15;
+
+    private const SESSION_DURATION_MINUTES = 10;
+
+    private const INDEX_TERMINAL_GRACE_MINUTES = 2;
+
+    /** @var array<int, string> */
+    public const TERMINAL_STATUSES = ['succeeded', 'failed', 'expired', 'cancelled'];
+
+    /** @var array<int, string> */
+    public const ACTIVE_STATUSES = ['starting', 'awaiting_redirect', 'finishing'];
+
+    public function __construct(
+        public string $server,
+        public string $status,
+        public ?string $authorizationUrl,
+        public ?string $error,
+        public Carbon $startedAt,
+        public Carbon $expiresAt,
+        public ?string $redirectUrl = null,
+    ) {}
+
+    public static function find(string $name): ?self
+    {
+        /** @var array<string, mixed>|null $data */
+        $data = Cache::get(self::cacheKey($name));
+
+        if (! is_array($data)) {
+            return null;
+        }
+
+        return self::fromArray($data);
+    }
+
+    public static function start(string $name): self
+    {
+        $now = Carbon::now();
+
+        $session = new self(
+            server: $name,
+            status: 'starting',
+            authorizationUrl: null,
+            error: null,
+            startedAt: $now,
+            expiresAt: $now->clone()->addMinutes(self::SESSION_DURATION_MINUTES),
+        );
+
+        $session->save();
+
+        return $session;
+    }
+
+    public function save(): void
+    {
+        Cache::put(self::cacheKey($this->server), $this->toStorageArray(), now()->addMinutes(self::TTL_MINUTES));
+
+        self::updateIndex($this->server, $this->status);
+    }
+
+    public function delete(): void
+    {
+        Cache::forget(self::cacheKey($this->server));
+        self::removeFromIndex($this->server);
+    }
+
+    public function isTerminal(): bool
+    {
+        return in_array($this->status, self::TERMINAL_STATUSES, true);
+    }
+
+    /**
+     * Server names with a session worth showing on the page, pruning any
+     * whose terminal grace period has elapsed.
+     *
+     * @return array<int, string>
+     */
+    public static function activeNames(): array
+    {
+        /** @var array<string, ?string> $index */
+        $index = Cache::get(self::indexKey(), []);
+
+        $changed = false;
+        $names = [];
+
+        foreach ($index as $name => $terminalAt) {
+            if ($terminalAt !== null && Carbon::parse($terminalAt)->lt(now()->subMinutes(self::INDEX_TERMINAL_GRACE_MINUTES))) {
+                unset($index[$name]);
+                $changed = true;
+
+                continue;
+            }
+
+            $names[] = $name;
+        }
+
+        if ($changed) {
+            Cache::put(self::indexKey(), $index, now()->addMinutes(self::TTL_MINUTES));
+        }
+
+        return $names;
+    }
+
+    /**
+     * @return array{server: string, status: string, authorizationUrl: ?string, error: ?string, startedAt: string, expiresAt: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'server' => $this->server,
+            'status' => $this->status,
+            'authorizationUrl' => $this->authorizationUrl,
+            'error' => $this->error,
+            'startedAt' => $this->startedAt->toIso8601String(),
+            'expiresAt' => $this->expiresAt->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function toStorageArray(): array
+    {
+        return [
+            'server' => $this->server,
+            'status' => $this->status,
+            'authorizationUrl' => $this->authorizationUrl,
+            'error' => $this->error,
+            'startedAt' => $this->startedAt->toIso8601String(),
+            'expiresAt' => $this->expiresAt->toIso8601String(),
+            'redirectUrl' => $this->redirectUrl,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private static function fromArray(array $data): self
+    {
+        return new self(
+            server: (string) $data['server'],
+            status: (string) $data['status'],
+            authorizationUrl: isset($data['authorizationUrl']) ? (string) $data['authorizationUrl'] : null,
+            error: isset($data['error']) ? (string) $data['error'] : null,
+            startedAt: Carbon::parse((string) $data['startedAt']),
+            expiresAt: Carbon::parse((string) $data['expiresAt']),
+            redirectUrl: isset($data['redirectUrl']) ? (string) $data['redirectUrl'] : null,
+        );
+    }
+
+    private static function updateIndex(string $name, string $status): void
+    {
+        /** @var array<string, ?string> $index */
+        $index = Cache::get(self::indexKey(), []);
+
+        $index[$name] = in_array($status, self::TERMINAL_STATUSES, true) ? now()->toIso8601String() : null;
+
+        Cache::put(self::indexKey(), $index, now()->addMinutes(self::TTL_MINUTES));
+    }
+
+    private static function removeFromIndex(string $name): void
+    {
+        /** @var array<string, ?string> $index */
+        $index = Cache::get(self::indexKey(), []);
+
+        unset($index[$name]);
+
+        Cache::put(self::indexKey(), $index, now()->addMinutes(self::TTL_MINUTES));
+    }
+
+    private static function cacheKey(string $name): string
+    {
+        return "mcp-login:{$name}";
+    }
+
+    private static function indexKey(): string
+    {
+        return 'mcp-login:index';
+    }
+}

--- a/config/docs.php
+++ b/config/docs.php
@@ -57,7 +57,15 @@ return [
         'repositories.adding' => 'repositories/#adding-a-repository',
         'repositories.setup' => 'repositories/#the-setup-task',
         'repositories.claude-md' => 'repositories/#claudemd-the-highest-leverage-config-point',
+        'repositories.management' => 'repositories/#repo-management-pages',
+        'repositories.multi-repo' => 'repositories/#multi-repo-requests',
+        'repositories.pr-review' => 'repositories/#pr-review-toggle',
+        'repositories.refresh' => 'repositories/#repo-refresh',
+        'repositories.rerun-setup' => 'repositories/#re-running-setup',
         'repositories.routing' => 'repositories/#routing-tasks-to-repos',
+
+        // PR review
+        'pr-review' => 'pr-review/',
 
         // Architecture
         'architecture' => 'architecture/',

--- a/config/yak.php
+++ b/config/yak.php
@@ -155,6 +155,27 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Recommended plugins
+    |--------------------------------------------------------------------------
+    |
+    | Plugin names highlighted in the Skills page "Recommended" section when
+    | not yet installed. Order here is the display order.
+    */
+
+    'recommended_plugins' => [
+        'code-review',
+        'pr-review-toolkit',
+        'security-guidance',
+        'feature-dev',
+        'code-simplifier',
+        'commit-commands',
+        'context7',
+        'playwright',
+        'sentry',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | API Keys
     |--------------------------------------------------------------------------
     */

--- a/config/yak.php
+++ b/config/yak.php
@@ -126,6 +126,15 @@ return [
 
     'mcp_config_path' => env('YAK_MCP_CONFIG_PATH'),
 
+    // SSH host the Settings > MCP servers page shows for running `yak-mcp`
+    // commands directly on the box (e.g. to complete a login without going
+    // through the browser flow). Null hides the ssh prefix and shows a hint
+    // to configure it instead.
+    'ssh_host' => env('YAK_SSH_HOST'),
+
+    // Docker container name used in the same page's ssh command hints.
+    'container_name' => env('YAK_CONTAINER_NAME', 'yak'),
+
     /*
     |--------------------------------------------------------------------------
     | Claude Code plugin / skill paths

--- a/resources/js/actions/App/Http/Controllers/Repositories/RepositoryController.ts
+++ b/resources/js/actions/App/Http/Controllers/Repositories/RepositoryController.ts
@@ -191,7 +191,7 @@ edit.head = (args: { repository: string | number | { slug: string | number } } |
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::update
-* @see app/Http/Controllers/Repositories/RepositoryController.php:93
+* @see app/Http/Controllers/Repositories/RepositoryController.php:110
 * @route '/repos/{repository}'
 */
 export const update = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -206,7 +206,7 @@ update.definition = {
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::update
-* @see app/Http/Controllers/Repositories/RepositoryController.php:93
+* @see app/Http/Controllers/Repositories/RepositoryController.php:110
 * @route '/repos/{repository}'
 */
 update.url = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions) => {
@@ -239,7 +239,7 @@ update.url = (args: { repository: string | number | { slug: string | number } } 
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::update
-* @see app/Http/Controllers/Repositories/RepositoryController.php:93
+* @see app/Http/Controllers/Repositories/RepositoryController.php:110
 * @route '/repos/{repository}'
 */
 update.patch = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -249,7 +249,7 @@ update.patch = (args: { repository: string | number | { slug: string | number } 
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::destroy
-* @see app/Http/Controllers/Repositories/RepositoryController.php:124
+* @see app/Http/Controllers/Repositories/RepositoryController.php:141
 * @route '/repos/{repository}'
 */
 export const destroy = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -264,7 +264,7 @@ destroy.definition = {
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::destroy
-* @see app/Http/Controllers/Repositories/RepositoryController.php:124
+* @see app/Http/Controllers/Repositories/RepositoryController.php:141
 * @route '/repos/{repository}'
 */
 destroy.url = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions) => {
@@ -297,7 +297,7 @@ destroy.url = (args: { repository: string | number | { slug: string | number } }
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::destroy
-* @see app/Http/Controllers/Repositories/RepositoryController.php:124
+* @see app/Http/Controllers/Repositories/RepositoryController.php:141
 * @route '/repos/{repository}'
 */
 destroy.delete = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({

--- a/resources/js/actions/App/Http/Controllers/Settings/McpLoginController.ts
+++ b/resources/js/actions/App/Http/Controllers/Settings/McpLoginController.ts
@@ -1,0 +1,160 @@
+import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../wayfinder'
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::redirect
+* @see app/Http/Controllers/Settings/McpLoginController.php:28
+* @route '/settings/mcp/{name}/login/redirect'
+*/
+export const redirect = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: redirect.url(args, options),
+    method: 'post',
+})
+
+redirect.definition = {
+    methods: ["post"],
+    url: '/settings/mcp/{name}/login/redirect',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::redirect
+* @see app/Http/Controllers/Settings/McpLoginController.php:28
+* @route '/settings/mcp/{name}/login/redirect'
+*/
+redirect.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { name: args }
+    }
+
+    if (Array.isArray(args)) {
+        args = {
+            name: args[0],
+        }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+        name: args.name,
+    }
+
+    return redirect.definition.url
+            .replace('{name}', parsedArgs.name.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::redirect
+* @see app/Http/Controllers/Settings/McpLoginController.php:28
+* @route '/settings/mcp/{name}/login/redirect'
+*/
+redirect.post = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: redirect.url(args, options),
+    method: 'post',
+})
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::start
+* @see app/Http/Controllers/Settings/McpLoginController.php:13
+* @route '/settings/mcp/{name}/login'
+*/
+export const start = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: start.url(args, options),
+    method: 'post',
+})
+
+start.definition = {
+    methods: ["post"],
+    url: '/settings/mcp/{name}/login',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::start
+* @see app/Http/Controllers/Settings/McpLoginController.php:13
+* @route '/settings/mcp/{name}/login'
+*/
+start.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { name: args }
+    }
+
+    if (Array.isArray(args)) {
+        args = {
+            name: args[0],
+        }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+        name: args.name,
+    }
+
+    return start.definition.url
+            .replace('{name}', parsedArgs.name.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::start
+* @see app/Http/Controllers/Settings/McpLoginController.php:13
+* @route '/settings/mcp/{name}/login'
+*/
+start.post = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: start.url(args, options),
+    method: 'post',
+})
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::cancel
+* @see app/Http/Controllers/Settings/McpLoginController.php:53
+* @route '/settings/mcp/{name}/login'
+*/
+export const cancel = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: cancel.url(args, options),
+    method: 'delete',
+})
+
+cancel.definition = {
+    methods: ["delete"],
+    url: '/settings/mcp/{name}/login',
+} satisfies RouteDefinition<["delete"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::cancel
+* @see app/Http/Controllers/Settings/McpLoginController.php:53
+* @route '/settings/mcp/{name}/login'
+*/
+cancel.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { name: args }
+    }
+
+    if (Array.isArray(args)) {
+        args = {
+            name: args[0],
+        }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+        name: args.name,
+    }
+
+    return cancel.definition.url
+            .replace('{name}', parsedArgs.name.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::cancel
+* @see app/Http/Controllers/Settings/McpLoginController.php:53
+* @route '/settings/mcp/{name}/login'
+*/
+cancel.delete = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: cancel.url(args, options),
+    method: 'delete',
+})
+
+const McpLoginController = { redirect, start, cancel }
+
+export default McpLoginController

--- a/resources/js/actions/App/Http/Controllers/Settings/McpServerController.ts
+++ b/resources/js/actions/App/Http/Controllers/Settings/McpServerController.ts
@@ -1,0 +1,186 @@
+import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../wayfinder'
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::index
+* @see app/Http/Controllers/Settings/McpServerController.php:25
+* @route '/settings/mcp'
+*/
+export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index.url(options),
+    method: 'get',
+})
+
+index.definition = {
+    methods: ["get","head"],
+    url: '/settings/mcp',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::index
+* @see app/Http/Controllers/Settings/McpServerController.php:25
+* @route '/settings/mcp'
+*/
+index.url = (options?: RouteQueryOptions) => {
+    return index.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::index
+* @see app/Http/Controllers/Settings/McpServerController.php:25
+* @route '/settings/mcp'
+*/
+index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index.url(options),
+    method: 'get',
+})
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::index
+* @see app/Http/Controllers/Settings/McpServerController.php:25
+* @route '/settings/mcp'
+*/
+index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index.url(options),
+    method: 'head',
+})
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::store
+* @see app/Http/Controllers/Settings/McpServerController.php:40
+* @route '/settings/mcp'
+*/
+export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store.url(options),
+    method: 'post',
+})
+
+store.definition = {
+    methods: ["post"],
+    url: '/settings/mcp',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::store
+* @see app/Http/Controllers/Settings/McpServerController.php:40
+* @route '/settings/mcp'
+*/
+store.url = (options?: RouteQueryOptions) => {
+    return store.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::store
+* @see app/Http/Controllers/Settings/McpServerController.php:40
+* @route '/settings/mcp'
+*/
+store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store.url(options),
+    method: 'post',
+})
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::logout
+* @see app/Http/Controllers/Settings/McpServerController.php:107
+* @route '/settings/mcp/{name}/logout'
+*/
+export const logout = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: logout.url(args, options),
+    method: 'post',
+})
+
+logout.definition = {
+    methods: ["post"],
+    url: '/settings/mcp/{name}/logout',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::logout
+* @see app/Http/Controllers/Settings/McpServerController.php:107
+* @route '/settings/mcp/{name}/logout'
+*/
+logout.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { name: args }
+    }
+
+    if (Array.isArray(args)) {
+        args = {
+            name: args[0],
+        }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+        name: args.name,
+    }
+
+    return logout.definition.url
+            .replace('{name}', parsedArgs.name.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::logout
+* @see app/Http/Controllers/Settings/McpServerController.php:107
+* @route '/settings/mcp/{name}/logout'
+*/
+logout.post = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: logout.url(args, options),
+    method: 'post',
+})
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::destroy
+* @see app/Http/Controllers/Settings/McpServerController.php:80
+* @route '/settings/mcp/{name}'
+*/
+export const destroy = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy.url(args, options),
+    method: 'delete',
+})
+
+destroy.definition = {
+    methods: ["delete"],
+    url: '/settings/mcp/{name}',
+} satisfies RouteDefinition<["delete"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::destroy
+* @see app/Http/Controllers/Settings/McpServerController.php:80
+* @route '/settings/mcp/{name}'
+*/
+destroy.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { name: args }
+    }
+
+    if (Array.isArray(args)) {
+        args = {
+            name: args[0],
+        }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+        name: args.name,
+    }
+
+    return destroy.definition.url
+            .replace('{name}', parsedArgs.name.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::destroy
+* @see app/Http/Controllers/Settings/McpServerController.php:80
+* @route '/settings/mcp/{name}'
+*/
+destroy.delete = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy.url(args, options),
+    method: 'delete',
+})
+
+const McpServerController = { index, store, logout, destroy }
+
+export default McpServerController

--- a/resources/js/actions/App/Http/Controllers/Settings/index.ts
+++ b/resources/js/actions/App/Http/Controllers/Settings/index.ts
@@ -2,12 +2,16 @@ import ProfileController from './ProfileController'
 import AccountController from './AccountController'
 import LinearConnectionController from './LinearConnectionController'
 import VideoThemeController from './VideoThemeController'
+import McpServerController from './McpServerController'
+import McpLoginController from './McpLoginController'
 
 const Settings = {
     ProfileController: Object.assign(ProfileController, ProfileController),
     AccountController: Object.assign(AccountController, AccountController),
     LinearConnectionController: Object.assign(LinearConnectionController, LinearConnectionController),
     VideoThemeController: Object.assign(VideoThemeController, VideoThemeController),
+    McpServerController: Object.assign(McpServerController, McpServerController),
+    McpLoginController: Object.assign(McpLoginController, McpLoginController),
 }
 
 export default Settings

--- a/resources/js/actions/App/Http/Controllers/SkillController.ts
+++ b/resources/js/actions/App/Http/Controllers/SkillController.ts
@@ -45,7 +45,7 @@ index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
 
 /**
 * @see \App\Http\Controllers\SkillController::store
-* @see app/Http/Controllers/SkillController.php:46
+* @see app/Http/Controllers/SkillController.php:50
 * @route '/skills'
 */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -60,7 +60,7 @@ store.definition = {
 
 /**
 * @see \App\Http\Controllers\SkillController::store
-* @see app/Http/Controllers/SkillController.php:46
+* @see app/Http/Controllers/SkillController.php:50
 * @route '/skills'
 */
 store.url = (options?: RouteQueryOptions) => {
@@ -69,7 +69,7 @@ store.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\SkillController::store
-* @see app/Http/Controllers/SkillController.php:46
+* @see app/Http/Controllers/SkillController.php:50
 * @route '/skills'
 */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -79,7 +79,7 @@ store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
 
 /**
 * @see \App\Http\Controllers\SkillController::update
-* @see app/Http/Controllers/SkillController.php:66
+* @see app/Http/Controllers/SkillController.php:70
 * @route '/skills/{name}'
 */
 export const update = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -94,7 +94,7 @@ update.definition = {
 
 /**
 * @see \App\Http\Controllers\SkillController::update
-* @see app/Http/Controllers/SkillController.php:66
+* @see app/Http/Controllers/SkillController.php:70
 * @route '/skills/{name}'
 */
 update.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
@@ -121,7 +121,7 @@ update.url = (args: { name: string | number } | [name: string | number ] | strin
 
 /**
 * @see \App\Http\Controllers\SkillController::update
-* @see app/Http/Controllers/SkillController.php:66
+* @see app/Http/Controllers/SkillController.php:70
 * @route '/skills/{name}'
 */
 update.patch = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -131,7 +131,7 @@ update.patch = (args: { name: string | number } | [name: string | number ] | str
 
 /**
 * @see \App\Http\Controllers\SkillController::upgrade
-* @see app/Http/Controllers/SkillController.php:90
+* @see app/Http/Controllers/SkillController.php:94
 * @route '/skills/{name}/update'
 */
 export const upgrade = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -146,7 +146,7 @@ upgrade.definition = {
 
 /**
 * @see \App\Http\Controllers\SkillController::upgrade
-* @see app/Http/Controllers/SkillController.php:90
+* @see app/Http/Controllers/SkillController.php:94
 * @route '/skills/{name}/update'
 */
 upgrade.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
@@ -173,7 +173,7 @@ upgrade.url = (args: { name: string | number } | [name: string | number ] | stri
 
 /**
 * @see \App\Http\Controllers\SkillController::upgrade
-* @see app/Http/Controllers/SkillController.php:90
+* @see app/Http/Controllers/SkillController.php:94
 * @route '/skills/{name}/update'
 */
 upgrade.post = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -183,7 +183,7 @@ upgrade.post = (args: { name: string | number } | [name: string | number ] | str
 
 /**
 * @see \App\Http\Controllers\SkillController::destroy
-* @see app/Http/Controllers/SkillController.php:81
+* @see app/Http/Controllers/SkillController.php:85
 * @route '/skills/{name}'
 */
 export const destroy = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -198,7 +198,7 @@ destroy.definition = {
 
 /**
 * @see \App\Http\Controllers\SkillController::destroy
-* @see app/Http/Controllers/SkillController.php:81
+* @see app/Http/Controllers/SkillController.php:85
 * @route '/skills/{name}'
 */
 destroy.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
@@ -225,7 +225,7 @@ destroy.url = (args: { name: string | number } | [name: string | number ] | stri
 
 /**
 * @see \App\Http\Controllers\SkillController::destroy
-* @see app/Http/Controllers/SkillController.php:81
+* @see app/Http/Controllers/SkillController.php:85
 * @route '/skills/{name}'
 */
 destroy.delete = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({

--- a/resources/js/components/repositories/ToggleRow.tsx
+++ b/resources/js/components/repositories/ToggleRow.tsx
@@ -1,4 +1,5 @@
 import { Toggle } from '@geocodio/console-ui';
+import { BookOpen } from 'lucide-react';
 
 export function ToggleRow({
     label,
@@ -6,18 +7,30 @@ export function ToggleRow({
     checked,
     onChange,
     id,
+    docsHref,
 }: {
     label: string;
     description: string;
     checked: boolean;
     onChange: (value: boolean) => void;
     id?: string;
+    docsHref?: string;
 }) {
     return (
         <div id={id} className="flex items-start justify-between gap-6 rounded-card border border-hair bg-panel px-4 py-3 shadow-card">
             <div>
                 <div className="text-[13px] font-medium">{label}</div>
                 <div className="mt-0.5 text-[12px] text-muted">{description}</div>
+                {docsHref && (
+                    <a
+                        href={docsHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-2 inline-flex items-center gap-1 text-[12px] text-accent-text hover:underline"
+                    >
+                        <BookOpen size={12} /> Docs
+                    </a>
+                )}
             </div>
             <Toggle checked={checked} onCheckedChange={onChange} label={label} className="mt-0.5" />
         </div>

--- a/resources/js/components/settings/mcp/AddMcpServerDialog.tsx
+++ b/resources/js/components/settings/mcp/AddMcpServerDialog.tsx
@@ -1,0 +1,104 @@
+import { Button, Dialog, Field, Select, Textarea, TextInput } from '@geocodio/console-ui';
+import { useForm } from '@inertiajs/react';
+import { useEffect } from 'react';
+import mcp from '@/routes/settings/mcp';
+
+type Transport = 'http' | 'sse' | 'stdio';
+
+const TRANSPORT_OPTIONS: { value: Transport; label: string }[] = [
+    { value: 'http', label: 'HTTP' },
+    { value: 'sse', label: 'SSE' },
+    { value: 'stdio', label: 'Command' },
+];
+
+export function AddMcpServerDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
+    const form = useForm<{ name: string; transport: Transport; target: string; headers: string }>({
+        name: '',
+        transport: 'http',
+        target: '',
+        headers: '',
+    });
+
+    useEffect(() => {
+        if (open) {
+            form.reset();
+            form.clearErrors();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open]);
+
+    const submit = () => {
+        form.post(mcp.store.url(), {
+            preserveScroll: true,
+            onSuccess: () => onOpenChange(false),
+        });
+    };
+
+    const isCommand = form.data.transport === 'stdio';
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={onOpenChange}
+            title="Add MCP server"
+            description="Added to the shared Claude Code config, so every sandbox sees it on its next run. Remote servers that use OAuth ask for a login afterwards."
+            footer={
+                <>
+                    <Button variant="tertiary" onClick={() => onOpenChange(false)}>
+                        Cancel
+                    </Button>
+                    <Button variant="primary" pending={form.processing} pendingLabel="Adding…" onClick={submit} data-testid="mcp-add-server-submit">
+                        Add server
+                    </Button>
+                </>
+            }
+        >
+            <div className="flex flex-col gap-4">
+                <Field label="Name" description="Letters, digits and dashes. This is the name agents see." error={form.errors.name}>
+                    <TextInput
+                        autoFocus
+                        placeholder="my-server"
+                        value={form.data.name}
+                        onChange={(e) => form.setData('name', e.target.value)}
+                        data-testid="mcp-server-name"
+                    />
+                </Field>
+
+                <Field label="Transport" error={form.errors.transport}>
+                    <Select
+                        options={TRANSPORT_OPTIONS}
+                        value={form.data.transport}
+                        onChange={(value) => form.setData('transport', (value ?? 'http') as Transport)}
+                        data-testid="mcp-server-transport"
+                    />
+                </Field>
+
+                <Field
+                    label={isCommand ? 'Command' : 'URL'}
+                    error={form.errors.target}
+                >
+                    <TextInput
+                        placeholder={isCommand ? 'npx -y my-mcp-server' : 'https://example.com/mcp'}
+                        value={form.data.target}
+                        onChange={(e) => form.setData('target', e.target.value)}
+                        data-testid="mcp-server-target"
+                    />
+                </Field>
+
+                <Field
+                    label="Headers"
+                    description="One per line. Leave empty for servers that log in with OAuth. For a command, this becomes environment variables (KEY=value)."
+                    error={form.errors.headers}
+                >
+                    <Textarea
+                        rows={3}
+                        placeholder={isCommand ? 'API_KEY=...' : 'Authorization: Bearer ...'}
+                        value={form.data.headers}
+                        onChange={(e) => form.setData('headers', e.target.value)}
+                        data-testid="mcp-server-headers"
+                    />
+                </Field>
+            </div>
+        </Dialog>
+    );
+}

--- a/resources/js/components/settings/mcp/McpLoginPanel.tsx
+++ b/resources/js/components/settings/mcp/McpLoginPanel.tsx
@@ -1,0 +1,229 @@
+import { Button, TextInput, cn } from '@geocodio/console-ui';
+import { CheckCircle2, Clock, ExternalLink, Loader2, XCircle } from 'lucide-react';
+import { useState } from 'react';
+import { useRouterAction } from '@/lib/useRouterAction';
+import mcp from '@/routes/settings/mcp';
+import type { McpLoginSessionData, McpServerRow } from '@/types/settings';
+
+type StepState = 'done' | 'current' | 'upcoming';
+
+export function McpLoginPanel({
+    server,
+    session,
+    sshHost,
+    onDismiss,
+    onRetry,
+}: {
+    server: McpServerRow;
+    session: McpLoginSessionData;
+    sshHost: string | null;
+    onDismiss: () => void;
+    onRetry: () => void;
+}) {
+    const action = useRouterAction();
+    const [redirectUrl, setRedirectUrl] = useState('');
+    const sshLoginCommand = sshHost ? `ssh -t root@${sshHost} ${server.loginCommand}` : server.loginCommand;
+
+    const finish = () => {
+        action.run('finish-login', 'post', mcp.login.redirect.url(server.name), { redirectUrl });
+    };
+
+    const cancel = () => {
+        action.run(`login-cancel-${server.name}`, 'delete', mcp.login.cancel.url(server.name));
+    };
+
+    return (
+        <div className="border-t border-hair bg-accent-soft/40 px-4 py-4" data-testid={`mcp-login-panel-${server.name}`}>
+            <div className="rounded-card border border-hair bg-panel p-4 shadow-card">
+                <Stepper session={session} />
+
+                <div className="mt-4">
+                    {session.status === 'starting' && (
+                        <div className="flex items-center gap-2 text-[12.5px] text-muted">
+                            <Loader2 size={14} className="animate-spin" />
+                            Asking {server.displayName} for an authorization link…
+                        </div>
+                    )}
+
+                    {session.status === 'awaiting_redirect' && (
+                        <div className="flex flex-col gap-3">
+                            <p className="text-[12.5px] leading-relaxed text-muted">
+                                Open the authorization page, approve access, then copy the localhost address the browser lands on &mdash; it will
+                                not load, that&apos;s expected &mdash; and paste it below.
+                            </p>
+                            <div className="flex items-center gap-3">
+                                {session.authorizationUrl && (
+                                    <a href={session.authorizationUrl} target="_blank" rel="noopener noreferrer">
+                                        <Button variant="primary" icon={<ExternalLink size={13} />} data-testid="mcp-open-authorization">
+                                            Open authorization page
+                                        </Button>
+                                    </a>
+                                )}
+                                <button
+                                    type="button"
+                                    className="text-[12px] text-muted underline"
+                                    onClick={() => session.authorizationUrl && navigator.clipboard.writeText(session.authorizationUrl)}
+                                >
+                                    Copy link
+                                </button>
+                            </div>
+                            {session.authorizationUrl && (
+                                <div className="truncate font-mono text-[11.5px] text-faint">{session.authorizationUrl}</div>
+                            )}
+                            <div className="flex items-center gap-2">
+                                <TextInput
+                                    value={redirectUrl}
+                                    onChange={(e) => setRedirectUrl(e.target.value)}
+                                    placeholder="http://localhost:PORT/callback?code=..."
+                                    className="flex-1"
+                                    data-testid="mcp-redirect-input"
+                                />
+                                <Button
+                                    variant="primary"
+                                    pending={action.isPending('finish-login')}
+                                    disabled={redirectUrl.trim() === ''}
+                                    onClick={finish}
+                                    data-testid="mcp-finish-login"
+                                >
+                                    Finish connecting
+                                </Button>
+                            </div>
+                        </div>
+                    )}
+
+                    {session.status === 'finishing' && (
+                        <div className="flex items-center gap-2 text-[12.5px] text-muted">
+                            <Loader2 size={14} className="animate-spin" />
+                            Finishing…
+                        </div>
+                    )}
+
+                    {session.status === 'succeeded' && (
+                        <SuccessCard displayName={server.displayName} onDismiss={onDismiss} />
+                    )}
+
+                    {session.status === 'failed' && <FailedCard error={session.error} onRetry={onRetry} />}
+
+                    {(session.status === 'expired' || session.status === 'cancelled') && (
+                        <NeutralOutcomeCard status={session.status} onRetry={onRetry} />
+                    )}
+                </div>
+
+                {(session.status === 'starting' || session.status === 'awaiting_redirect' || session.status === 'finishing') && (
+                    <div className="mt-4 flex items-center justify-between border-t border-hair pt-3 text-[11.5px] text-faint">
+                        <span className="flex flex-col gap-0.5">
+                            <span className="flex items-center gap-1.5">
+                                <Clock size={12} />
+                                This login session stays open for 10 minutes.
+                            </span>
+                            <span>
+                                Prefer the terminal? <code className="font-mono">{sshLoginCommand}</code>
+                            </span>
+                        </span>
+                        <div className="flex items-center gap-3">
+                            {session.status === 'awaiting_redirect' && session.authorizationUrl && (
+                                <a href={session.authorizationUrl} target="_blank" rel="noopener noreferrer" className="underline">
+                                    Lost the page? Reopen the authorization link
+                                </a>
+                            )}
+                            <button type="button" className="underline" onClick={cancel}>
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function Stepper({ session }: { session: McpLoginSessionData }) {
+    const authorizeState: StepState = session.authorizationUrl || session.status === 'finishing' || session.status === 'succeeded' ? 'done' : 'current';
+    const pasteState: StepState =
+        session.status === 'finishing' || session.status === 'succeeded'
+            ? 'done'
+            : session.status === 'awaiting_redirect'
+              ? 'current'
+              : 'upcoming';
+    const doneState: StepState = session.status === 'succeeded' ? 'done' : session.status === 'finishing' ? 'current' : 'upcoming';
+
+    const steps: { label: string; state: StepState }[] = [
+        { label: 'Authorize', state: authorizeState },
+        { label: 'Paste the redirect URL', state: pasteState },
+        { label: 'Done', state: doneState },
+    ];
+
+    return (
+        <ol className="flex items-center gap-4">
+            {steps.map((step, index) => (
+                <li key={step.label} className="flex items-center gap-2">
+                    {step.state === 'done' ? (
+                        <CheckCircle2 size={15} className="text-ok" />
+                    ) : (
+                        <span
+                            className={cn(
+                                'flex size-[15px] items-center justify-center rounded-full border',
+                                step.state === 'current' ? 'border-accent bg-accent text-white' : 'border-hair',
+                            )}
+                        />
+                    )}
+                    <span className={cn('text-[12px]', step.state === 'upcoming' ? 'text-faint' : 'text-body')}>{step.label}</span>
+                    {index < steps.length - 1 && <span className="ml-2 h-px w-6 bg-hair" />}
+                </li>
+            ))}
+        </ol>
+    );
+}
+
+function SuccessCard({ displayName, onDismiss }: { displayName: string; onDismiss: () => void }) {
+    return (
+        <div className="flex items-start gap-3 rounded-card border border-ok/30 bg-panel p-3">
+            <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-ok-soft text-ok">
+                <CheckCircle2 size={16} />
+            </div>
+            <div className="flex-1">
+                <div className="text-[13px] font-medium">{displayName} is connected</div>
+                <p className="mt-1 text-[12px] leading-relaxed text-muted">
+                    The credential is stored in the shared Claude Code config, so every sandbox picks it up on its next run. Tokens refresh on
+                    their own.
+                </p>
+            </div>
+            <button type="button" className="shrink-0 text-[12px] text-muted underline" onClick={onDismiss}>
+                Dismiss
+            </button>
+        </div>
+    );
+}
+
+function FailedCard({ error, onRetry }: { error: string | null; onRetry: () => void }) {
+    return (
+        <div className="flex items-start gap-3 rounded-card border border-fail/30 bg-panel p-3">
+            <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-fail-soft text-fail">
+                <XCircle size={16} />
+            </div>
+            <div className="flex-1">
+                <div className="text-[13px] font-medium">Could not complete the login</div>
+                {error && <pre className="mt-2 whitespace-pre-wrap rounded-control bg-panel-2 p-2 font-mono text-[11.5px] text-fail">{error}</pre>}
+                <p className="mt-2 text-[12px] leading-relaxed text-muted">
+                    Start again, and paste the redirect URL within ten minutes of approving.
+                </p>
+                <Button variant="primary" className="mt-3 h-7 px-2.5 text-[12px]" onClick={onRetry}>
+                    Try again
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+function NeutralOutcomeCard({ status, onRetry }: { status: 'expired' | 'cancelled'; onRetry: () => void }) {
+    return (
+        <div className="flex items-start gap-3 rounded-card border border-hair bg-panel p-3">
+            <div className="flex-1">
+                <div className="text-[13px] font-medium">Login {status === 'expired' ? 'expired' : 'cancelled'}</div>
+                <Button variant="primary" className="mt-3 h-7 px-2.5 text-[12px]" onClick={onRetry}>
+                    Try again
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/settings/mcp/McpServerTable.tsx
+++ b/resources/js/components/settings/mcp/McpServerTable.tsx
@@ -1,0 +1,191 @@
+import { Link, router } from '@inertiajs/react';
+import { Badge, Button, cn } from '@geocodio/console-ui';
+import { useState } from 'react';
+import { skills } from '@/routes';
+import { useRouterAction } from '@/lib/useRouterAction';
+import { McpLoginPanel } from '@/components/settings/mcp/McpLoginPanel';
+import mcp from '@/routes/settings/mcp';
+import type { McpLoginSessionData, McpServerRow } from '@/types/settings';
+
+const ACTIVE_STATUSES: McpLoginSessionData['status'][] = ['starting', 'awaiting_redirect', 'finishing'];
+
+const GRID_COLS = 'grid-cols-[1.2fr_2fr_150px_170px_160px]';
+
+export function McpServerTable({
+    servers,
+    loginSessions,
+    sshHost,
+    onRemove,
+}: {
+    servers: McpServerRow[];
+    loginSessions: Record<string, McpLoginSessionData>;
+    sshHost: string | null;
+    onRemove: (server: McpServerRow) => void;
+}) {
+    const action = useRouterAction();
+    const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+    const [rechecking, setRechecking] = useState<string | null>(null);
+
+    const recheckRow = (name: string) => {
+        setRechecking(name);
+        router.reload({ only: ['servers', 'checkedAgo'], onFinish: () => setRechecking(null) });
+    };
+
+    const startLogin = (name: string) => {
+        setDismissed((prev) => {
+            if (!prev.has(name)) {
+                return prev;
+            }
+            const next = new Set(prev);
+            next.delete(name);
+            return next;
+        });
+        action.run(`login-start-${name}`, 'post', mcp.login.start.url(name));
+    };
+
+    return (
+        <div className="overflow-hidden rounded-card border border-hair bg-panel shadow-card">
+            <div className={cn('grid gap-2 border-b border-hair bg-panel-2 px-4 py-2 text-[11.5px] font-medium text-faint', GRID_COLS)}>
+                <span>Server</span>
+                <span>Command or URL</span>
+                <span>Source</span>
+                <span>Status</span>
+                <span />
+            </div>
+
+            {servers.map((server) => {
+                const session = loginSessions[server.name];
+                const showPanel = !!session && !dismissed.has(server.name);
+                const sessionActive = !!session && ACTIVE_STATUSES.includes(session.status);
+
+                return (
+                    <div key={server.name} className="border-b border-hair last:border-b-0" data-testid={`mcp-row-${server.name}`}>
+                        <div className={cn('grid items-center gap-2 px-4 py-3', GRID_COLS)}>
+                            <div>
+                                <div className="text-[13px] font-medium">{server.displayName}</div>
+                                {server.status === 'failed' && server.detail && (
+                                    <div className="mt-0.5 truncate text-[11.5px] text-fail">{server.detail}</div>
+                                )}
+                            </div>
+                            <div className="truncate font-mono text-[12px] text-muted" title={server.target}>
+                                {server.target}
+                            </div>
+                            <SourceCell server={server} />
+                            <div>
+                                <StatusBadge server={server} />
+                            </div>
+                            <div className="flex items-center justify-end gap-2">
+                                {server.canConnect && !sessionActive && (
+                                    <Button
+                                        variant="primary"
+                                        className="h-7 px-2.5 text-[12px]"
+                                        pending={action.isPending(`login-start-${server.name}`)}
+                                        onClick={() => startLogin(server.name)}
+                                        data-testid={`mcp-connect-${server.name}`}
+                                    >
+                                        Connect
+                                    </Button>
+                                )}
+                                {sessionActive && (
+                                    <Button
+                                        variant="tertiary"
+                                        className="h-7 px-2 text-[12px]"
+                                        pending={action.isPending(`login-cancel-${server.name}`)}
+                                        onClick={() => action.run(`login-cancel-${server.name}`, 'delete', mcp.login.cancel.url(server.name))}
+                                    >
+                                        Cancel
+                                    </Button>
+                                )}
+                                {server.canLogout && (
+                                    <Button
+                                        variant="tertiary"
+                                        className="h-7 px-2 text-[12px]"
+                                        pending={action.isPending(`logout-${server.name}`)}
+                                        onClick={() => action.run(`logout-${server.name}`, 'post', mcp.logout.url(server.name))}
+                                        data-testid={`mcp-logout-${server.name}`}
+                                    >
+                                        Log out
+                                    </Button>
+                                )}
+                                {server.status === 'failed' && (
+                                    <Button
+                                        variant="tertiary"
+                                        className="h-7 px-2 text-[12px]"
+                                        pending={rechecking === server.name}
+                                        onClick={() => recheckRow(server.name)}
+                                    >
+                                        Re-check
+                                    </Button>
+                                )}
+                                {server.canRemove && (
+                                    <Button
+                                        variant="tertiary"
+                                        className="h-7 px-2 text-[12px] text-fail"
+                                        onClick={() => onRemove(server)}
+                                        data-testid={`mcp-remove-${server.name}`}
+                                    >
+                                        Remove
+                                    </Button>
+                                )}
+                            </div>
+                        </div>
+
+                        {showPanel && session && (
+                            <McpLoginPanel
+                                server={server}
+                                session={session}
+                                sshHost={sshHost}
+                                onDismiss={() => setDismissed((prev) => new Set(prev).add(server.name))}
+                                onRetry={() => startLogin(server.name)}
+                            />
+                        )}
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+function SourceCell({ server }: { server: McpServerRow }) {
+    if (server.source === 'deploy') {
+        return (
+            <div className="text-[12.5px]">
+                <div>Deploy config</div>
+                <div className="text-[11px] text-faint">managed by Ansible</div>
+            </div>
+        );
+    }
+
+    if (server.source === 'plugin') {
+        return (
+            <div className="text-[12.5px]">
+                <div>
+                    Plugin{' '}
+                    <Link href={skills.url()} className="text-accent-text underline">
+                        {server.pluginName}
+                    </Link>
+                </div>
+                <div className="text-[11px] text-faint">remove from Skills</div>
+            </div>
+        );
+    }
+
+    return <div className="text-[12.5px]">Added here</div>;
+}
+
+function StatusBadge({ server }: { server: McpServerRow }) {
+    switch (server.status) {
+        case 'connected':
+            return <Badge tone="ok">Connected</Badge>;
+        case 'needs_auth':
+            return <Badge tone="warn">Needs login</Badge>;
+        case 'failed':
+            return <Badge tone="fail">Failed</Badge>;
+        case 'pending_approval':
+            return <Badge tone="neutral">Pending approval</Badge>;
+        case 'token':
+            return <Badge tone="neutral">Token configured</Badge>;
+        default:
+            return <Badge tone="neutral">Unknown</Badge>;
+    }
+}

--- a/resources/js/components/settings/mcp/SshFallback.tsx
+++ b/resources/js/components/settings/mcp/SshFallback.tsx
@@ -1,0 +1,57 @@
+import { Button, cn } from '@geocodio/console-ui';
+import { ChevronRight, Copy } from 'lucide-react';
+import { useState } from 'react';
+
+export function SshFallback({ sshHost }: { sshHost: string | null }) {
+    const [open, setOpen] = useState(false);
+
+    const prefix = sshHost ? `ssh -t root@${sshHost} ` : '';
+    const commands = [
+        `${prefix}yak-mcp login <name>`,
+        `${prefix}yak-mcp list`,
+        `${prefix}yak-mcp add --transport http <name> <url>`,
+        `${prefix}yak-mcp remove <name>`,
+    ];
+
+    const copyAll = () => {
+        navigator.clipboard.writeText(commands.join('\n'));
+    };
+
+    return (
+        <div className="rounded-card border border-hair bg-panel shadow-card">
+            <button
+                type="button"
+                className="flex w-full items-center gap-2 px-4 py-3 text-left"
+                onClick={() => setOpen((o) => !o)}
+                data-testid="mcp-ssh-toggle"
+            >
+                <ChevronRight size={14} className={cn('shrink-0 text-faint transition-transform', open && 'rotate-90')} />
+                <div>
+                    <div className="text-[13px] font-medium">Prefer the terminal?</div>
+                    <div className="text-[12px] text-faint">Every action here has a one-line yak-mcp command for SSH.</div>
+                </div>
+            </button>
+
+            {open && (
+                <div className="border-t border-hair px-4 py-4">
+                    <p className="text-[12.5px] leading-relaxed text-muted">
+                        The <code className="font-mono">yak-mcp</code> helper on the server wraps the Claude CLI inside the Yak container, like{' '}
+                        <code className="font-mono">yak-claude-login</code> does for the Claude Code login. It takes any{' '}
+                        <code className="font-mono">claude mcp</code> subcommand.
+                    </p>
+
+                    <div className="mt-3 flex items-start gap-2">
+                        <pre className="flex-1 overflow-x-auto rounded-control bg-panel-2 p-3 font-mono text-[12px] leading-relaxed">
+                            {commands.join('\n')}
+                        </pre>
+                        <Button variant="tertiary" icon={<Copy size={13} />} onClick={copyAll} className="shrink-0">
+                            Copy
+                        </Button>
+                    </div>
+
+                    {!sshHost && <p className="mt-2 text-[12px] text-faint">Set YAK_SSH_HOST to show the full ssh command.</p>}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/resources/js/layouts/SettingsLayout.tsx
+++ b/resources/js/layouts/SettingsLayout.tsx
@@ -1,10 +1,10 @@
 import { Link, router, usePage } from '@inertiajs/react';
 import { SettingsShell, type SettingsNavSection } from '@geocodio/console-ui';
-import { Inbox, User, Video as VideoIcon, Zap } from 'lucide-react';
+import { Inbox, Server, User, Video as VideoIcon, Zap } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { channels, tasks } from '@/routes';
 import { edit as profileEdit } from '@/routes/profile';
-import { linear, video } from '@/routes/settings';
+import { linear, mcp, video } from '@/routes/settings';
 
 const SECTIONS: SettingsNavSection[] = [
     {
@@ -46,11 +46,19 @@ const SECTIONS: SettingsNavSection[] = [
                 icon: <Inbox size={15} />,
                 description: 'Slack, Linear, and Sentry inputs.',
             },
+            {
+                slug: 'mcp',
+                href: mcp.url(),
+                label: 'MCP servers',
+                icon: <Server size={15} />,
+                description: 'Tool servers agents can reach inside every sandbox, and their logins.',
+                keywords: ['mcp', 'tools', 'oauth'],
+            },
         ],
     },
 ];
 
-export function SettingsLayout({ slug, children }: { slug: 'profile' | 'linear' | 'video' | 'channels'; children: ReactNode }) {
+export function SettingsLayout({ slug, children }: { slug: 'profile' | 'linear' | 'video' | 'channels' | 'mcp'; children: ReactNode }) {
     const currentPath = usePage().url.split('?')[0];
 
     return (
@@ -60,7 +68,7 @@ export function SettingsLayout({ slug, children }: { slug: 'profile' | 'linear' 
             currentPath={currentPath}
             backHref={tasks.url()}
             backLabel="Back to Yak"
-            wide={slug === 'video' || slug === 'channels'}
+            wide={slug === 'video' || slug === 'channels' || slug === 'mcp'}
             LinkComponent={Link}
             onNavigate={(href) => router.visit(href)}
         >

--- a/resources/js/pages/Repositories/Form.tsx
+++ b/resources/js/pages/Repositories/Form.tsx
@@ -1,6 +1,6 @@
 import { Head, useForm } from '@inertiajs/react';
-import { Badge, Button, Field, Select, StatusPill, Textarea, TextInput } from '@geocodio/console-ui';
-import { ExternalLink, RefreshCw, Sparkles } from 'lucide-react';
+import { Badge, Button, Field, Select, StatusPill, Textarea, TextInput, Tooltip } from '@geocodio/console-ui';
+import { BookOpen, ExternalLink, Info, RefreshCw, Sparkles } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useRouterAction } from '@/lib/useRouterAction';
 import { AppLayout } from '@/layouts/AppLayout';
@@ -19,6 +19,7 @@ import type {
     GitHubSearchRepo,
     ManifestData,
     RepositoryDetail,
+    RepositoryDocsLinks,
     RepositoryOptions,
     RepositoryStats,
     SandboxData,
@@ -34,7 +35,7 @@ type Props = PageProps<{
     stats: RepositoryStats | null;
     canDelete: boolean;
     deleteBlockedReason: string | null;
-    docsUrl: string;
+    docsLinks: RepositoryDocsLinks;
 }>;
 
 type FormData = {
@@ -59,16 +60,49 @@ type FormData = {
     manifest: ManifestData | null;
 };
 
-function Section({ id, title, description, children, aside }: { id: string; title: string; description?: string; children: ReactNode; aside?: ReactNode }) {
+function Section({
+    id,
+    title,
+    description,
+    children,
+    aside,
+    docsHref,
+}: {
+    id: string;
+    title: string;
+    description?: string;
+    children: ReactNode;
+    aside?: ReactNode;
+    docsHref?: string;
+}) {
     return (
         <section id={id} className="grid grid-cols-[220px_1fr] gap-8 border-b border-hair py-8 first:pt-2 last:border-0">
             <div>
                 <h2 className="text-[13px] font-semibold">{title}</h2>
                 {description && <p className="mt-1 text-[12px] leading-relaxed text-muted">{description}</p>}
+                {docsHref && (
+                    <a
+                        href={docsHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-2 inline-flex items-center gap-1 text-[12px] text-accent-text hover:underline"
+                    >
+                        <BookOpen size={12} /> Docs
+                    </a>
+                )}
                 {aside}
             </div>
             <div className="flex flex-col gap-6">{children}</div>
         </section>
+    );
+}
+
+/** Small hover hint for compact fields that have no room for a full description. */
+function InfoTip({ label }: { label: string }) {
+    return (
+        <Tooltip label={label}>
+            <Info size={12} className="shrink-0 text-faint hover:text-muted" aria-label={label} />
+        </Tooltip>
     );
 }
 
@@ -154,7 +188,7 @@ function ManifestSection({
     );
 }
 
-export default function Form({ repository, options, manifest, sandbox, setupHistory, stats, canDelete, deleteBlockedReason, docsUrl }: Props) {
+export default function Form({ repository, options, manifest, sandbox, setupHistory, stats, canDelete, deleteBlockedReason, docsLinks }: Props) {
     const isEditing = repository !== null;
     const showManifest = isEditing && repository.deploymentsEnabled && manifest !== null;
 
@@ -245,15 +279,27 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                             </a>
                         )}
                         {isEditing && repository && (
-                            <Button
-                                icon={<RefreshCw size={13} />}
-                                pending={action.isPending('rerun-setup')}
-                                pendingLabel="Dispatching…"
-                                onClick={() => action.run('rerun-setup', 'post', repos.rerunSetup.url(repository.slug))}
-                                title="Tears down the sandbox's dev environment and rebuilds it from scratch -- README, CLAUDE.md, dependencies, migrations, and a fresh sandbox snapshot."
-                            >
-                                Re-run setup
-                            </Button>
+                            <div className="flex items-center gap-2">
+                                <Tooltip label="Tears down the sandbox's dev environment and rebuilds it from scratch -- README, CLAUDE.md, dependencies, migrations, and a fresh sandbox snapshot.">
+                                    <Button
+                                        icon={<RefreshCw size={13} />}
+                                        pending={action.isPending('rerun-setup')}
+                                        pendingLabel="Dispatching…"
+                                        onClick={() => action.run('rerun-setup', 'post', repos.rerunSetup.url(repository.slug))}
+                                    >
+                                        Re-run setup
+                                    </Button>
+                                </Tooltip>
+                                <a
+                                    href={docsLinks.rerunSetup}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-faint hover:text-muted"
+                                    aria-label="Re-run setup docs"
+                                >
+                                    <BookOpen size={13} />
+                                </a>
+                            </div>
                         )}
                     </>
                 }
@@ -297,14 +343,19 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                             </>
                         )}{' '}
                         See the{' '}
-                        <a href={docsUrl} target="_blank" rel="noopener noreferrer" className="text-accent-text hover:underline">
+                        <a href={docsLinks.guide} target="_blank" rel="noopener noreferrer" className="text-accent-text hover:underline">
                             repositories guide
                         </a>{' '}
                         for details.
                     </p>
 
                     {!isEditing && (
-                        <Section id="github" title="GitHub repository" description="Pick the repository Yak should clone. It dispatches a setup task after saving.">
+                        <Section
+                            id="github"
+                            title="GitHub repository"
+                            description="Pick the repository Yak should clone. It dispatches a setup task after saving."
+                            docsHref={docsLinks.adding}
+                        >
                             <GitHubRepoPicker
                                 selected={form.data.selected_github_repo ? { fullName: form.data.selected_github_repo, defaultBranch: form.data.default_branch } : null}
                                 sentryProjects={options.sentryProjects}
@@ -315,7 +366,7 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                         </Section>
                     )}
 
-                    <Section id="basics" title="Basics" description="How Yak identifies this repository and where it clones from.">
+                    <Section id="basics" title="Basics" description="How Yak identifies this repository and where it clones from." docsHref={docsLinks.adding}>
                         <div className="grid grid-cols-2 gap-4">
                             {isEditing && repository && (
                                 <Field label="Slug" description="Auto-generated. Cannot be changed.">
@@ -331,7 +382,10 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                                 </Field>
                             )}
                             <Field label="Display name" error={form.errors.name}>
-                                <TextInput value={form.data.name} onChange={(e) => form.setData('name', e.target.value)} />
+                                <div className="flex items-center gap-2">
+                                    <TextInput className="flex-1" value={form.data.name} onChange={(e) => form.setData('name', e.target.value)} />
+                                    <InfoTip label="Shown in the dashboard and in task lists. Defaults to the GitHub repo name." />
+                                </div>
                             </Field>
                             <Field label="Git URL" description="HTTPS clone URL. Authenticated via the GitHub App." error={form.errors.git_url}>
                                 <TextInput
@@ -342,11 +396,22 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                                 />
                             </Field>
                             <Field label="Default branch" error={form.errors.default_branch}>
-                                <TextInput
-                                    className="font-mono text-[12px]"
-                                    value={form.data.default_branch}
-                                    onChange={(e) => form.setData('default_branch', e.target.value)}
-                                />
+                                <div className="flex items-center gap-2">
+                                    <TextInput
+                                        className="flex-1 font-mono text-[12px]"
+                                        value={form.data.default_branch}
+                                        onChange={(e) => form.setData('default_branch', e.target.value)}
+                                    />
+                                    <InfoTip label="Branch Yak bases task branches on and opens pull requests against." />
+                                </div>
+                                <a
+                                    href={docsLinks.refresh}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="mt-1 inline-flex items-center gap-1 text-[11px] text-accent-text hover:underline"
+                                >
+                                    <BookOpen size={11} /> How refresh works
+                                </a>
                             </Field>
                         </div>
                         <Field
@@ -356,6 +421,11 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                         >
                             <Textarea rows={2} value={form.data.description} onChange={(e) => form.setData('description', e.target.value)} />
                         </Field>
+                        <p className="-mt-4 text-[12px] text-muted">
+                            <a href={docsLinks.routing} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-accent-text hover:underline">
+                                <BookOpen size={11} /> See how routing works
+                            </a>
+                        </p>
                         {isEditing && (
                             <Field
                                 label="Agent instructions"
@@ -373,6 +443,18 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                             </Field>
                         )}
                         {isEditing && (
+                            <p className="-mt-4 text-[12px] text-muted">
+                                <a
+                                    href={docsLinks.claudeMd}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex items-center gap-1 text-accent-text hover:underline"
+                                >
+                                    <BookOpen size={11} /> See CLAUDE.md guidance
+                                </a>
+                            </p>
+                        )}
+                        {isEditing && (
                             <div className="grid grid-cols-3 gap-4">
                                 <Field label="Public site URL" description="Shown in the video's browser bar instead of the sandbox address." error={form.errors.public_site_url}>
                                     <TextInput
@@ -382,15 +464,27 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                                     />
                                 </Field>
                                 <Field label="CI system" error={form.errors.ci_system}>
-                                    <Select options={options.ciSystems} value={form.data.ci_system} onChange={(v) => form.setData('ci_system', v ?? 'none')} />
+                                    <div className="flex items-center gap-2">
+                                        <Select
+                                            className="flex-1"
+                                            options={options.ciSystems}
+                                            value={form.data.ci_system}
+                                            onChange={(v) => form.setData('ci_system', v ?? 'none')}
+                                        />
+                                        <InfoTip label="Where Yak reads CI results from after it pushes a branch. Detected from the repo when you add it." />
+                                    </div>
                                 </Field>
                                 {options.sentryProjects.length > 0 ? (
                                     <Field label="Sentry project">
-                                        <Select
-                                            options={[{ value: '', label: 'None' }, ...options.sentryProjects]}
-                                            value={form.data.sentry_project}
-                                            onChange={(v) => form.setData('sentry_project', v ?? '')}
-                                        />
+                                        <div className="flex items-center gap-2">
+                                            <Select
+                                                className="flex-1"
+                                                options={[{ value: '', label: 'None' }, ...options.sentryProjects]}
+                                                value={form.data.sentry_project}
+                                                onChange={(v) => form.setData('sentry_project', v ?? '')}
+                                            />
+                                            <InfoTip label="Maps incoming Sentry alerts for this project to this repository." />
+                                        </div>
                                     </Field>
                                 ) : (
                                     <Field label="Sentry project slug" description="Maps incoming Sentry webhooks to this repository.">
@@ -405,7 +499,7 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                         )}
                     </Section>
 
-                    <Section id="automation" title="Automation" description="What Yak does on its own for this repository.">
+                    <Section id="automation" title="Automation" description="What Yak does on its own for this repository." docsHref={docsLinks.prReview}>
                         {isEditing && (
                             <ToggleRow
                                 label="Active"
@@ -419,12 +513,14 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                             description="Tasks that name no repository land here. Only one repository can be the default."
                             checked={form.data.is_default}
                             onChange={(v) => form.setData('is_default', v)}
+                            docsHref={docsLinks.routing}
                         />
                         <ToggleRow
                             label="PR review"
                             description="Have Yak review every open, non-draft pull request on this repo."
                             checked={form.data.pr_review_enabled}
                             onChange={(v) => form.setData('pr_review_enabled', v)}
+                            docsHref={docsLinks.prReview}
                         />
                         {form.data.pr_review_enabled && !(repository?.prReviewEnabled ?? false) && (
                             <ToggleRow
@@ -486,7 +582,12 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                     </div>
 
                     {isEditing && sandbox && (
-                        <Section id="sandbox" title="Sandbox template" description="The snapshot every task for this repository starts from.">
+                        <Section
+                            id="sandbox"
+                            title="Sandbox template"
+                            description="The snapshot every task for this repository starts from."
+                            docsHref={docsLinks.setup}
+                        >
                             <dl className="grid grid-cols-[140px_1fr] gap-y-2 text-[12px]">
                                 <dt className="text-faint">Snapshot</dt>
                                 <dd className="font-mono">{sandbox.snapshot ?? '—'}</dd>
@@ -510,6 +611,7 @@ export default function Form({ repository, options, manifest, sandbox, setupHist
                             id="setup-history"
                             title="Setup history"
                             description="Setup tasks prepare the dev environment and verify it works."
+                            docsHref={docsLinks.setup}
                         >
                             <SetupHistory rows={setupHistory} viewAllHref={setupHistory.length > 0 ? tasks.url({ query: { tab: 'setup', repo: repository.slug } }) : null} />
                         </Section>

--- a/resources/js/pages/Settings/McpServers.tsx
+++ b/resources/js/pages/Settings/McpServers.tsx
@@ -1,0 +1,177 @@
+import { Deferred, Head, router, usePoll } from '@inertiajs/react';
+import { Button, ConfirmDialog, EmptyState, Skeleton } from '@geocodio/console-ui';
+import { Plus, RotateCw, Server as ServerIcon, TriangleAlert } from 'lucide-react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { SettingsLayout } from '@/layouts/SettingsLayout';
+import { McpServerTable } from '@/components/settings/mcp/McpServerTable';
+import { AddMcpServerDialog } from '@/components/settings/mcp/AddMcpServerDialog';
+import { SshFallback } from '@/components/settings/mcp/SshFallback';
+import mcp from '@/routes/settings/mcp';
+import type { PageProps } from '@/types/shared';
+import type { McpLoginSessionData, McpServerRow } from '@/types/settings';
+
+type Props = PageProps<{
+    servers: McpServerRow[] | undefined;
+    loginSessions: Record<string, McpLoginSessionData>;
+    checkedAgo: string | null;
+    sshHost: string | null;
+    docsUrl: string;
+}>;
+
+const ACTIVE_SESSION_STATUSES: McpLoginSessionData['status'][] = ['starting', 'awaiting_redirect', 'finishing'];
+
+export default function McpServers({ servers, loginSessions, checkedAgo, sshHost, docsUrl }: Props) {
+    const [showAddServer, setShowAddServer] = useState(false);
+    const [pendingRemove, setPendingRemove] = useState<McpServerRow | null>(null);
+    const [removing, setRemoving] = useState(false);
+    const [rechecking, setRechecking] = useState(false);
+
+    const hasActiveSession = Object.values(loginSessions).some((s) => ACTIVE_SESSION_STATUSES.includes(s.status));
+    usePoll(2000, { only: ['loginSessions'] }, { autoStart: hasActiveSession });
+
+    // usePoll refreshes loginSessions on its own; once one of them lands on
+    // "succeeded" the server list is stale (the CLI can now see the token),
+    // so pull it once rather than waiting for the next manual re-check.
+    const previousStatuses = useRef<Record<string, McpLoginSessionData['status']>>({});
+    useEffect(() => {
+        const previous = previousStatuses.current;
+        const justSucceeded = Object.entries(loginSessions).some(([name, session]) => session.status === 'succeeded' && previous[name] !== 'succeeded');
+
+        if (justSucceeded) {
+            router.reload({ only: ['servers', 'checkedAgo'] });
+        }
+
+        previousStatuses.current = Object.fromEntries(Object.entries(loginSessions).map(([name, session]) => [name, session.status]));
+    }, [loginSessions]);
+
+    const needsAuthCount = (servers ?? []).filter((s) => s.status === 'needs_auth').length;
+
+    const recheck = () => {
+        setRechecking(true);
+        router.reload({ only: ['servers', 'checkedAgo'], onFinish: () => setRechecking(false) });
+    };
+
+    const remove = () => {
+        if (!pendingRemove) {
+            return;
+        }
+
+        setRemoving(true);
+        router.delete(mcp.destroy.url(pendingRemove.name), {
+            preserveScroll: true,
+            onFinish: () => {
+                setRemoving(false);
+                setPendingRemove(null);
+            },
+        });
+    };
+
+    return (
+        <>
+            <Head title="MCP servers" />
+
+            <div className="flex flex-col gap-4">
+                <div className="flex items-start justify-between gap-6">
+                    <p className="max-w-prose text-[13px] leading-relaxed text-muted">
+                        Tool servers the agent can reach inside every sandbox. Servers from Yak&apos;s generated config use tokens set at deploy
+                        time; servers added here may need a one-time login. See the{' '}
+                        <a href={docsUrl} target="_blank" rel="noopener noreferrer" className="text-accent-text underline">
+                            MCP servers guide
+                        </a>
+                        .
+                    </p>
+                    <div className="flex shrink-0 items-center gap-3">
+                        {checkedAgo && <span className="text-[12px] text-faint">Checked {checkedAgo}</span>}
+                        <Button
+                            variant="secondary"
+                            icon={<RotateCw size={13} />}
+                            pending={rechecking}
+                            pendingLabel="Checking…"
+                            onClick={recheck}
+                            data-testid="mcp-recheck"
+                        >
+                            Re-check
+                        </Button>
+                        <Button
+                            variant="primary"
+                            icon={<Plus size={13} />}
+                            onClick={() => setShowAddServer(true)}
+                            data-testid="mcp-add-server"
+                        >
+                            Add server
+                        </Button>
+                    </div>
+                </div>
+
+                {needsAuthCount > 0 && (
+                    <WarnStrip>
+                        <b>
+                            {needsAuthCount} server{needsAuthCount === 1 ? '' : 's'} need{needsAuthCount === 1 ? 's' : ''} a login.
+                        </b>{' '}
+                        Agents skip their tools until someone connects them.
+                    </WarnStrip>
+                )}
+
+                <Deferred data="servers" fallback={<TableSkeleton />}>
+                    {servers && servers.length === 0 ? (
+                        <EmptyState
+                            title="No MCP servers configured."
+                            body="Add one below, or check the deploy config for servers set at provisioning time."
+                            icon={<ServerIcon size={20} />}
+                            action={
+                                <Button variant="primary" icon={<Plus size={13} />} onClick={() => setShowAddServer(true)}>
+                                    Add server
+                                </Button>
+                            }
+                        />
+                    ) : (
+                        <McpServerTable servers={servers ?? []} loginSessions={loginSessions} sshHost={sshHost} onRemove={setPendingRemove} />
+                    )}
+                </Deferred>
+
+                <SshFallback sshHost={sshHost} />
+            </div>
+
+            <AddMcpServerDialog open={showAddServer} onOpenChange={setShowAddServer} />
+
+            <ConfirmDialog
+                open={pendingRemove !== null}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setPendingRemove(null);
+                    }
+                }}
+                title={`Remove ${pendingRemove?.name}?`}
+                body="Removes the server from the shared config and clears its stored login. Agents lose its tools on their next run. Servers that come from a plugin or from the deploy config cannot be removed here."
+                confirmLabel="Remove"
+                busy={removing}
+                confirmTestId="mcp-remove-confirm"
+                onConfirm={remove}
+            />
+        </>
+    );
+}
+
+function WarnStrip({ children }: { children: ReactNode }) {
+    return (
+        <div className="flex items-start gap-2 rounded-card border border-warn/30 bg-warn-soft p-3 text-[12.5px] leading-relaxed text-body">
+            <TriangleAlert size={15} className="mt-0.5 shrink-0 text-warn" />
+            <span>{children}</span>
+        </div>
+    );
+}
+
+function TableSkeleton() {
+    return (
+        <div className="overflow-hidden rounded-card border border-hair bg-panel shadow-card">
+            <div className="border-b border-hair bg-panel-2 px-4 py-2 text-[11.5px] text-faint">Checking servers… this takes a few seconds.</div>
+            <div className="flex flex-col gap-3 p-4">
+                {[0, 1, 2].map((i) => (
+                    <Skeleton key={i} className="h-8 w-full rounded-control" />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+McpServers.layout = (page: ReactNode) => <SettingsLayout slug="mcp">{page}</SettingsLayout>;

--- a/resources/js/pages/Skills/Index.tsx
+++ b/resources/js/pages/Skills/Index.tsx
@@ -1,7 +1,7 @@
 import { Head, router, useForm } from '@inertiajs/react';
-import { Button, ConfirmDialog, Menu, TextInput } from '@geocodio/console-ui';
+import { Button, ConfirmDialog, Menu, TextInput, cn } from '@geocodio/console-ui';
 import { ChevronDown, Loader2, Plus, RotateCw } from 'lucide-react';
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Fragment, useEffect, useRef, useState, type ReactNode } from 'react';
 import { AppLayout } from '@/layouts/AppLayout';
 import { PageHeader } from '@/components/PageHeader';
 import { SkillCard } from '@/components/skills/SkillCard';
@@ -11,13 +11,24 @@ import { skills } from '@/routes';
 import { destroy, install as installSkill, update, upgrade } from '@/routes/skills';
 import { refresh } from '@/routes/marketplaces';
 import type { PageProps } from '@/types/shared';
-import type { AvailableSkillRow, BundledSkillRow, InstalledSkillRow, MarketplaceRow, SkillsFilters, SkillsFilterValue } from '@/types/skills';
+import type {
+    AvailablePage,
+    AvailableSkillRow,
+    BundledSkillRow,
+    InstalledSkillRow,
+    MarketplaceRow,
+    RecommendedSkillRow,
+    SkillCategory,
+    SkillsFilters,
+    SkillsFilterValue,
+} from '@/types/skills';
 
 type Props = PageProps<{
     installed: InstalledSkillRow[];
     bundled: BundledSkillRow[];
-    available: AvailableSkillRow[];
-    availableTotal: number;
+    available: AvailablePage;
+    categories: SkillCategory[];
+    recommended: RecommendedSkillRow[];
     marketplaces: MarketplaceRow[];
     filters: SkillsFilters;
 }>;
@@ -29,7 +40,7 @@ const FILTER_OPTIONS: { value: SkillsFilterValue; label: string }[] = [
     { value: 'available', label: 'Available' },
 ];
 
-export default function Index({ installed, bundled, available, availableTotal, marketplaces: marketplaceRows, filters }: Props) {
+export default function Index({ installed, bundled, available, categories, recommended, marketplaces: marketplaceRows, filters }: Props) {
     const [search, setSearch] = useState(filters.search);
     const [searching, setSearching] = useState(false);
     const [showInstallFromUrl, setShowInstallFromUrl] = useState(false);
@@ -40,8 +51,14 @@ export default function Index({ installed, bundled, available, availableTotal, m
     const [pendingUninstall, setPendingUninstall] = useState<InstalledSkillRow | null>(null);
     const [uninstalling, setUninstalling] = useState(false);
 
-    const navigate = (next: Partial<SkillsFilters>) => {
-        router.get(skills.url(), { search, filter: filters.filter, ...next }, { preserveState: true, replace: true });
+    // Any change other than an explicit page navigation resets to page 1, so
+    // `page` is only included when the caller passes it.
+    const navigate = (next: Partial<SkillsFilters> & { page?: number }) => {
+        router.get(
+            skills.url(),
+            { search, filter: filters.filter, category: filters.category, page: undefined, ...next },
+            { preserveState: true, replace: true },
+        );
     };
 
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -59,7 +76,7 @@ export default function Index({ installed, bundled, available, availableTotal, m
         debounceRef.current = setTimeout(() => {
             router.get(
                 skills.url(),
-                { search, filter: filters.filter },
+                { search, filter: filters.filter, category: filters.category },
                 { preserveState: true, replace: true, onFinish: () => setSearching(false) },
             );
         }, 200);
@@ -128,6 +145,10 @@ export default function Index({ installed, bundled, available, availableTotal, m
     const showBundled = filters.filter === 'all' || filters.filter === 'bundled';
     const showAvailable = filters.filter === 'all' || filters.filter === 'available';
     const showMarketplaces = filters.filter === 'all';
+    const showAvailableSection = showAvailable && (marketplaceRows.length > 0 || available.total > 0);
+    const recommendedMeta = recommended.some((r) => r.recommendedReason === 'similar')
+        ? 'based on what you have installed'
+        : 'popular picks';
 
     return (
         <>
@@ -216,10 +237,10 @@ export default function Index({ installed, bundled, available, availableTotal, m
                     </Section>
                 )}
 
-                {showAvailable && available.length > 0 && (
-                    <Section title="Available" meta={marketplaceRows.length > 0 ? `from ${marketplaceRows.map((m) => m.name).join(', ')}` : 'no marketplaces configured'}>
+                {showAvailable && recommended.length > 0 && (
+                    <Section title="Recommended" meta={recommendedMeta} data-testid="recommended-section">
                         <Grid>
-                            {available.map((skill) => (
+                            {recommended.map((skill) => (
                                 <SkillCard
                                     key={skill.key}
                                     variant="available"
@@ -229,10 +250,87 @@ export default function Index({ installed, bundled, available, availableTotal, m
                                 />
                             ))}
                         </Grid>
-                        {availableTotal > available.length && (
-                            <p className="mt-3 text-[12px] text-muted">
-                                Showing {available.length} of {availableTotal}. Use search to narrow results.
-                            </p>
+                    </Section>
+                )}
+
+                {showAvailableSection && (
+                    <Section
+                        title="Available"
+                        meta={marketplaceRows.length > 0 ? `${available.total} from ${marketplaceRows.map((m) => m.name).join(', ')}` : 'no marketplaces configured'}
+                    >
+                        {categories.length > 0 && (
+                            <div className="mb-3 flex flex-wrap gap-1.5">
+                                <CategoryChip
+                                    label={`All (${available.total})`}
+                                    selected={filters.category === ''}
+                                    onClick={() => navigate({ category: '' })}
+                                    testId="category-all"
+                                />
+                                {categories.map((category) => (
+                                    <CategoryChip
+                                        key={category.value}
+                                        label={`${category.label} (${category.count})`}
+                                        selected={filters.category === category.value}
+                                        onClick={() => navigate({ category: category.value })}
+                                        testId={`category-${category.value}`}
+                                    />
+                                ))}
+                            </div>
+                        )}
+
+                        {available.items.length === 0 ? (
+                            <p className="text-[12.5px] text-muted">No plugins match.</p>
+                        ) : (
+                            <>
+                                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                                    {available.items.map((skill, index) => {
+                                        const previous = available.items[index - 1];
+                                        const showHeading = filters.category === '' && (index === 0 || skill.category !== previous?.category);
+
+                                        return (
+                                            <Fragment key={skill.key}>
+                                                {showHeading && (
+                                                    <div className="col-span-full mt-2 first:mt-0">
+                                                        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-faint">
+                                                            {skill.category ?? 'Other'}
+                                                        </h3>
+                                                    </div>
+                                                )}
+                                                <SkillCard
+                                                    variant="available"
+                                                    skill={skill}
+                                                    onInstall={() => install(skill)}
+                                                    installing={installingKey === skill.key}
+                                                />
+                                            </Fragment>
+                                        );
+                                    })}
+                                </div>
+
+                                {available.lastPage > 1 && (
+                                    <div className="mt-3 flex items-center justify-between border-t border-hair pt-3" data-testid="available-pagination">
+                                        <Button
+                                            variant="tertiary"
+                                            disabled={available.page <= 1}
+                                            onClick={() => navigate({ page: available.page - 1 })}
+                                            data-testid="available-prev"
+                                        >
+                                            Previous
+                                        </Button>
+                                        <span className="tnum text-[12px] text-muted">
+                                            Page {available.page} of {available.lastPage} · {available.total} plugins
+                                        </span>
+                                        <Button
+                                            variant="tertiary"
+                                            disabled={available.page >= available.lastPage}
+                                            onClick={() => navigate({ page: available.page + 1 })}
+                                            data-testid="available-next"
+                                        >
+                                            Next
+                                        </Button>
+                                    </div>
+                                )}
+                            </>
                         )}
                     </Section>
                 )}
@@ -264,9 +362,9 @@ export default function Index({ installed, bundled, available, availableTotal, m
     );
 }
 
-function Section({ title, meta, children }: { title: string; meta?: string; children: ReactNode }) {
+function Section({ title, meta, children, ...rest }: { title: string; meta?: string; children: ReactNode; 'data-testid'?: string }) {
     return (
-        <div className="mb-8">
+        <div className="mb-8" data-testid={rest['data-testid']}>
             <div className="mb-3 flex items-baseline gap-2">
                 <h2 className="text-[12px] font-semibold uppercase tracking-wide text-faint">{title}</h2>
                 {meta && <span className="text-[11px] text-faint">{meta}</span>}
@@ -278,6 +376,22 @@ function Section({ title, meta, children }: { title: string; meta?: string; chil
 
 function Grid({ children }: { children: ReactNode }) {
     return <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">{children}</div>;
+}
+
+function CategoryChip({ label, selected, onClick, testId }: { label: string; selected: boolean; onClick: () => void; testId: string }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            data-testid={testId}
+            className={cn(
+                'rounded-pill border border-hair px-2 py-0.5 text-[12px] text-muted transition-colors hover:text-body',
+                selected && 'border-accent/40 bg-accent-soft text-accent-text',
+            )}
+        >
+            {label}
+        </button>
+    );
 }
 
 Index.layout = (page: ReactNode) => <AppLayout>{page}</AppLayout>;

--- a/resources/js/routes/repos/index.ts
+++ b/resources/js/routes/repos/index.ts
@@ -236,7 +236,7 @@ edit.head = (args: { repository: string | number | { slug: string | number } } |
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::update
-* @see app/Http/Controllers/Repositories/RepositoryController.php:93
+* @see app/Http/Controllers/Repositories/RepositoryController.php:110
 * @route '/repos/{repository}'
 */
 export const update = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -251,7 +251,7 @@ update.definition = {
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::update
-* @see app/Http/Controllers/Repositories/RepositoryController.php:93
+* @see app/Http/Controllers/Repositories/RepositoryController.php:110
 * @route '/repos/{repository}'
 */
 update.url = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions) => {
@@ -284,7 +284,7 @@ update.url = (args: { repository: string | number | { slug: string | number } } 
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::update
-* @see app/Http/Controllers/Repositories/RepositoryController.php:93
+* @see app/Http/Controllers/Repositories/RepositoryController.php:110
 * @route '/repos/{repository}'
 */
 update.patch = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -294,7 +294,7 @@ update.patch = (args: { repository: string | number | { slug: string | number } 
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::destroy
-* @see app/Http/Controllers/Repositories/RepositoryController.php:124
+* @see app/Http/Controllers/Repositories/RepositoryController.php:141
 * @route '/repos/{repository}'
 */
 export const destroy = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -309,7 +309,7 @@ destroy.definition = {
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::destroy
-* @see app/Http/Controllers/Repositories/RepositoryController.php:124
+* @see app/Http/Controllers/Repositories/RepositoryController.php:141
 * @route '/repos/{repository}'
 */
 destroy.url = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions) => {
@@ -342,7 +342,7 @@ destroy.url = (args: { repository: string | number | { slug: string | number } }
 
 /**
 * @see \App\Http\Controllers\Repositories\RepositoryController::destroy
-* @see app/Http/Controllers/Repositories/RepositoryController.php:124
+* @see app/Http/Controllers/Repositories/RepositoryController.php:141
 * @route '/repos/{repository}'
 */
 destroy.delete = (args: { repository: string | number | { slug: string | number } } | [repository: string | number | { slug: string | number } ] | string | number | { slug: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({

--- a/resources/js/routes/settings/index.ts
+++ b/resources/js/routes/settings/index.ts
@@ -1,6 +1,7 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../wayfinder'
 import linearCc9558 from './linear'
 import video6ca361 from './video'
+import mcp62c737 from './mcp'
 /**
 * @see \App\Http\Controllers\Settings\LinearConnectionController::linear
 * @see app/Http/Controllers/Settings/LinearConnectionController.php:16
@@ -89,9 +90,54 @@ video.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     method: 'head',
 })
 
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::mcp
+* @see app/Http/Controllers/Settings/McpServerController.php:25
+* @route '/settings/mcp'
+*/
+export const mcp = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: mcp.url(options),
+    method: 'get',
+})
+
+mcp.definition = {
+    methods: ["get","head"],
+    url: '/settings/mcp',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::mcp
+* @see app/Http/Controllers/Settings/McpServerController.php:25
+* @route '/settings/mcp'
+*/
+mcp.url = (options?: RouteQueryOptions) => {
+    return mcp.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::mcp
+* @see app/Http/Controllers/Settings/McpServerController.php:25
+* @route '/settings/mcp'
+*/
+mcp.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: mcp.url(options),
+    method: 'get',
+})
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::mcp
+* @see app/Http/Controllers/Settings/McpServerController.php:25
+* @route '/settings/mcp'
+*/
+mcp.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: mcp.url(options),
+    method: 'head',
+})
+
 const settings = {
     linear: Object.assign(linear, linearCc9558),
     video: Object.assign(video, video6ca361),
+    mcp: Object.assign(mcp, mcp62c737),
 }
 
 export default settings

--- a/resources/js/routes/settings/mcp/index.ts
+++ b/resources/js/routes/settings/mcp/index.ts
@@ -1,0 +1,148 @@
+import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../wayfinder'
+import login from './login'
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::store
+* @see app/Http/Controllers/Settings/McpServerController.php:40
+* @route '/settings/mcp'
+*/
+export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store.url(options),
+    method: 'post',
+})
+
+store.definition = {
+    methods: ["post"],
+    url: '/settings/mcp',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::store
+* @see app/Http/Controllers/Settings/McpServerController.php:40
+* @route '/settings/mcp'
+*/
+store.url = (options?: RouteQueryOptions) => {
+    return store.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::store
+* @see app/Http/Controllers/Settings/McpServerController.php:40
+* @route '/settings/mcp'
+*/
+store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store.url(options),
+    method: 'post',
+})
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::logout
+* @see app/Http/Controllers/Settings/McpServerController.php:107
+* @route '/settings/mcp/{name}/logout'
+*/
+export const logout = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: logout.url(args, options),
+    method: 'post',
+})
+
+logout.definition = {
+    methods: ["post"],
+    url: '/settings/mcp/{name}/logout',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::logout
+* @see app/Http/Controllers/Settings/McpServerController.php:107
+* @route '/settings/mcp/{name}/logout'
+*/
+logout.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { name: args }
+    }
+
+    if (Array.isArray(args)) {
+        args = {
+            name: args[0],
+        }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+        name: args.name,
+    }
+
+    return logout.definition.url
+            .replace('{name}', parsedArgs.name.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::logout
+* @see app/Http/Controllers/Settings/McpServerController.php:107
+* @route '/settings/mcp/{name}/logout'
+*/
+logout.post = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: logout.url(args, options),
+    method: 'post',
+})
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::destroy
+* @see app/Http/Controllers/Settings/McpServerController.php:80
+* @route '/settings/mcp/{name}'
+*/
+export const destroy = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy.url(args, options),
+    method: 'delete',
+})
+
+destroy.definition = {
+    methods: ["delete"],
+    url: '/settings/mcp/{name}',
+} satisfies RouteDefinition<["delete"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::destroy
+* @see app/Http/Controllers/Settings/McpServerController.php:80
+* @route '/settings/mcp/{name}'
+*/
+destroy.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { name: args }
+    }
+
+    if (Array.isArray(args)) {
+        args = {
+            name: args[0],
+        }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+        name: args.name,
+    }
+
+    return destroy.definition.url
+            .replace('{name}', parsedArgs.name.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpServerController::destroy
+* @see app/Http/Controllers/Settings/McpServerController.php:80
+* @route '/settings/mcp/{name}'
+*/
+destroy.delete = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy.url(args, options),
+    method: 'delete',
+})
+
+const mcp = {
+    store: Object.assign(store, store),
+    login: Object.assign(login, login),
+    logout: Object.assign(logout, logout),
+    destroy: Object.assign(destroy, destroy),
+}
+
+export default mcp

--- a/resources/js/routes/settings/mcp/login/index.ts
+++ b/resources/js/routes/settings/mcp/login/index.ts
@@ -1,0 +1,164 @@
+import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../wayfinder'
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::redirect
+* @see app/Http/Controllers/Settings/McpLoginController.php:28
+* @route '/settings/mcp/{name}/login/redirect'
+*/
+export const redirect = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: redirect.url(args, options),
+    method: 'post',
+})
+
+redirect.definition = {
+    methods: ["post"],
+    url: '/settings/mcp/{name}/login/redirect',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::redirect
+* @see app/Http/Controllers/Settings/McpLoginController.php:28
+* @route '/settings/mcp/{name}/login/redirect'
+*/
+redirect.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { name: args }
+    }
+
+    if (Array.isArray(args)) {
+        args = {
+            name: args[0],
+        }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+        name: args.name,
+    }
+
+    return redirect.definition.url
+            .replace('{name}', parsedArgs.name.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::redirect
+* @see app/Http/Controllers/Settings/McpLoginController.php:28
+* @route '/settings/mcp/{name}/login/redirect'
+*/
+redirect.post = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: redirect.url(args, options),
+    method: 'post',
+})
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::start
+* @see app/Http/Controllers/Settings/McpLoginController.php:13
+* @route '/settings/mcp/{name}/login'
+*/
+export const start = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: start.url(args, options),
+    method: 'post',
+})
+
+start.definition = {
+    methods: ["post"],
+    url: '/settings/mcp/{name}/login',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::start
+* @see app/Http/Controllers/Settings/McpLoginController.php:13
+* @route '/settings/mcp/{name}/login'
+*/
+start.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { name: args }
+    }
+
+    if (Array.isArray(args)) {
+        args = {
+            name: args[0],
+        }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+        name: args.name,
+    }
+
+    return start.definition.url
+            .replace('{name}', parsedArgs.name.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::start
+* @see app/Http/Controllers/Settings/McpLoginController.php:13
+* @route '/settings/mcp/{name}/login'
+*/
+start.post = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: start.url(args, options),
+    method: 'post',
+})
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::cancel
+* @see app/Http/Controllers/Settings/McpLoginController.php:53
+* @route '/settings/mcp/{name}/login'
+*/
+export const cancel = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: cancel.url(args, options),
+    method: 'delete',
+})
+
+cancel.definition = {
+    methods: ["delete"],
+    url: '/settings/mcp/{name}/login',
+} satisfies RouteDefinition<["delete"]>
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::cancel
+* @see app/Http/Controllers/Settings/McpLoginController.php:53
+* @route '/settings/mcp/{name}/login'
+*/
+cancel.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { name: args }
+    }
+
+    if (Array.isArray(args)) {
+        args = {
+            name: args[0],
+        }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+        name: args.name,
+    }
+
+    return cancel.definition.url
+            .replace('{name}', parsedArgs.name.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Http\Controllers\Settings\McpLoginController::cancel
+* @see app/Http/Controllers/Settings/McpLoginController.php:53
+* @route '/settings/mcp/{name}/login'
+*/
+cancel.delete = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: cancel.url(args, options),
+    method: 'delete',
+})
+
+const login = {
+    redirect: Object.assign(redirect, redirect),
+    start: Object.assign(start, start),
+    cancel: Object.assign(cancel, cancel),
+}
+
+export default login

--- a/resources/js/routes/skills/index.ts
+++ b/resources/js/routes/skills/index.ts
@@ -1,7 +1,7 @@
 import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../wayfinder'
 /**
 * @see \App\Http\Controllers\SkillController::install
-* @see app/Http/Controllers/SkillController.php:46
+* @see app/Http/Controllers/SkillController.php:50
 * @route '/skills'
 */
 export const install = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -16,7 +16,7 @@ install.definition = {
 
 /**
 * @see \App\Http\Controllers\SkillController::install
-* @see app/Http/Controllers/SkillController.php:46
+* @see app/Http/Controllers/SkillController.php:50
 * @route '/skills'
 */
 install.url = (options?: RouteQueryOptions) => {
@@ -25,7 +25,7 @@ install.url = (options?: RouteQueryOptions) => {
 
 /**
 * @see \App\Http\Controllers\SkillController::install
-* @see app/Http/Controllers/SkillController.php:46
+* @see app/Http/Controllers/SkillController.php:50
 * @route '/skills'
 */
 install.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -35,7 +35,7 @@ install.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
 
 /**
 * @see \App\Http\Controllers\SkillController::update
-* @see app/Http/Controllers/SkillController.php:66
+* @see app/Http/Controllers/SkillController.php:70
 * @route '/skills/{name}'
 */
 export const update = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -50,7 +50,7 @@ update.definition = {
 
 /**
 * @see \App\Http\Controllers\SkillController::update
-* @see app/Http/Controllers/SkillController.php:66
+* @see app/Http/Controllers/SkillController.php:70
 * @route '/skills/{name}'
 */
 update.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
@@ -77,7 +77,7 @@ update.url = (args: { name: string | number } | [name: string | number ] | strin
 
 /**
 * @see \App\Http\Controllers\SkillController::update
-* @see app/Http/Controllers/SkillController.php:66
+* @see app/Http/Controllers/SkillController.php:70
 * @route '/skills/{name}'
 */
 update.patch = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
@@ -87,7 +87,7 @@ update.patch = (args: { name: string | number } | [name: string | number ] | str
 
 /**
 * @see \App\Http\Controllers\SkillController::upgrade
-* @see app/Http/Controllers/SkillController.php:90
+* @see app/Http/Controllers/SkillController.php:94
 * @route '/skills/{name}/update'
 */
 export const upgrade = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -102,7 +102,7 @@ upgrade.definition = {
 
 /**
 * @see \App\Http\Controllers\SkillController::upgrade
-* @see app/Http/Controllers/SkillController.php:90
+* @see app/Http/Controllers/SkillController.php:94
 * @route '/skills/{name}/update'
 */
 upgrade.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
@@ -129,7 +129,7 @@ upgrade.url = (args: { name: string | number } | [name: string | number ] | stri
 
 /**
 * @see \App\Http\Controllers\SkillController::upgrade
-* @see app/Http/Controllers/SkillController.php:90
+* @see app/Http/Controllers/SkillController.php:94
 * @route '/skills/{name}/update'
 */
 upgrade.post = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -139,7 +139,7 @@ upgrade.post = (args: { name: string | number } | [name: string | number ] | str
 
 /**
 * @see \App\Http\Controllers\SkillController::destroy
-* @see app/Http/Controllers/SkillController.php:81
+* @see app/Http/Controllers/SkillController.php:85
 * @route '/skills/{name}'
 */
 export const destroy = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
@@ -154,7 +154,7 @@ destroy.definition = {
 
 /**
 * @see \App\Http\Controllers\SkillController::destroy
-* @see app/Http/Controllers/SkillController.php:81
+* @see app/Http/Controllers/SkillController.php:85
 * @route '/skills/{name}'
 */
 destroy.url = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions) => {
@@ -181,7 +181,7 @@ destroy.url = (args: { name: string | number } | [name: string | number ] | stri
 
 /**
 * @see \App\Http\Controllers\SkillController::destroy
-* @see app/Http/Controllers/SkillController.php:81
+* @see app/Http/Controllers/SkillController.php:85
 * @route '/skills/{name}'
 */
 destroy.delete = (args: { name: string | number } | [name: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({

--- a/resources/js/types/repositories.ts
+++ b/resources/js/types/repositories.ts
@@ -67,6 +67,17 @@ export type RepositoryStats = {
     reviews30d: number;
 };
 
+export type RepositoryDocsLinks = {
+    guide: string;
+    adding: string;
+    setup: string;
+    claudeMd: string;
+    routing: string;
+    prReview: string;
+    refresh: string;
+    rerunSetup: string;
+};
+
 export type GitHubSearchRepo = {
     id: number | null;
     fullName: string;

--- a/resources/js/types/settings.ts
+++ b/resources/js/types/settings.ts
@@ -46,3 +46,28 @@ export type VideoThemeData = {
 };
 
 export type BlockKind = 'title' | 'chapter' | 'shot' | 'summary';
+
+export type McpServerRow = {
+    name: string; // e.g. "linear", "plugin:figma:figma"
+    displayName: string; // "linear"; for plugin servers the last segment ("figma")
+    target: string; // command + args joined for stdio; URL for http/sse
+    transport: 'stdio' | 'http' | 'sse' | 'unknown';
+    source: 'deploy' | 'user' | 'plugin';
+    pluginName: string | null; // for source 'plugin': the middle segment of plugin:<plugin>:<server>
+    status: 'connected' | 'needs_auth' | 'failed' | 'pending_approval' | 'token' | 'unknown';
+    // 'token' = deploy-config server (not health-checked). 'pending_approval' = CLI "⏸ Pending approval".
+    detail: string | null; // failure text if the CLI printed one, else null
+    canConnect: boolean; // status === 'needs_auth' (any source; plugin servers can log in too)
+    canLogout: boolean; // source !== 'deploy' && status === 'connected' && transport !== 'stdio'
+    canRemove: boolean; // source === 'user'
+    loginCommand: string; // "yak-mcp login <name>" -- with sshHost set, the page prefixes "ssh -t root@<sshHost> "
+};
+
+export type McpLoginSessionData = {
+    server: string;
+    status: 'starting' | 'awaiting_redirect' | 'finishing' | 'succeeded' | 'failed' | 'expired' | 'cancelled';
+    authorizationUrl: string | null; // set once status reaches awaiting_redirect
+    error: string | null; // CLI error text for failed
+    startedAt: string; // ISO 8601
+    expiresAt: string; // ISO 8601 (startedAt + 10 min)
+};

--- a/resources/js/types/skills.ts
+++ b/resources/js/types/skills.ts
@@ -22,6 +22,24 @@ export type AvailableSkillRow = {
     link: string | null;
 };
 
+export type RecommendedSkillRow = AvailableSkillRow & {
+    recommendedReason: 'popular' | 'similar';
+};
+
+export type AvailablePage = {
+    items: AvailableSkillRow[];
+    page: number;
+    lastPage: number;
+    total: number;
+    perPage: number;
+};
+
+export type SkillCategory = {
+    value: string;
+    label: string;
+    count: number;
+};
+
 export type MarketplaceRow = {
     name: string;
     source: string;
@@ -33,4 +51,5 @@ export type SkillsFilterValue = 'all' | 'installed' | 'bundled' | 'available';
 export type SkillsFilters = {
     search: string;
     filter: SkillsFilterValue;
+    category: string;
 };

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -2,6 +2,8 @@
 
 use App\Http\Controllers\Settings\AccountController;
 use App\Http\Controllers\Settings\LinearConnectionController;
+use App\Http\Controllers\Settings\McpLoginController;
+use App\Http\Controllers\Settings\McpServerController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\VideoThemeController;
 use Illuminate\Support\Facades\Route;
@@ -24,4 +26,21 @@ Route::middleware(['auth'])->group(function () {
     Route::post('settings/video/reset', [VideoThemeController::class, 'reset'])->name('settings.video.reset');
     Route::delete('settings/video/logo', [VideoThemeController::class, 'destroyLogo'])->name('settings.video.logo.destroy');
     Route::post('settings/video/sample', [VideoThemeController::class, 'sample'])->name('settings.video.sample');
+
+    Route::get('settings/mcp', [McpServerController::class, 'index'])->name('settings.mcp');
+    Route::post('settings/mcp', [McpServerController::class, 'store'])->name('settings.mcp.store');
+
+    // Registered before the shorter settings.mcp.destroy/logout routes
+    // below: {name} is deliberately greedy (`.+`) so a colon-bearing
+    // plugin name like "plugin:figma:figma" is captured whole, but that
+    // greediness also lets it swallow a trailing "/login" or
+    // "/login/redirect" segment. Laravel matches routes in registration
+    // order, so the longer URIs must come first or every one of these
+    // would be shadowed by settings.mcp.destroy/settings.mcp.logout.
+    Route::post('settings/mcp/{name}/login/redirect', [McpLoginController::class, 'redirect'])->where('name', '.+')->name('settings.mcp.login.redirect');
+    Route::post('settings/mcp/{name}/login', [McpLoginController::class, 'start'])->where('name', '.+')->name('settings.mcp.login.start');
+    Route::delete('settings/mcp/{name}/login', [McpLoginController::class, 'cancel'])->where('name', '.+')->name('settings.mcp.login.cancel');
+
+    Route::post('settings/mcp/{name}/logout', [McpServerController::class, 'logout'])->where('name', '.+')->name('settings.mcp.logout');
+    Route::delete('settings/mcp/{name}', [McpServerController::class, 'destroy'])->where('name', '.+')->name('settings.mcp.destroy');
 });

--- a/tests/Browser/McpServersSmokeTest.php
+++ b/tests/Browser/McpServersSmokeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->create());
+
+    $this->deployConfig = sys_get_temp_dir() . '/yak-mcp-browser-' . uniqid() . '.json';
+    File::put($this->deployConfig, json_encode([
+        'mcpServers' => [
+            'sentry-alerts' => [
+                'type' => 'http',
+                'url' => 'https://mcp.sentry.dev/deploy',
+            ],
+        ],
+    ]));
+
+    config()->set('yak.mcp_config_path', $this->deployConfig);
+    config()->set('yak.ssh_host', 'geocodio.yak.build');
+
+    $mcpListOutput = implode("\n", [
+        'linear: https://mcp.linear.app/sse (SSE) - ✔ Connected',
+        'sentry: https://mcp.sentry.dev/mcp (HTTP) - ! Needs authentication',
+        'plugin:figma-tools:figma: npx -y figma-mcp - ✔ Connected',
+    ]);
+
+    Process::fake([
+        '*mcp list*' => Process::result(output: $mcpListOutput, exitCode: 0),
+        '*' => Process::result(output: 'ok', exitCode: 0),
+    ]);
+
+    Queue::fake();
+});
+
+afterEach(function () {
+    File::delete($this->deployConfig);
+});
+
+test('MCP servers page renders servers and starts a login for one that needs auth', function () {
+    $page = visit(route('settings.mcp'));
+
+    $page->assertNoJavaScriptErrors();
+    $page->assertSee('MCP servers');
+
+    $page->waitForText('sentry');
+    $page->assertSee('linear');
+    $page->assertSee('sentry-alerts');
+    $page->assertSee('figma');
+
+    $page->click('[data-testid="mcp-connect-sentry"]');
+
+    $page->waitForText('Asking sentry for an authorization link');
+    $page->assertVisible('[data-testid="mcp-login-panel-sentry"]');
+
+    $page->assertNoJavaScriptErrors();
+});

--- a/tests/Browser/SkillsSmokeTest.php
+++ b/tests/Browser/SkillsSmokeTest.php
@@ -19,15 +19,37 @@ beforeEach(function () {
         ],
     ]));
 
+    // 30 plugins across two categories: 15 "productivity" (including the
+    // original demo-plugin, kept so the install-button test below still
+    // targets a known key) and 15 "testing" -- enough to span two pages of
+    // the 24-per-page Available list.
+    $plugins = [[
+        'name' => 'demo-plugin',
+        'description' => 'Demonstration plugin for browser test',
+        'category' => 'productivity',
+    ]];
+
+    for ($i = 2; $i <= 15; $i++) {
+        $plugins[] = [
+            'name' => sprintf('productivity-plugin-%02d', $i),
+            'description' => 'A productivity plugin',
+            'category' => 'productivity',
+        ];
+    }
+
+    for ($i = 1; $i <= 15; $i++) {
+        $plugins[] = [
+            'name' => sprintf('testing-plugin-%02d', $i),
+            'description' => 'A testing plugin',
+            'category' => 'testing',
+        ];
+    }
+
     File::put(
         $this->tmp . '/marketplaces/acme-plugins/.claude-plugin/marketplace.json',
         json_encode([
             'owner' => ['name' => 'acme'],
-            'plugins' => [[
-                'name' => 'demo-plugin',
-                'description' => 'Demonstration plugin for browser test',
-                'category' => 'demo',
-            ]],
+            'plugins' => $plugins,
         ]),
     );
 
@@ -54,4 +76,30 @@ test('Skills page renders and the Install button click invokes the backend', fun
 
     Process::assertRan(fn ($p) => str_contains($p->command, 'plugins install')
         && str_contains($p->command, 'demo-plugin@acme-plugins'));
+});
+
+test('Skills page filters by category and paginates the Available list', function () {
+    $page = visit(route('skills'));
+
+    $page->assertNoJavaScriptErrors();
+
+    $page->assertVisible('[data-testid="category-all"]');
+    $page->assertVisible('[data-testid="category-productivity"]');
+    $page->assertVisible('[data-testid="category-testing"]');
+
+    $page->click('[data-testid="category-testing"]');
+
+    $page->assertSee('testing-plugin-01');
+    $page->assertDontSee('demo-plugin');
+    $page->assertDontSee('productivity-plugin-02');
+
+    $page->click('[data-testid="category-all"]');
+
+    $page->assertSee('demo-plugin');
+
+    $page->click('[data-testid="available-next"]');
+
+    $page->assertSee('Page 2 of 2');
+
+    $page->assertNoJavaScriptErrors();
 });

--- a/tests/Feature/DocsTest.php
+++ b/tests/Feature/DocsTest.php
@@ -19,6 +19,10 @@ it('falls back to the base URL for unknown anchors', function () {
     expect(Docs::url('does.not.exist'))->toBe('https://geocodio.github.io/yak/');
 });
 
+it('resolves the repositories PR review anchor', function () {
+    expect(Docs::url('repositories.pr-review'))->toEndWith('repositories/#pr-review-toggle');
+});
+
 it('respects the YAK_DOCS_URL env override', function () {
     config()->set('docs.base_url', 'https://custom.example.com/docs/');
 

--- a/tests/Feature/Jobs/McpLoginJobTest.php
+++ b/tests/Feature/Jobs/McpLoginJobTest.php
@@ -1,0 +1,240 @@
+<?php
+
+use App\ClaudeCli;
+use App\Jobs\McpLoginJob;
+use App\Services\InteractiveProcess;
+use App\Services\InteractiveProcessFactory;
+use App\Support\McpLoginSession;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Sleep;
+
+/**
+ * Scripted InteractiveProcess double: streams a queue of output chunks,
+ * optionally running a side effect (e.g. mutating the shared
+ * McpLoginSession, simulating another request completing the redirect or
+ * cancelling) the moment a given chunk is delivered, and reports itself as
+ * no longer running once its input is closed or its chunks run dry (when
+ * configured to auto-exit).
+ */
+final class FakeInteractiveProcess implements InteractiveProcess
+{
+    private int $callIndex = 0;
+
+    private bool $stopped = false;
+
+    private bool $exited = false;
+
+    /** @var array<int, string> */
+    public array $written = [];
+
+    /**
+     * @param  array<int, string>  $chunks
+     * @param  array<int, Closure>  $sideEffects  keyed by the chunk index they fire after
+     */
+    public function __construct(
+        private array $chunks,
+        private readonly array $sideEffects = [],
+        private readonly int $exitCode = 0,
+        private readonly bool $autoExitWhenChunksExhausted = false,
+    ) {}
+
+    /**
+     * Side effects are keyed by call index rather than gated behind
+     * remaining chunks, so a test can schedule one for a call made after
+     * the chunk queue is already exhausted (e.g. to simulate another
+     * request mutating the shared session a couple of polls after the job
+     * last read it).
+     */
+    public function incrementalOutput(): string
+    {
+        $index = $this->callIndex;
+        $this->callIndex++;
+
+        $chunk = $this->chunks !== [] ? array_shift($this->chunks) : '';
+
+        if ($chunk !== '' && $this->chunks === [] && $this->autoExitWhenChunksExhausted) {
+            $this->exited = true;
+        }
+
+        if (isset($this->sideEffects[$index])) {
+            ($this->sideEffects[$index])();
+        }
+
+        return $chunk;
+    }
+
+    public function isRunning(): bool
+    {
+        return ! $this->stopped && ! $this->exited;
+    }
+
+    public function write(string $data): void
+    {
+        $this->written[] = $data;
+    }
+
+    public function closeInput(): void
+    {
+        $this->exited = true;
+    }
+
+    public function stop(): void
+    {
+        $this->stopped = true;
+    }
+
+    public function wait(): int
+    {
+        return $this->exitCode;
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->exitCode === 0;
+    }
+}
+
+function runMcpLoginJob(string $server, InteractiveProcess $process): void
+{
+    app()->instance(InteractiveProcessFactory::class, new class($process) extends InteractiveProcessFactory
+    {
+        public function __construct(private readonly InteractiveProcess $process) {}
+
+        public function start(string $shellCommand, int $timeout): InteractiveProcess
+        {
+            return $this->process;
+        }
+    });
+
+    (new McpLoginJob($server))->handle(app(ClaudeCli::class), app(InteractiveProcessFactory::class));
+}
+
+const AUTH_URL_CHUNK = <<<'TXT'
+Starting authentication for "linear"…
+Visit this URL to authorize:
+  https://mcp.linear.app/authorize?response_type=code&client_id=abc&redirect_uri=http%3A%2F%2Flocalhost%3A57772%2Fcallback&state=xyz
+
+Waiting for authorization… (^C to cancel)
+Or paste the redirect URL here:
+TXT;
+
+beforeEach(function () {
+    Sleep::fake();
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('captures the authorization URL and moves the session to awaiting_redirect', function () {
+    McpLoginSession::start('linear');
+
+    $capturedUrl = null;
+    $capturedStatus = null;
+
+    // The session never receives a redirect in this test, so the job would
+    // otherwise poll forever; cancel it once the URL has been captured so
+    // handle() returns, but only after recording what the session looked
+    // like right after the URL was found.
+    $process = new FakeInteractiveProcess(
+        chunks: [AUTH_URL_CHUNK],
+        // Fires on the poll *after* the URL-bearing chunk was delivered,
+        // once the job has already saved authorizationUrl/awaiting_redirect.
+        sideEffects: [1 => function () use (&$capturedUrl, &$capturedStatus) {
+            $session = McpLoginSession::find('linear');
+            $capturedUrl = $session->authorizationUrl;
+            $capturedStatus = $session->status;
+
+            $session->status = 'cancelled';
+            $session->save();
+        }],
+    );
+
+    runMcpLoginJob('linear', $process);
+
+    expect($capturedStatus)->toBe('awaiting_redirect');
+    expect($capturedUrl)->toBe(
+        'https://mcp.linear.app/authorize?response_type=code&client_id=abc&redirect_uri=http%3A%2F%2Flocalhost%3A57772%2Fcallback&state=xyz'
+    );
+    expect(McpLoginSession::find('linear')->status)->toBe('cancelled');
+});
+
+it('captures the URL, accepts the redirect, and concludes succeeded', function () {
+    McpLoginSession::start('linear');
+
+    $process = new FakeInteractiveProcess(
+        chunks: [AUTH_URL_CHUNK],
+        sideEffects: [1 => function () {
+            $session = McpLoginSession::find('linear');
+            expect($session->status)->toBe('awaiting_redirect');
+            expect($session->authorizationUrl)->toBe(
+                'https://mcp.linear.app/authorize?response_type=code&client_id=abc&redirect_uri=http%3A%2F%2Flocalhost%3A57772%2Fcallback&state=xyz'
+            );
+
+            $session->redirectUrl = 'http://localhost:57772/callback?code=abc';
+            $session->status = 'finishing';
+            $session->save();
+        }],
+        exitCode: 0,
+    );
+
+    runMcpLoginJob('linear', $process);
+
+    $session = McpLoginSession::find('linear');
+    expect($session->status)->toBe('succeeded');
+    expect($process->written)->toBe(["http://localhost:57772/callback?code=abc\n"]);
+});
+
+it('concludes failed when the CLI reports an error and never asks for a redirect', function () {
+    McpLoginSession::start('linear');
+
+    $process = new FakeInteractiveProcess(
+        chunks: ["Couldn't complete authentication for \"linear\": invalid_grant – the authorization code has expired\n"],
+        exitCode: 1,
+        autoExitWhenChunksExhausted: true,
+    );
+
+    runMcpLoginJob('linear', $process);
+
+    $session = McpLoginSession::find('linear');
+    expect($session->status)->toBe('failed');
+    expect($session->error)->toContain("Couldn't complete authentication");
+});
+
+it('cancels the process and marks the session cancelled', function () {
+    McpLoginSession::start('linear');
+
+    $process = new FakeInteractiveProcess(
+        chunks: ["some preamble\n"],
+        sideEffects: [0 => function () {
+            $session = McpLoginSession::find('linear');
+            $session->status = 'cancelled';
+            $session->save();
+        }],
+    );
+
+    runMcpLoginJob('linear', $process);
+
+    expect(McpLoginSession::find('linear')->status)->toBe('cancelled');
+});
+
+it('expires the session once 10 minutes have passed', function () {
+    Carbon::setTestNow(Carbon::parse('2026-01-01 00:00:00'));
+    McpLoginSession::start('linear');
+
+    Carbon::setTestNow(Carbon::parse('2026-01-01 00:11:00'));
+
+    $process = new FakeInteractiveProcess(chunks: []);
+
+    runMcpLoginJob('linear', $process);
+
+    expect(McpLoginSession::find('linear')->status)->toBe('expired');
+});
+
+it('returns immediately when no session exists (e.g. it was removed before the job ran)', function () {
+    $process = new FakeInteractiveProcess(chunks: [AUTH_URL_CHUNK]);
+
+    runMcpLoginJob('linear', $process);
+
+    expect(McpLoginSession::find('linear'))->toBeNull();
+});

--- a/tests/Feature/Repositories/RepositoryControllerTest.php
+++ b/tests/Feature/Repositories/RepositoryControllerTest.php
@@ -6,6 +6,7 @@ use App\Models\PrReview;
 use App\Models\Repository;
 use App\Models\User;
 use App\Models\YakTask;
+use App\Support\Docs;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
@@ -618,12 +619,34 @@ test('setup history is limited to the 10 most recent setup tasks', function () {
             ->where('setupHistory.9.id', 'setup-limit-2'));
 });
 
-test('edit exposes a docs link for the repositories guide', function () {
+test('edit exposes docs links for the repositories guide', function () {
     $repo = Repository::factory()->create();
 
     $this->get(route('repos.edit', $repo))
         ->assertInertia(fn (Assert $page) => $page
-            ->where('docsUrl', fn (string $url) => str_contains($url, 'repositories')));
+            ->has('docsLinks', fn (Assert $links) => $links
+                ->where('guide', Docs::url('repositories'))
+                ->where('adding', Docs::url('repositories.adding'))
+                ->where('setup', Docs::url('repositories.setup'))
+                ->where('claudeMd', Docs::url('repositories.claude-md'))
+                ->where('routing', Docs::url('repositories.routing'))
+                ->where('prReview', Docs::url('repositories.pr-review'))
+                ->where('refresh', Docs::url('repositories.refresh'))
+                ->where('rerunSetup', Docs::url('repositories.rerun-setup'))));
+});
+
+test('create exposes docs links for the repositories guide', function () {
+    $this->get(route('repos.create'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('docsLinks', fn (Assert $links) => $links
+                ->where('guide', Docs::url('repositories'))
+                ->where('adding', Docs::url('repositories.adding'))
+                ->where('setup', Docs::url('repositories.setup'))
+                ->where('claudeMd', Docs::url('repositories.claude-md'))
+                ->where('routing', Docs::url('repositories.routing'))
+                ->where('prReview', Docs::url('repositories.pr-review'))
+                ->where('refresh', Docs::url('repositories.refresh'))
+                ->where('rerunSetup', Docs::url('repositories.rerun-setup'))));
 });
 
 test('saving the repository form persists manifest fields in the same request', function () {

--- a/tests/Feature/Settings/McpServerControllerTest.php
+++ b/tests/Feature/Settings/McpServerControllerTest.php
@@ -1,0 +1,254 @@
+<?php
+
+use App\Jobs\McpLoginJob;
+use App\Models\User;
+use App\Support\McpLoginSession;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Queue;
+use Inertia\Testing\AssertableInertia as Assert;
+
+const CONTROLLER_MCP_LIST_FIXTURE = <<<'TXT'
+Checking MCP server health…
+
+linear: https://mcp.linear.app/mcp (HTTP) - ✔ Connected
+plugin:figma:figma: https://mcp.figma.com/mcp (HTTP) - ! Needs authentication
+TXT;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->create());
+    Process::fake([
+        '*mcp list*' => Process::result(output: CONTROLLER_MCP_LIST_FIXTURE),
+        '*' => Process::result(),
+    ]);
+    config()->set('yak.mcp_config_path', null);
+});
+
+/**
+ * Requests the deferred `servers` prop via an Inertia partial reload, the
+ * way the frontend's `<Deferred data="servers">` follow-up would.
+ */
+function requestMcpServers(?string $only = 'servers,checkedAgo')
+{
+    $version = test()->get(route('settings.mcp'), ['X-Inertia' => 'true'])->headers->get('X-Inertia-Version');
+
+    $headers = [
+        'X-Inertia' => 'true',
+        'X-Inertia-Version' => (string) $version,
+        'X-Inertia-Partial-Component' => 'Settings/McpServers',
+    ];
+
+    if ($only !== null) {
+        $headers['X-Inertia-Partial-Data'] = $only;
+    }
+
+    return test()->get(route('settings.mcp'), $headers);
+}
+
+it('renders the page with deferred servers and eager login sessions', function () {
+    $this->get(route('settings.mcp'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('Settings/McpServers')
+            ->where('checkedAgo', null)
+            ->has('loginSessions')
+            ->has('docsUrl')
+            ->missing('servers'));
+});
+
+it('resolves servers (deploy + user + plugin) and checkedAgo on the deferred partial request', function () {
+    $response = requestMcpServers();
+
+    $response->assertJsonPath('props.checkedAgo', 'just now');
+
+    $names = collect($response->json('props.servers'))->pluck('name')->all();
+    expect($names)->toContain('linear')->toContain('plugin:figma:figma');
+
+    $byName = collect($response->json('props.servers'))->keyBy('name');
+    expect($byName['linear']['status'])->toBe('connected')
+        ->and($byName['linear']['source'])->toBe('user')
+        ->and($byName['plugin:figma:figma']['source'])->toBe('plugin')
+        ->and($byName['plugin:figma:figma']['status'])->toBe('needs_auth')
+        ->and($byName['plugin:figma:figma']['canConnect'])->toBeTrue();
+});
+
+it('includes deploy-config servers alongside user and plugin servers', function () {
+    $tmp = sys_get_temp_dir() . '/yak-mcp-controller-' . uniqid();
+    File::makeDirectory($tmp, recursive: true);
+    File::put($tmp . '/mcp.json', json_encode([
+        'mcpServers' => ['deploy-one' => ['type' => 'http', 'url' => 'https://mcp.example.com']],
+    ]));
+    config()->set('yak.mcp_config_path', $tmp . '/mcp.json');
+
+    $byName = collect(requestMcpServers()->json('props.servers'))->keyBy('name');
+
+    expect($byName['deploy-one']['status'])->toBe('token')
+        ->and($byName['deploy-one']['source'])->toBe('deploy')
+        ->and($byName['deploy-one']['canRemove'])->toBeFalse();
+
+    File::deleteDirectory($tmp);
+});
+
+it('flashes an error and omits user/plugin servers when claude mcp list fails', function () {
+    Process::fake(['*mcp list*' => Process::result(output: '', errorOutput: 'not logged in', exitCode: 1)]);
+
+    $response = requestMcpServers();
+
+    expect($response->json('props.servers'))->toBe([]);
+});
+
+it('adds a server via the CLI and flashes success', function () {
+    $this->post(route('settings.mcp.store'), [
+        'name' => 'my-server',
+        'transport' => 'http',
+        'target' => 'https://mcp.example.com/mcp',
+        'headers' => "Authorization: Bearer abc123\n",
+    ])->assertRedirect();
+
+    Process::assertRan(fn ($process) => str_contains($process->command, 'mcp add --scope user --transport http')
+        && str_contains($process->command, "-H 'Authorization: Bearer abc123'")
+        && str_contains($process->command, "'my-server'")
+        && str_contains($process->command, "'https://mcp.example.com/mcp'"));
+});
+
+it('splits a stdio target into command and args after --', function () {
+    $this->post(route('settings.mcp.store'), [
+        'name' => 'local',
+        'transport' => 'stdio',
+        'target' => 'npx -y some-server',
+    ])->assertRedirect();
+
+    Process::assertRan(fn ($process) => str_contains($process->command, "-- 'npx' '-y' 'some-server'"));
+});
+
+it('rejects a store request with an invalid server name', function () {
+    $this->post(route('settings.mcp.store'), [
+        'name' => 'bad name!',
+        'transport' => 'http',
+        'target' => 'https://mcp.example.com',
+    ])->assertSessionHasErrors('name');
+});
+
+it('rejects a store request with a non-url target for an http transport', function () {
+    $this->post(route('settings.mcp.store'), [
+        'name' => 'ok-name',
+        'transport' => 'http',
+        'target' => 'not a url',
+    ])->assertSessionHasErrors('target');
+});
+
+it('refuses to remove a deploy-config server', function () {
+    $tmp = sys_get_temp_dir() . '/yak-mcp-controller-' . uniqid();
+    File::makeDirectory($tmp, recursive: true);
+    File::put($tmp . '/mcp.json', json_encode([
+        'mcpServers' => ['deploy-one' => ['type' => 'http', 'url' => 'https://mcp.example.com']],
+    ]));
+    config()->set('yak.mcp_config_path', $tmp . '/mcp.json');
+
+    $this->delete(route('settings.mcp.destroy', ['name' => 'deploy-one']))
+        ->assertRedirect()
+        ->assertSessionHas('error');
+
+    Process::assertNotRan(fn ($process) => str_contains($process->command, 'mcp remove'));
+
+    File::deleteDirectory($tmp);
+});
+
+it('refuses to remove a plugin server', function () {
+    $this->delete(route('settings.mcp.destroy', ['name' => 'plugin:figma:figma']))
+        ->assertRedirect()
+        ->assertSessionHas('error');
+
+    Process::assertNotRan(fn ($process) => str_contains($process->command, 'mcp remove'));
+});
+
+it('removes a user server, ignoring logout failure', function () {
+    Process::fake([
+        '*mcp logout*' => Process::result(exitCode: 1, errorOutput: 'not connected'),
+        '*mcp remove*' => Process::result(),
+        '*mcp list*' => Process::result(output: CONTROLLER_MCP_LIST_FIXTURE),
+    ]);
+
+    $this->delete(route('settings.mcp.destroy', ['name' => 'linear']))
+        ->assertRedirect()
+        ->assertSessionHas('success');
+
+    Process::assertRan(fn ($process) => str_contains($process->command, "mcp remove --scope user 'linear'"));
+});
+
+it('logs out of a server', function () {
+    Process::fake(['*mcp logout*' => Process::result()]);
+
+    $this->post(route('settings.mcp.logout', ['name' => 'linear']))
+        ->assertRedirect()
+        ->assertSessionHas('success');
+
+    Process::assertRan(fn ($process) => str_contains($process->command, "mcp logout 'linear'"));
+});
+
+it('starts a login session and dispatches the login job', function () {
+    Queue::fake();
+
+    $this->post(route('settings.mcp.login.start', ['name' => 'plugin:figma:figma']))
+        ->assertRedirect();
+
+    Queue::assertPushed(McpLoginJob::class, fn (McpLoginJob $job) => $job->server === 'plugin:figma:figma');
+
+    $session = McpLoginSession::find('plugin:figma:figma');
+    expect($session)->not->toBeNull()
+        ->and($session->status)->toBe('starting');
+});
+
+it('refuses to start a second login while one is already in progress', function () {
+    Queue::fake();
+
+    McpLoginSession::start('linear');
+
+    $this->post(route('settings.mcp.login.start', ['name' => 'linear']))
+        ->assertRedirect()
+        ->assertSessionHas('error');
+
+    Queue::assertNotPushed(McpLoginJob::class);
+});
+
+it('validates and applies a redirect url, moving the session to finishing', function () {
+    $session = McpLoginSession::start('linear');
+    $session->status = 'awaiting_redirect';
+    $session->authorizationUrl = 'https://mcp.linear.app/authorize';
+    $session->save();
+
+    $this->post(route('settings.mcp.login.redirect', ['name' => 'linear']), [
+        'redirectUrl' => 'http://localhost:57772/callback?code=abc',
+    ])->assertRedirect();
+
+    $updated = McpLoginSession::find('linear');
+    expect($updated->status)->toBe('finishing')
+        ->and($updated->redirectUrl)->toBe('http://localhost:57772/callback?code=abc');
+});
+
+it('rejects a redirect url that is not a localhost address', function () {
+    $session = McpLoginSession::start('linear');
+    $session->status = 'awaiting_redirect';
+    $session->save();
+
+    $this->post(route('settings.mcp.login.redirect', ['name' => 'linear']), [
+        'redirectUrl' => 'https://evil.example.com/callback',
+    ])->assertRedirect()->assertSessionHas('error');
+
+    expect(McpLoginSession::find('linear')->status)->toBe('awaiting_redirect');
+});
+
+it('cancels an in-progress login', function () {
+    McpLoginSession::start('linear');
+
+    $this->delete(route('settings.mcp.login.cancel', ['name' => 'linear']))
+        ->assertRedirect();
+
+    expect(McpLoginSession::find('linear')->status)->toBe('cancelled');
+});
+
+it('requires authentication', function () {
+    auth()->logout();
+
+    $this->get(route('settings.mcp'))->assertRedirect(route('login'));
+});

--- a/tests/Feature/Skills/SkillControllerTest.php
+++ b/tests/Feature/Skills/SkillControllerTest.php
@@ -117,13 +117,28 @@ it('uninstalls a plugin', function () {
         && str_contains($p->command, 'code-review@official'));
 });
 
-it('updates a plugin', function () {
-    Process::fake(['*' => Process::result(output: '', exitCode: 0)]);
+it('updates a plugin and reports the new version', function () {
+    Process::fake(['*' => Process::result(
+        output: "Checking for updates for plugin \"code-review@official\" at user scope…\n✔ Updated code-review to version (2.1.0).\n",
+        exitCode: 0,
+    )]);
 
     $this->post(route('skills.upgrade', 'code-review@official'))
         ->assertRedirect()
-        ->assertSessionHas('success', 'Updated code-review@official.');
+        ->assertSessionHas('success', 'Updated code-review@official (2.1.0).');
 
     Process::assertRan(fn ($p) => str_contains($p->command, 'plugins update')
-        && str_contains($p->command, 'code-review@official'));
+        && str_contains($p->command, 'code-review@official')
+        && str_contains($p->command, '--yes'));
+});
+
+it('says so when a plugin is already at the latest version', function () {
+    Process::fake(['*' => Process::result(
+        output: "Checking for updates for plugin \"code-review@official\" at user scope…\n✔ code-review is already at the latest version (0120fb83da5d).\n",
+        exitCode: 0,
+    )]);
+
+    $this->post(route('skills.upgrade', 'code-review@official'))
+        ->assertRedirect()
+        ->assertSessionHas('success', 'code-review@official is already at the latest version (0120fb83da5d).');
 });

--- a/tests/Feature/Skills/SkillControllerTest.php
+++ b/tests/Feature/Skills/SkillControllerTest.php
@@ -323,3 +323,30 @@ it('echoes the selected category back in filters', function () {
         ->assertOk()
         ->assertInertia(fn (Assert $page) => $page->where('filters.category', 'testing'));
 });
+
+it('dedupes recommendations by name across marketplaces and skips installed names', function () {
+    foreach (['official', 'mirror'] as $marketplace) {
+        File::makeDirectory("{$this->tmp}/marketplaces/{$marketplace}/.claude-plugin", recursive: true);
+        File::put("{$this->tmp}/marketplaces/{$marketplace}/.claude-plugin/marketplace.json", json_encode([
+            'owner' => ['name' => 'acme'],
+            'plugins' => [
+                ['name' => 'code-review', 'description' => "Review from {$marketplace}", 'category' => 'development'],
+                ['name' => 'security-guidance', 'description' => "Security from {$marketplace}", 'category' => 'security'],
+            ],
+        ]));
+    }
+
+    File::put("{$this->tmp}/known_marketplaces.json", json_encode([
+        'official' => ['source' => ['repo' => 'github:acme/official'], 'installLocation' => "{$this->tmp}/marketplaces/official"],
+        'mirror' => ['source' => ['repo' => 'github:acme/mirror'], 'installLocation' => "{$this->tmp}/marketplaces/mirror"],
+    ]));
+    writeInstalledPluginsFixture($this->tmp, ['security-guidance@official']);
+
+    $this->get(route('skills'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('recommended', 1, fn (Assert $row) => $row
+                ->where('name', 'code-review')
+                ->where('marketplace', 'official')
+                ->etc()));
+});

--- a/tests/Feature/Skills/SkillControllerTest.php
+++ b/tests/Feature/Skills/SkillControllerTest.php
@@ -18,6 +18,52 @@ afterEach(function () {
     File::deleteDirectory($this->tmp);
 });
 
+/**
+ * Writes a `known_marketplaces.json` + marketplace manifest fixture with the
+ * given plugin entries (each: name, description, category).
+ *
+ * @param  array<int, array{name: string, description?: string, category?: ?string}>  $plugins
+ */
+function writeMarketplaceFixture(string $tmp, string $marketplace, array $plugins): void
+{
+    File::makeDirectory("{$tmp}/marketplaces/{$marketplace}/.claude-plugin", recursive: true);
+
+    File::put("{$tmp}/known_marketplaces.json", json_encode([
+        $marketplace => [
+            'source' => ['repo' => "github:acme/{$marketplace}"],
+            'installLocation' => "{$tmp}/marketplaces/{$marketplace}",
+            'lastUpdated' => '2026-04-14T00:00:00Z',
+        ],
+    ]));
+
+    File::put(
+        "{$tmp}/marketplaces/{$marketplace}/.claude-plugin/marketplace.json",
+        json_encode([
+            'owner' => ['name' => 'acme'],
+            'plugins' => array_map(fn (array $p) => [
+                'name' => $p['name'],
+                'description' => $p['description'] ?? "{$p['name']} description",
+                'category' => array_key_exists('category', $p) ? $p['category'] : 'general',
+            ], $plugins),
+        ]),
+    );
+}
+
+/**
+ * @param  array<int, array{scope?: string, version?: string}>  $overrides  keyed by plugin key (name@marketplace)
+ */
+function writeInstalledPluginsFixture(string $tmp, array $keys): void
+{
+    $plugins = [];
+    foreach ($keys as $key) {
+        $plugins[$key] = [[
+            'scope' => 'user', 'installPath' => '/x', 'version' => '1', 'installedAt' => '2026-01-01T00:00:00Z',
+        ]];
+    }
+
+    File::put("{$tmp}/installed_plugins.json", json_encode(['version' => 2, 'plugins' => $plugins]));
+}
+
 it('renders the page', function () {
     $this->get(route('skills'))
         ->assertOk()
@@ -26,9 +72,17 @@ it('renders the page', function () {
             ->has('installed')
             ->has('bundled')
             ->has('available')
+            ->has('available.items')
+            ->has('available.page')
+            ->has('available.lastPage')
+            ->has('available.total')
+            ->has('available.perPage')
+            ->has('categories')
+            ->has('recommended')
             ->has('marketplaces')
             ->where('filters.search', '')
-            ->where('filters.filter', 'all'));
+            ->where('filters.filter', 'all')
+            ->where('filters.category', ''));
 });
 
 it('installs a plugin from a marketplace', function () {
@@ -141,4 +195,131 @@ it('says so when a plugin is already at the latest version', function () {
     $this->post(route('skills.upgrade', 'code-review@official'))
         ->assertRedirect()
         ->assertSessionHas('success', 'code-review@official is already at the latest version (0120fb83da5d).');
+});
+
+it('paginates available plugins', function () {
+    writeMarketplaceFixture($this->tmp, 'acme', array_map(
+        fn (int $i) => ['name' => sprintf('plugin-%02d', $i)],
+        range(1, 30),
+    ));
+
+    $this->get(route('skills'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('available.items', 24)
+            ->where('available.page', 1)
+            ->where('available.lastPage', 2)
+            ->where('available.total', 30)
+            ->where('available.perPage', 24));
+
+    $this->get(route('skills', ['page' => 2]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('available.items', 6)
+            ->where('available.page', 2));
+
+    $this->get(route('skills', ['page' => 99]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('available.page', 2)
+            ->has('available.items', 6));
+});
+
+it('sorts available plugins by category then name and computes category counts', function () {
+    writeMarketplaceFixture($this->tmp, 'acme', [
+        ['name' => 'alpha-charlie', 'category' => 'alpha'],
+        ['name' => 'alpha-alpha', 'category' => 'alpha'],
+        ['name' => 'alpha-bravo', 'category' => 'alpha'],
+        ['name' => 'zeta-bravo', 'category' => 'zeta'],
+        ['name' => 'zeta-alpha', 'category' => 'zeta'],
+        ['name' => 'null-bravo', 'category' => null],
+        ['name' => 'null-alpha', 'category' => null],
+    ]);
+
+    $this->get(route('skills'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('available.items', 7, fn (Assert $row) => $row->where('name', 'alpha-alpha')->etc())
+            ->where('available.items.1.name', 'alpha-bravo')
+            ->where('available.items.2.name', 'alpha-charlie')
+            ->where('available.items.3.name', 'zeta-alpha')
+            ->where('available.items.4.name', 'zeta-bravo')
+            ->where('available.items.5.name', 'null-alpha')
+            ->where('available.items.6.name', 'null-bravo')
+            ->where('categories', [
+                ['value' => 'alpha', 'label' => 'Alpha', 'count' => 3],
+                ['value' => 'zeta', 'label' => 'Zeta', 'count' => 2],
+                ['value' => 'other', 'label' => 'Other', 'count' => 2],
+            ]));
+});
+
+it('filters available plugins by category, including other for null category', function () {
+    writeMarketplaceFixture($this->tmp, 'acme', [
+        ['name' => 'alpha-charlie', 'category' => 'alpha'],
+        ['name' => 'alpha-alpha', 'category' => 'alpha'],
+        ['name' => 'alpha-bravo', 'category' => 'alpha'],
+        ['name' => 'zeta-bravo', 'category' => 'zeta'],
+        ['name' => 'zeta-alpha', 'category' => 'zeta'],
+        ['name' => 'null-bravo', 'category' => null],
+        ['name' => 'null-alpha', 'category' => null],
+    ]);
+
+    $this->get(route('skills', ['category' => 'alpha']))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('available.items', 3)
+            ->where('available.total', 3)
+            ->where('available.items.0.name', 'alpha-alpha')
+            ->where('categories', [
+                ['value' => 'alpha', 'label' => 'Alpha', 'count' => 3],
+                ['value' => 'zeta', 'label' => 'Zeta', 'count' => 2],
+                ['value' => 'other', 'label' => 'Other', 'count' => 2],
+            ]));
+
+    $this->get(route('skills', ['category' => 'other']))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('available.items', 2)
+            ->where('available.total', 2)
+            ->where('available.items.0.name', 'null-alpha')
+            ->where('available.items.1.name', 'null-bravo'));
+});
+
+it('recommends configured popular plugins first, then plugins sharing an installed category', function () {
+    writeMarketplaceFixture($this->tmp, 'acme', [
+        ['name' => 'my-installed', 'category' => 'productivity'],
+        ['name' => 'code-review', 'category' => null],
+        ['name' => 'context7', 'category' => null],
+        ['name' => 'sibling-c', 'category' => 'productivity'],
+        ['name' => 'sibling-a', 'category' => 'productivity'],
+        ['name' => 'sibling-b', 'category' => 'productivity'],
+        ['name' => 'unrelated', 'category' => 'testing'],
+    ]);
+
+    writeInstalledPluginsFixture($this->tmp, ['my-installed@acme']);
+
+    $this->get(route('skills'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('recommended', 5)
+            ->where('recommended.0.name', 'code-review')
+            ->where('recommended.0.recommendedReason', 'popular')
+            ->where('recommended.1.name', 'context7')
+            ->where('recommended.1.recommendedReason', 'popular')
+            ->where('recommended.2.name', 'sibling-a')
+            ->where('recommended.2.recommendedReason', 'similar')
+            ->where('recommended.3.name', 'sibling-b')
+            ->where('recommended.3.recommendedReason', 'similar')
+            ->where('recommended.4.name', 'sibling-c')
+            ->where('recommended.4.recommendedReason', 'similar'));
+
+    $this->get(route('skills', ['search' => 'code']))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page->where('recommended', []));
+});
+
+it('echoes the selected category back in filters', function () {
+    $this->get(route('skills', ['category' => 'testing']))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page->where('filters.category', 'testing'));
 });

--- a/tests/Unit/McpServerReaderTest.php
+++ b/tests/Unit/McpServerReaderTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use App\DataTransferObjects\McpServer;
+use App\Exceptions\ClaudeCliException;
+use App\Services\McpServerReader;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->tmp = sys_get_temp_dir() . '/yak-mcp-reader-' . uniqid();
+    File::makeDirectory($this->tmp, recursive: true);
+});
+
+afterEach(function () {
+    File::deleteDirectory($this->tmp);
+});
+
+const MCP_LIST_FIXTURE = <<<'TXT'
+Checking MCP server health…
+
+claude.ai Notion: https://mcp.notion.com/mcp - ✔ Connected
+plugin:figma:figma: https://mcp.figma.com/mcp (HTTP) - ! Needs authentication
+plugin:linear:linear: https://mcp.linear.app/mcp (HTTP) - ! Needs authentication
+playwright: npx @playwright/mcp@latest - ✔ Connected
+context7: npx -y @upstash/context7-mcp - ✔ Connected
+stripe: https://mcp.stripe.com - ✘ Failed to connect
+local-thing: node ./server.js - ⏸ Pending approval
+TXT;
+
+it('parses every mark, plugin names, and the HTTP hint from a realistic claude mcp list output', function () {
+    Process::fake(['*mcp list*' => Process::result(output: MCP_LIST_FIXTURE)]);
+
+    $servers = app(McpServerReader::class)->userServers();
+
+    expect($servers)->toHaveCount(7);
+
+    $byName = $servers->keyBy('name');
+
+    /** @var McpServer $notion */
+    $notion = $byName['claude.ai Notion'];
+    expect($notion->status)->toBe('connected')
+        ->and($notion->source)->toBe('user')
+        ->and($notion->transport)->toBe('http')
+        ->and($notion->canRemove)->toBeTrue()
+        ->and($notion->canLogout)->toBeTrue();
+
+    /** @var McpServer $figma */
+    $figma = $byName['plugin:figma:figma'];
+    expect($figma->status)->toBe('needs_auth')
+        ->and($figma->source)->toBe('plugin')
+        ->and($figma->pluginName)->toBe('figma')
+        ->and($figma->displayName)->toBe('figma')
+        ->and($figma->transport)->toBe('http')
+        ->and($figma->canConnect)->toBeTrue()
+        ->and($figma->canRemove)->toBeFalse();
+
+    /** @var McpServer $playwright */
+    $playwright = $byName['playwright'];
+    expect($playwright->transport)->toBe('stdio')
+        ->and($playwright->target)->toBe('npx @playwright/mcp@latest')
+        ->and($playwright->status)->toBe('connected')
+        ->and($playwright->canLogout)->toBeFalse();
+
+    /** @var McpServer $stripe */
+    $stripe = $byName['stripe'];
+    expect($stripe->status)->toBe('failed')
+        ->and($stripe->detail)->toBe('Failed to connect');
+
+    /** @var McpServer $pending */
+    $pending = $byName['local-thing'];
+    expect($pending->status)->toBe('pending_approval');
+});
+
+it('ignores non-matching lines like the health-check banner and blanks', function () {
+    Process::fake(['*mcp list*' => Process::result(output: "Checking MCP server health…\n\nplaywright: npx @playwright/mcp@latest - ✔ Connected\n")]);
+
+    expect(app(McpServerReader::class)->userServers())->toHaveCount(1);
+});
+
+it('throws when claude mcp list exits non-zero', function () {
+    Process::fake(['*mcp list*' => Process::result(output: '', errorOutput: 'not logged in', exitCode: 1)]);
+
+    app(McpServerReader::class)->userServers();
+})->throws(ClaudeCliException::class);
+
+it('reads deploy servers from the configured JSON file', function () {
+    $path = $this->tmp . '/mcp.json';
+    File::put($path, json_encode([
+        'mcpServers' => [
+            'deploy-http' => ['type' => 'http', 'url' => 'https://mcp.example.com/mcp'],
+            'deploy-stdio' => ['command' => 'npx', 'args' => ['-y', 'some-server']],
+        ],
+    ]));
+    config()->set('yak.mcp_config_path', $path);
+
+    $servers = app(McpServerReader::class)->deployServers();
+
+    expect($servers)->toHaveCount(2);
+
+    $byName = $servers->keyBy('name');
+
+    /** @var McpServer $http */
+    $http = $byName['deploy-http'];
+    expect($http->status)->toBe('token')
+        ->and($http->source)->toBe('deploy')
+        ->and($http->transport)->toBe('http')
+        ->and($http->target)->toBe('https://mcp.example.com/mcp')
+        ->and($http->canConnect)->toBeFalse()
+        ->and($http->canRemove)->toBeFalse();
+
+    /** @var McpServer $stdio */
+    $stdio = $byName['deploy-stdio'];
+    expect($stdio->transport)->toBe('stdio')
+        ->and($stdio->target)->toBe('npx -y some-server');
+});
+
+it('returns an empty collection when the deploy config path is unset', function () {
+    config()->set('yak.mcp_config_path', null);
+
+    expect(app(McpServerReader::class)->deployServers())->toHaveCount(0);
+});
+
+it('returns an empty collection when the deploy config file is missing', function () {
+    config()->set('yak.mcp_config_path', $this->tmp . '/missing.json');
+
+    expect(app(McpServerReader::class)->deployServers())->toHaveCount(0);
+});
+
+it('returns an empty collection when the deploy config file is invalid JSON', function () {
+    $path = $this->tmp . '/broken.json';
+    File::put($path, 'not json');
+    config()->set('yak.mcp_config_path', $path);
+
+    expect(app(McpServerReader::class)->deployServers())->toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

Finishes the skills and repositories feedback from this morning's UI review that was never implemented, and adds a Settings > MCP servers page with in-browser OAuth login.

## Changes

**Skills: Update button** — `claude plugin update` exits 0 whether it installed a new version or the plugin was already current, so the page always said "Updated X." while the card kept its old timestamp. Yak now parses the CLI output and reports which happened, with the version. Passes `--yes`, which the CLI requires without a TTY.

**Skills: discovery** — the 60-item cap is gone. Available plugins are paged 24 at a time, sorted by category then name, with category chips (with counts) and group headings. A Recommended section shows configured popular plugins (`yak.recommended_plugins`) first, then plugins sharing a category with something already installed. Recommendations dedupe by plugin name across marketplaces.

**Repositories form: help** — per-section docs links, tooltips on the compact fields that had no description, and inline links to the routing and CLAUDE.md guides. Five new docs anchors in `config/docs.php`.

**Settings > MCP servers** — lists every MCP server agents can reach, from three sources: the Ansible deploy config (token-based, managed), servers added to the shared Claude Code config, and servers that plugins ship. Health comes from `claude mcp list`. Remote servers that need a login get a Connect button: a queued `McpLoginJob` runs `claude mcp login --no-browser` under a pseudo-terminal (`script`), captures the authorization URL, and feeds back the redirect URL the user pastes on the page. Servers can be added and removed at user scope. A collapsed terminal fallback shows one-line `yak-mcp` commands.

**Ops** — new `yak-mcp` helper installed by the `claude-code-config` Ansible role (wraps `yak-claude-login mcp …`, adds `--no-browser` to `login`), plus `YAK_SSH_HOST` and `YAK_CONTAINER_NAME` in the container env so the page can print a copyable ssh one-liner. Docs note in the prompting guide.

## Tests

Feature and unit: Skills, Repositories, Docs, Settings (MCP controller, login controller, reader parser, login job with a fake interactive process). Browser: Skills category-and-paging smoke test, MCP servers smoke test. PHPStan and Pint clean.

## Worth watching after deploy

The login handoff depends on the CLI's `--no-browser` prompt text, which is not a documented interface. If a CLI upgrade changes it, the page falls back to the ssh command. The deploy needs the `claude-code-config` role to run so `yak-mcp` lands on the host (`./deploy.sh` already tags it).

https://claude.ai/code/session_015niN98p3uEdbHcfGxBb8Mu