### PR TITLE
fix(ui): slide the mobile nav in from the right, not up from the bottom

### DIFF
--- a/resources/js/components/MobileNavSheet.tsx
+++ b/resources/js/components/MobileNavSheet.tsx
@@ -5,6 +5,10 @@ import { SidebarNav } from '@/components/Sidebar';
 /**
  * The navigation drawer below `lg`, opened by the top bar's menu button via
  * the `yak:open-nav` event so pages never hold drawer state themselves.
+ *
+ * It enters from the right, the edge the menu button sits on, so the panel
+ * comes from where the thumb pressed. The top padding clears the status bar
+ * when Yak runs from the home screen under `viewport-fit=cover`.
  */
 export function MobileNavSheet() {
     const [open, setOpen] = useState(false);
@@ -16,8 +20,17 @@ export function MobileNavSheet() {
     }, []);
 
     return (
-        <Sheet open={open} onOpenChange={setOpen} side="bottom" title="Navigation" hideTitle data-testid="mobile-nav">
-            <div className="-mx-2 flex min-h-0 flex-1 flex-col overflow-y-auto pb-2">
+        <Sheet
+            open={open}
+            onOpenChange={setOpen}
+            side="right"
+            width="w-[min(19rem,84vw)]"
+            title="Navigation"
+            hideTitle
+            className="pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))]"
+            data-testid="mobile-nav"
+        >
+            <div className="-mx-2 flex min-h-0 flex-1 flex-col overflow-y-auto">
                 <SidebarNav touch onNavigate={() => setOpen(false)} />
             </div>
         </Sheet>


### PR DESCRIPTION
The mobile navigation opened as a bottom sheet. A hamburger button conventionally opens a side drawer; a bottom sheet reads as an action list, so the motion was surprising.

The drawer now enters from the right, the edge the menu button sits on, so the panel arrives from where the thumb pressed. It is full height, capped at `min(19rem, 84vw)`, and pads for the status bar and home indicator so it looks right when Yak runs from the home screen.

`Sheet` in console-ui offers only `right` and `bottom`, so right is the side available without changing the design system.

![Nav drawer](https://github.com/user-attachments/assets/359f4140-c58a-4210-9e5d-81110ec6cf65)

The existing browser test in `tests/Browser/AppShellTest.php` covers this and is side-agnostic: it opens the drawer, follows a link, and asserts the drawer closes. All 3 tests pass, and `tsc --noEmit` is clean.

https://claude.ai/code/session_011g8D9JfQ9DyVxwNu4yibNB
